### PR TITLE
Add missing InputMethod import to poly_kybd_mock

### DIFF
--- a/polyhost/device/poly_kybd.py
+++ b/polyhost/device/poly_kybd.py
@@ -45,6 +45,8 @@ class PolyKybd:
         self.poly_settings = poly_settings
         self.num_layers = None
 
+        self._fresh_boot = False
+
         # Statistics
         self.stat_plain = 0
         self.stat_comp = 0
@@ -94,9 +96,19 @@ class PolyKybd:
             result, msg = self.hid.send_and_read_validate(
                 compose_cmd(Cmd.GET_ID), 50, expect(Cmd.GET_ID))
             msg = msg.decode().strip('\x00')
-            return result, msg if not result else msg[3:]
+            if not result:
+                return False, msg
+            if len(msg) > 2 and msg[2] == '*':
+                self._fresh_boot = True
+            return True, msg[3:]
         except Exception as e:
             return False, f"Exception: {e}"
+
+    def pop_fresh_boot(self) -> bool:
+        """Returns True (and clears the flag) if firmware signalled a fresh boot via GET_ID."""
+        result = self._fresh_boot
+        self._fresh_boot = False
+        return result
 
     def query_version_info(self) -> tuple[bool, str]:
         result, msg = self.query_id()

--- a/polyhost/device/poly_kybd.py
+++ b/polyhost/device/poly_kybd.py
@@ -25,6 +25,10 @@ import hid
 from polyhost.util.dict_util import split_dict
 
 
+# Firmware sets byte 2 of the GET_ID response to '*' to signal a fresh boot.
+_GET_ID_FRESH_BOOT_FLAG = '*'
+
+
 class PolyKybd:
     """
     Communication to PolyKybd
@@ -98,7 +102,7 @@ class PolyKybd:
             msg = msg.decode().strip('\x00')
             if not result:
                 return False, msg
-            if len(msg) > 2 and msg[2] == '*':
+            if len(msg) > 2 and msg[2] == _GET_ID_FRESH_BOOT_FLAG:
                 self._fresh_boot = True
             return True, msg[3:]
         except Exception as e:

--- a/polyhost/device/poly_kybd_mock.py
+++ b/polyhost/device/poly_kybd_mock.py
@@ -4,6 +4,7 @@ import time
 from typing import Any
 
 from polyhost.device.device_settings import DeviceSettings
+from polyhost.util.dict_util import split_by_n_chars
 from polyhost.device.im_converter import ImageConverter
 from polyhost.device.keys import KeyCode, Modifier
 from polyhost.device.overlay_sim import OverlayFirmwareSim, display_flat_idx
@@ -79,6 +80,10 @@ class PolyKybdMock:
     def connect(self) -> bool:
         self._log_call("connect")
         return True
+
+    def pop_fresh_boot(self) -> bool:
+        self._log_call("pop_fresh_boot")
+        return False
 
     # -------------------------------------------------------------------------
     # Identity

--- a/polyhost/device/poly_kybd_mock.py
+++ b/polyhost/device/poly_kybd_mock.py
@@ -7,6 +7,7 @@ from polyhost.device.device_settings import DeviceSettings
 from polyhost.device.im_converter import ImageConverter
 from polyhost.device.keys import KeyCode, Modifier
 from polyhost.device.overlay_sim import OverlayFirmwareSim, display_flat_idx
+from polyhost.input.unicode_input import InputMethod
 
 
 class PolyKybdMock:

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -645,6 +645,11 @@ class PolyHost(QApplication):
         if kb_log:
             self.keeb_log.info(kb_log)
 
+        if self.connected and self.keeb.pop_fresh_boot():
+            cache_capacity = DeviceSettings().OVERLAY_MAPPING_CAPACITY
+            self.device_mgr.reset_all_caches(cache_capacity)
+            self.log.info("Firmware restart detected — overlay MRU cache reset (capacity %d).", cache_capacity)
+
         if not self.is_closing:
             QTimer.singleShot(UPDATE_CYCLE_MSEC, self.active_window_reporter)
         # except Exception as e:

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -134,7 +134,7 @@ class PolyHost(QApplication):
 
         connected = self.keeb.connect()
         self.device_mgr.connect_secondaries()
-        self.device_mgr.reset_all_caches(DeviceSettings().OVERLAY_MAPPING_CAPACITY)
+        self.device_mgr.reset_all_caches(self.keeb.device_settings.OVERLAY_MAPPING_CAPACITY)
         if connected:
             self.log.info("Connected to PolyKybd.")
         else:
@@ -646,7 +646,7 @@ class PolyHost(QApplication):
             self.keeb_log.info(kb_log)
 
         if self.connected and self.keeb.pop_fresh_boot():
-            cache_capacity = DeviceSettings().OVERLAY_MAPPING_CAPACITY
+            cache_capacity = self.keeb.device_settings.OVERLAY_MAPPING_CAPACITY
             self.device_mgr.reset_all_caches(cache_capacity)
             self.log.info("Firmware restart detected — overlay MRU cache reset (capacity %d).", cache_capacity)
 


### PR DESCRIPTION
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Handle firmware fresh-boot signalling from the keyboard and propagate it to reset overlay caches on the host.

Bug Fixes:
- Use the connected keyboard's device settings when resetting overlay caches instead of creating a new DeviceSettings instance.

Enhancements:
- Track a fresh-boot flag from the GET_ID response in PolyKybd and expose it via a pop_fresh_boot method.
- Trigger an overlay MRU cache reset on the host when a fresh firmware boot is detected, with appropriate logging.
- Extend the PolyKybdMock to support the new pop_fresh_boot interface and add missing utility and input imports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * System now detects firmware restarts and automatically resets overlay configuration cache to maintain synchronization.

* **Chores**
  * Optimized device settings initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thpoll83/PolyKybdHost/pull/6)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->