### PR TITLE
Reset overlay MRU cache on firmware FIRMWARE_READY notification

### DIFF
--- a/polyhost/device/command_ids.py
+++ b/polyhost/device/command_ids.py
@@ -43,3 +43,4 @@ class Cmd(Enum):
     SET_UNICODE_MODE = 20
     SEND_OVERLAY_MAPPING = 21
     GET_DEFAULT_LAYER = 22
+    FIRMWARE_READY = 23  # unsolicited notification sent by firmware on boot

--- a/polyhost/device/hid_helper.py
+++ b/polyhost/device/hid_helper.py
@@ -88,6 +88,7 @@ class HidHelper:
     def __init__(self, settings):
         self.settings = settings
         self.lock = threading.Lock()
+        self._firmware_ready_pending = False
 
         device_interfaces = hid.enumerate(self.settings.VID, self.settings.PID)
         raw_hid_interfaces = [i for i in device_interfaces if i['usage_page'] == self.settings.HID_RAW_USAGE_PAGE and i['usage'] == self.settings.HID_RAW_USAGE]
@@ -118,6 +119,25 @@ class HidHelper:
         if self.remote_console is None:
             return bytearray()
         return self.remote_console.read(self.settings.HID_CONSOLE_REPORT_SIZE, timeout=0)
+
+    def peek_notification(self) -> None:
+        """Non-blocking read; sets _firmware_ready_pending if FIRMWARE_READY is seen."""
+        if self.interface is None:
+            return
+        try:
+            with self.lock:
+                report = self.interface.read(self.settings.HID_REPORT_SIZE, timeout=0)
+            if report and report.startswith(b"P\x17"):
+                self._firmware_ready_pending = True
+        except Exception:
+            pass
+
+    def pop_firmware_ready(self) -> bool:
+        """Returns True (and clears the flag) if a FIRMWARE_READY notification arrived."""
+        if self._firmware_ready_pending:
+            self._firmware_ready_pending = False
+            return True
+        return False
 
     def interface_acquired(self):
         return self.interface is not None
@@ -283,6 +303,8 @@ class HidHelper:
                     break
                 if response_report.startswith(expected_prefix):
                     return True, response_report, self.lock
+                if response_report.startswith(b"P\x17"):
+                    self._firmware_ready_pending = True
                 # Stale reply — keep draining
         except Exception as e:
             # self.lock.release()

--- a/polyhost/device/poly_kybd.py
+++ b/polyhost/device/poly_kybd.py
@@ -74,6 +74,14 @@ class PolyKybd:
             return self.serial.read_all()
         return None
 
+    def poll_notifications(self) -> None:
+        """Non-blocking peek for unsolicited firmware notifications (e.g. FIRMWARE_READY)."""
+        self.hid.peek_notification()
+
+    def pop_firmware_ready(self) -> bool:
+        """Returns True if firmware sent a FIRMWARE_READY notification since last check."""
+        return self.hid.pop_firmware_ready()
+
     def get_console_output(self, flush_and_return=True) -> str | None:
         try:
             last_line = self.hid.get_console_output()

--- a/polyhost/device/poly_kybd_mock.py
+++ b/polyhost/device/poly_kybd_mock.py
@@ -7,6 +7,7 @@ from polyhost.device.device_settings import DeviceSettings
 from polyhost.device.im_converter import ImageConverter
 from polyhost.device.keys import KeyCode, Modifier
 from polyhost.device.overlay_sim import OverlayFirmwareSim, display_flat_idx
+from polyhost.input.unicode_input import InputMethod
 
 
 class PolyKybdMock:

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -645,6 +645,12 @@ class PolyHost(QApplication):
         if kb_log:
             self.keeb_log.info(kb_log)
 
+        self.keeb.poll_notifications()
+        if self.connected and self.keeb.pop_firmware_ready():
+            cache_capacity = DeviceSettings().OVERLAY_MAPPING_CAPACITY
+            self.device_mgr.reset_all_caches(cache_capacity)
+            self.log.info("Firmware restart detected — overlay MRU cache reset (capacity %d).", cache_capacity)
+
         if not self.is_closing:
             QTimer.singleShot(UPDATE_CYCLE_MSEC, self.active_window_reporter)
         # except Exception as e:


### PR DESCRIPTION
## Summary

- Adds `FIRMWARE_READY` (cmd `0x17`) to the `Cmd` enum in `command_ids.py` — an unsolicited notification the firmware sends on boot so the host knows the firmware has restarted.
- `HidHelper` gains `peek_notification()` (non-blocking read that sets a flag when `P\x17` is seen) and `pop_firmware_ready()` (consume the flag).
- Stale `P\x17` reports that arrive during normal command response draining are also captured rather than silently discarded.
- `PolyKybd` surfaces `poll_notifications()` and `pop_firmware_ready()` to callers.
- `PolyHost.active_window_reporter()` polls on every tick; on detection it calls `device_mgr.reset_all_caches()` and logs the restart — ensuring the host's overlay MRU cache is flushed after every firmware reboot without relying on fragile USB connect/disconnect events.
- Fixes a missing `InputMethod` import in `poly_kybd_mock.py`.

## Test plan

- [ ] Flash firmware with `FIRMWARE_READY` support and verify the host logs "Firmware restart detected" on connect/reset
- [ ] Confirm overlays reload correctly after a firmware reset (cache flushed)
- [ ] Verify no spurious cache resets during normal operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle firmware boot notifications to keep host overlay caches in sync with device restarts.

New Features:
- Propagate a non-blocking firmware notification polling pathway from HID helper through PolyKybd to the host.
- Add a FIRMWARE_READY command identifier for unsolicited boot notifications from firmware.

Bug Fixes:
- Ensure the overlay MRU cache is reset when firmware restarts instead of relying on USB reconnection events.
- Fix a missing InputMethod import in the PolyKybd mock implementation.

Enhancements:
- Capture firmware-ready notifications that arrive while draining stale HID reports so they are not discarded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced firmware restart detection to automatically clear cached device settings and ensure proper host-device synchronization when the keyboard reboots.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thpoll83/PolyKybdHost/pull/4)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->