### PR TITLE
Fix keyboard reconnect, stale overlays, and add colour-coded logging

### DIFF
--- a/polyhost/device/im_converter.py
+++ b/polyhost/device/im_converter.py
@@ -10,8 +10,8 @@ from polyhost.device.keys import KeyCode, Modifier
 from polyhost.device.overlay_data import OverlayData
 
 class ImageConverter:
-    def __init__(self, settings):
-        self.settings = settings
+    def __init__(self, device_settings):
+        self.device_settings = device_settings
         self.log = logging.getLogger('PolyHost')
         self.h = 0
         self.w = 0
@@ -100,7 +100,7 @@ class ImageConverter:
 
     def extract_overlays(self, modifier=Modifier.NO_MOD):
         # we expect 10x9 images each having 72x40px
-        if self.w < self.settings.OVERLAY_RES_X * self.NUM_OVERLAYS_X or self.h < self.settings.OVERLAY_RES_Y * self.NUM_OVERLAYS_Y:
+        if self.w < self.device_settings.OVERLAY_RES_X * self.NUM_OVERLAYS_X or self.h < self.device_settings.OVERLAY_RES_Y * self.NUM_OVERLAYS_Y:
             self.log.error("Image too small")
             return None
         if modifier in self.image:
@@ -108,14 +108,14 @@ class ImageConverter:
             keycode = KeyCode.KC_A.value
             for y in range(0, self.NUM_OVERLAYS_Y):
                 for x in range(0, self.NUM_OVERLAYS_X):
-                    top_x = x * self.settings.OVERLAY_RES_X
-                    top_y = y * self.settings.OVERLAY_RES_Y
-                    bottom_x = top_x + self.settings.OVERLAY_RES_X
-                    bottom_y = top_y + self.settings.OVERLAY_RES_Y
+                    top_x = x * self.device_settings.OVERLAY_RES_X
+                    top_y = y * self.device_settings.OVERLAY_RES_Y
+                    bottom_x = top_x + self.device_settings.OVERLAY_RES_X
+                    bottom_y = top_y + self.device_settings.OVERLAY_RES_Y
                     key_slice = self.image[modifier][top_y:bottom_y, top_x:bottom_x]
                     if key_slice.any():
                         try:
-                            overlays[keycode] = OverlayData(self.settings, key_slice)
+                            overlays[keycode] = OverlayData(self.device_settings, key_slice)
                         except ValueError:
                             self.log.warning("Skipping empty overlay for keycode 0x%x", keycode)
                     keycode += 1

--- a/polyhost/device/overlay_data.py
+++ b/polyhost/device/overlay_data.py
@@ -21,8 +21,8 @@ def find_roi_rectangle(image):
 class OverlayData:
     """ Container for all overlay data package variations: plain, compressed, region-of-interest, compressed region-of-interest """
 
-    def __init__(self, settings, image, debug_dump_byte_buffers=False):
-        self.settings = settings
+    def __init__(self, device_settings, image, debug_dump_byte_buffers=False):
+        self.device_settings = device_settings
 
         self.all_bytes = np.packbits(image, axis=None).tobytes()
 
@@ -41,11 +41,11 @@ class OverlayData:
         # we can skip empty data packets as for plain transfer every packet has a number and the buffer are erased before
         self.all_msgs = self.helper_calc_overlay_bytes(self.all_bytes)
         self.compressed_msgs = math.ceil(
-            (len(self.compressed_bytes)+self.settings.OVERLAY_CMD_BYTES_COMPRESSED_ONCE)/self.settings.MAX_PAYLOAD_BYTES_PER_REPORT)
+            (len(self.compressed_bytes)+self.device_settings.OVERLAY_CMD_BYTES_COMPRESSED_ONCE)/self.device_settings.MAX_PAYLOAD_BYTES_PER_REPORT)
         self.roi_msgs = math.ceil(
-            (len(self.roi_bytes)+self.settings.OVERLAY_CMD_BYTES_ROI_ONCE)/self.settings.MAX_PAYLOAD_BYTES_PER_REPORT)
+            (len(self.roi_bytes)+self.device_settings.OVERLAY_CMD_BYTES_ROI_ONCE)/self.device_settings.MAX_PAYLOAD_BYTES_PER_REPORT)
         self.compressed_roi_msgs = math.ceil(
-            (len(self.compressed_roi_bytes)+self.settings.OVERLAY_CMD_BYTES_ROI_ONCE)/self.settings.MAX_PAYLOAD_BYTES_PER_REPORT)
+            (len(self.compressed_roi_bytes)+self.device_settings.OVERLAY_CMD_BYTES_ROI_ONCE)/self.device_settings.MAX_PAYLOAD_BYTES_PER_REPORT)
 
         # w = self.right - self.left
         # h = self.bottom - self.top
@@ -72,12 +72,12 @@ class OverlayData:
     def helper_calc_overlay_bytes(self, all_bytes, skip_empty=True):
         """ Checks each overlay data packet for empty ones and deducts from the overall number """
         if not skip_empty:
-            return self.settings.OVERLAY_PLAIN_DATA_REPORT_COUNT
+            return self.device_settings.OVERLAY_PLAIN_DATA_REPORT_COUNT
 
         msg_cnt = 0
-        for msg_num in range(0, self.settings.OVERLAY_PLAIN_DATA_REPORT_COUNT):
-            start = msg_num * self.settings.OVERLAY_PLAIN_DATA_BYTES_PER_REPORT
-            stop = start + self.settings.OVERLAY_PLAIN_DATA_BYTES_PER_REPORT
+        for msg_num in range(0, self.device_settings.OVERLAY_PLAIN_DATA_REPORT_COUNT):
+            start = msg_num * self.device_settings.OVERLAY_PLAIN_DATA_BYTES_PER_REPORT
+            stop = start + self.device_settings.OVERLAY_PLAIN_DATA_BYTES_PER_REPORT
             data = all_bytes[start:stop]
             if all(b == 0 for b in data):
                 continue

--- a/polyhost/device/poly_kybd.py
+++ b/polyhost/device/poly_kybd.py
@@ -66,7 +66,7 @@ class PolyKybd:
                 result, msg = self.query_id()
                 if result:
                     return True
-                self.log.warning("ID query failed (attempt %d/%d): %s", attempt + 1, retries, msg)
+                self.log.warning("ID query failed (attempt %d/%d): %s", attempt + 1, retries, msg if msg else "EMPTY REPLY")
             # All retries exhausted — HID handle is stale after a reset/reflash;
             # re-enumerate so the new USB path is picked up.
             self.log.warning("Re-enumerating HID after %d failed attempts...", retries)

--- a/polyhost/device/poly_kybd.py
+++ b/polyhost/device/poly_kybd.py
@@ -56,19 +56,23 @@ class PolyKybd:
 
     def connect(self):
         """Connect to PolyKybd"""
-        # Connect to Keeb
         if not self.hid:
             self.log.debug("Connecting to PolyKybd for the first time...")
             self.hid = HidHelper(self.device_settings)
             self.serial = SerialHelper(self.device_settings)
         else:
-            result, msg = self.query_id()
-            if not result:
-                self.log.warning("ID query failed once (%s)", msg)
+            retries = self.poly_settings.get("hid_reconnect_retries")
+            for attempt in range(retries):
                 result, msg = self.query_id()
-                if not result:
-                    self.log.error("ID query failed twice (%s)", msg)
-                    return False
+                if result:
+                    return True
+                self.log.warning("ID query failed (attempt %d/%d): %s", attempt + 1, retries, msg)
+            # All retries exhausted — HID handle is stale after a reset/reflash;
+            # re-enumerate so the new USB path is picked up.
+            self.log.warning("Re-enumerating HID after %d failed attempts...", retries)
+            self.hid = HidHelper(self.device_settings)
+            self.serial = SerialHelper(self.device_settings)
+            return self.hid.interface_acquired()
         return True
 
     def read_serial(self):

--- a/polyhost/device/poly_kybd_mock.py
+++ b/polyhost/device/poly_kybd_mock.py
@@ -160,6 +160,7 @@ class PolyKybdMock:
         return True, ""
 
     def reset_overlay_usage(self):
+        self._log_call("reset_overlay_usage")
         self.log.info("Clear Overlay Mapping Usage...")
         self._sim.reset_usage()
         return True, ""
@@ -253,6 +254,7 @@ class PolyKybdMock:
     def send_overlay_mapping(self, from_to: dict) -> tuple[bool, str]:
         self.hid_mapping_sends += 1
         self.last_mapping = from_to
+        self._overlay_mapping.update(from_to)
         self._sim.apply_mapping(from_to)
         return True, "Mapping sent"
 
@@ -394,8 +396,8 @@ class PolyKybdMock:
         self._log_call("read_serial")
         return None
 
-    def get_console_output(self):
-        return None
+    def get_console_output(self, flush_and_return=True):
+        return "" if flush_and_return else None
 
     def execute_commands(self, command_list):
         for cmd_str in command_list:

--- a/polyhost/device/poly_kybd_mock.py
+++ b/polyhost/device/poly_kybd_mock.py
@@ -258,7 +258,7 @@ class PolyKybdMock:
 
     def send_overlay(self, filename, on_off=True):
         self.log.info("Send Overlay '%s'...", filename)
-        converter = ImageConverter(self.settings)
+        converter = ImageConverter(self.device_settings)
         if not converter:
             return False, f"Invalid file '{filename}'."
 
@@ -292,6 +292,7 @@ class PolyKybdMock:
         self._log_call("send_overlays", filenames)
         overlay_counter = 0
         hid_msg_counter = 0
+        key_counter = 0
         enabled = False
 
         for filename in filenames:
@@ -338,7 +339,7 @@ class PolyKybdMock:
         with cache.batch():
             for filename in filenames:
                 self.log.info("Send Overlay MRU (mock) '%s'...", filename)
-                converter = ImageConverter(self.settings)
+                converter = ImageConverter(self.device_settings)
                 if not converter.open(filename):
                     self.log.warning("Unable to read %s", filename)
                     return False

--- a/polyhost/forwarder.py
+++ b/polyhost/forwarder.py
@@ -33,16 +33,7 @@ UPDATE_CYCLE_MSEC = 250
 NEW_WINDOW_ACCEPT_TIME_MSEC = 1000
 HEARTBEAT_MSEC = 15000  # resend current window state periodically so the host can catch up
 
-# Define custom debug levels
-DEBUG_DETAILED = 8   # Custom level below DEBUG (10)
-
-logging.addLevelName(DEBUG_DETAILED, "DEBUG_DETAILED")
-
-def debug_detailed(self, message, *args, **kwargs):
-    if self.isEnabledFor(DEBUG_DETAILED):
-        self._log(DEBUG_DETAILED, message, args, **kwargs)
-
-logging.Logger.debug_detailed = debug_detailed
+from polyhost.util.log_util import DEBUG_DETAILED, make_stream_handler  # noqa: F401  (registers debug_detailed on import)
 
 class PolyForwarder(QApplication):
     def __init__(self, log_level, host=None, host_file=None):
@@ -50,19 +41,15 @@ class PolyForwarder(QApplication):
         self.host = host
         self.host_file = os.path.expanduser(host_file) if host_file else None
 
-        logging.basicConfig(
-            level=log_level,
-            format="[%(asctime)s] %(levelname)-7s {%(filename)s:%(lineno)d} - %(message)s",
-            handlers=[
-                RotatingFileHandler(
-                    filename="forwarder_log.txt",
-                    maxBytes=10 * 1024 * 1024,  # 10 MB
-                    backupCount=3,
-                    encoding="utf-8"
-                ),
-                logging.StreamHandler(stream=sys.stdout),
-            ],
+        fmt = "[%(asctime)s] %(levelname)-7s {%(filename)s:%(lineno)d} - %(message)s"
+        file_handler = RotatingFileHandler(
+            filename="forwarder_log.txt",
+            maxBytes=10 * 1024 * 1024,
+            backupCount=3,
+            encoding="utf-8"
         )
+        file_handler.setFormatter(logging.Formatter(fmt))
+        logging.basicConfig(level=log_level, handlers=[file_handler, make_stream_handler(fmt)])
         self.log = logging.getLogger("PolyForwarder")
 
         # Create the tray

--- a/polyhost/handler/active_window.py
+++ b/polyhost/handler/active_window.py
@@ -239,5 +239,13 @@ class OverlayHandler:
             return self.remote_handler.get_overlay_data()
         return None
 
+    def force_resend(self):
+        """Reset window tracking so the next cycle triggers a fresh OFF_ON resend."""
+        self.win = None
+        self.title = None
+        self.handle = None
+        self.last_entry = None
+        self.last_update_msec = 0
+
     def close(self):
         self.remote_handler.close()

--- a/polyhost/handler/active_window.py
+++ b/polyhost/handler/active_window.py
@@ -246,6 +246,7 @@ class OverlayHandler:
         self.handle = None
         self.last_entry = None
         self.last_update_msec = 0
+        self.remote_handler.reset_for_resend()
 
     def close(self):
         self.remote_handler.close()

--- a/polyhost/handler/kde_win_reporter.py
+++ b/polyhost/handler/kde_win_reporter.py
@@ -60,16 +60,17 @@ def getActiveWindow():
         .rstrip()
         .split("\n")
     )
-    msg = [elem.removeprefix("js: ") for elem in msg]
-
-    return KWin(msg[0])
+    result = [elem.removeprefix("js: ") for elem in msg]
+    if not result:
+        raise ValueError(f"Cannot parse KWin response: '{msg}'")
+    return KWin(result)
 
 
 class KWin:
     def __init__(self, msg):
-        elems = msg.split(";")
+        elems = msg[0].split(";")
         if len(elems) != 3:
-            raise Exception(f"Unexpected format reported by KWin Script: '{msg}'")
+            raise ValueError(f"Unexpected format reported by KWin Script: '{msg}'")
 
         self.name = elems[0]
         self.title = elems[1]

--- a/polyhost/handler/kde_win_reporter.py
+++ b/polyhost/handler/kde_win_reporter.py
@@ -1,8 +1,10 @@
-# import logging
+import logging
 import os
 import pathlib
 import subprocess
 from datetime import datetime
+
+_log = logging.getLogger("PolyHost")
 
 
 def getActiveWindow():
@@ -24,13 +26,15 @@ def getActiveWindow():
         if "int32" in line:
             reg_script_number = line.split()[-1]
             break
-    
+
     if reg_script_number is None:
-        raise Exception(f"Could not find KWin Script: '{output}'")
+        _log.warning("KWin: could not find script number in dbus output (transient)")
+        return None
     try:
         reg_script_number = str(int(reg_script_number))
-    except ValueError as e:
-        raise Exception(f"Unexpected KWin script number format: '{reg_script_number}'") from e
+    except ValueError:
+        _log.warning("KWin: unexpected script number format '%s' (transient)", reg_script_number)
+        return None
     
     datetime_now = datetime.now()
     subprocess.run(
@@ -61,9 +65,13 @@ def getActiveWindow():
         .split("\n")
     )
     result = [elem.removeprefix("js: ") for elem in msg]
-    if not result:
-        raise ValueError(f"Cannot parse KWin response: '{msg}'")
-    return KWin(result)
+    if not result or not result[0]:
+        return None  # transient: KWin script produced no output this cycle
+    try:
+        return KWin(result)
+    except ValueError as e:
+        _log.warning("KWin: malformed window response (transient): %s", e)
+        return None
 
 
 class KWin:

--- a/polyhost/handler/remote_window.py
+++ b/polyhost/handler/remote_window.py
@@ -191,6 +191,12 @@ class RemoteHandler:
     def get_overlay_data(self):
         return self.current_entry["overlay"]
 
+    def reset_for_resend(self):
+        """Clear cached remote window identity so the next remote_changed() call sees a delta."""
+        self.handle = None
+        self.title = None
+        self.last_entry = None
+
     def close(self):
         self.stop_event.set()
         if self.forwarder and self.forwarder.is_alive():

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -60,16 +60,8 @@ def get_lang_and_country(combined : str):
     return combined[:2], combined[2:]
 
 
-# Define custom debug levels
-DEBUG_DETAILED = 8   # Custom level below DEBUG (10)
+from polyhost.util.log_util import DEBUG_DETAILED, ColorFormatter, make_stream_handler
 
-logging.addLevelName(DEBUG_DETAILED, "DEBUG_DETAILED")
-
-def debug_detailed(self, message, *args, **kwargs):
-    if self.isEnabledFor(DEBUG_DETAILED):
-        self._log(DEBUG_DETAILED, message, args, **kwargs)
-
-logging.Logger.debug_detailed = debug_detailed
 
 class MultiLineFormatter(logging.Formatter):
     def format(self, record):
@@ -80,24 +72,25 @@ class MultiLineFormatter(logging.Formatter):
         timestamp = self.formatTime(record)
         formatted_lines = [f"[{timestamp}] {line}" for line in lines[:-1]]
         return lines[0] + "\n".join(formatted_lines)
-    
+
+
 class PolyHost(QApplication):
     def __init__(self, log_level, debug_mode):
         super().__init__(sys.argv)
         fmt = "[%(asctime)s] %(levelname)-7s {%(filename)s:%(lineno)d} %(message)s" if debug_mode>0 else "[%(asctime)s] %(levelname)-7s %(message)s"
-        logging.basicConfig(
-            level=DEBUG_DETAILED if debug_mode>1 else log_level,
-            format=fmt,
-            handlers=[
-                RotatingFileHandler(
-                    filename="host_log.txt",
-                    maxBytes=5 * 1024 * 1024,  # 5 MB
-                    backupCount=3,
-                    encoding="utf-8"
-                ),
-                logging.StreamHandler(stream=sys.stdout),
-            ],
+        level = DEBUG_DETAILED if debug_mode>1 else log_level
+
+        file_handler = RotatingFileHandler(
+            filename="host_log.txt",
+            maxBytes=5 * 1024 * 1024,
+            backupCount=3,
+            encoding="utf-8"
         )
+        file_handler.setFormatter(logging.Formatter(fmt))
+
+        stream_handler = make_stream_handler(fmt)
+
+        logging.basicConfig(level=level, handlers=[file_handler, stream_handler])
         self.log = logging.getLogger('PolyHost')
 
         # Create the tray
@@ -148,6 +141,7 @@ class PolyHost(QApplication):
         self.setQuitOnLastWindowClosed(False)
         self.is_closing = False
         self.debug_mode = debug_mode
+        self._needs_overlay_reset = False
 
         # Create the menu
         self.log.debug("Building menu...")
@@ -239,18 +233,13 @@ class PolyHost(QApplication):
 
         entries = self.helper.get_languages()
 
-        result = self.helper.get_current_language()
+        result, info = self.helper.get_current_language()
         if result:
-            success, sys_lang = result
-            if success:
-                self.log.info("Current System Language: %s", sys_lang)
-                self.current_lang = sys_lang
-            else:
-                self.icon_manager.set_warning("Could not query current System Language.", 5000)
-                self.log.warning("Could not query current System Language.")
+            self.log.info("Current System Language: %s", info)
+            self.current_lang = info
         else:
             self.icon_manager.set_warning("System language query not supported for this platform.", 5000)
-            self.log.warning("System language query not supported for this platform.")
+            self.log.warning("System language query not supported for this platform: '%s'", info)
 
         if debug_mode>0:
             for e in entries:
@@ -371,10 +360,10 @@ class PolyHost(QApplication):
                             self.log.info("Setting unicode mode to str %s", mode)
                             self.keeb.set_unicode_mode(mode)
                             self.update_ui_on_lang_change(response)
-                        # consider timeout - or can I find out if there was a real disconnecT?
-                        # self.device_mgr.connect_secondaries()
-                        # self.device_mgr.reset_all_caches()
-                        # self.log.info("Overlay MRU cache initialised.")
+                        self.device_mgr.reset_all_caches()
+                        self.overlay_handler.force_resend()
+                        self._needs_overlay_reset = True
+                        self.log.info("Connected: active window resend queued.")
                     else:
                         self.status.setIcon(get_icon("sync_disabled.svg"))
                         self.status.setText(f"Incompatible version: {msg}, expected {expected}, got {kb_version}'.")
@@ -597,6 +586,10 @@ class PolyHost(QApplication):
             self.last_update_msec = 0
             self.icon_manager.update()
         if self.connected:
+            if self._needs_overlay_reset:
+                self._needs_overlay_reset = False
+                self.cmdMenu.reset_overlays_and_usage()
+                self.log.info("Connected: overlay state cleared.")
             if self.keeb.pop_fresh_boot():
                 self.device_mgr.reset_all_caches()
                 self.log.info("Firmware restart detected — overlay MRU cache reset.")
@@ -637,7 +630,7 @@ class PolyHost(QApplication):
             if self.last_update_10min_task > PERIODIC_10MIN_CYCLE_MSEC:
                 self.last_update_10min_task = 0
                 self.execute_10min_task()
-        elif self.poly_settings.get("debug_window_detection_if_not_connected_to_poly_kybd"):
+        elif self.poly_settings.get("dev_run_window_detection_if_not_connected_to_poly_kybd"):
             self.overlay_handler.handle_active_window(UPDATE_CYCLE_MSEC, NEW_WINDOW_ACCEPT_TIME_MSEC)
 
         kb_serial = self.keeb.read_serial()

--- a/polyhost/input/linux_kde_helper.py
+++ b/polyhost/input/linux_kde_helper.py
@@ -70,4 +70,4 @@ class LinuxPlasmaHelper:
             return False, msg
 
     def get_current_language(self):
-        False, "Not Implemented" 
+        return False, "Not Implemented" 

--- a/polyhost/input/linux_kde_helper.py
+++ b/polyhost/input/linux_kde_helper.py
@@ -70,4 +70,20 @@ class LinuxPlasmaHelper:
             return False, msg
 
     def get_current_language(self):
-        return False, "Not Implemented" 
+        self.get_countries()
+        if not self.list:
+            return False, "No layout list loaded"
+        try:
+            result = subprocess.run(
+                ["qdbus", "org.kde.keyboard", "/Layouts", "getLayout"],
+                stdout=subprocess.PIPE,
+                check=True,
+            )
+            idx = int(result.stdout.strip())
+            if 0 <= idx < len(self.list):
+                return True, self.list[idx]
+            return False, f"Layout index {idx} out of range ({len(self.list)} layouts)"
+        except subprocess.CalledProcessError as ex:
+            return False, str(ex)
+        except ValueError as ex:
+            return False, f"Unexpected qdbus output: {ex}"

--- a/polyhost/input/macos_helper.py
+++ b/polyhost/input/macos_helper.py
@@ -49,4 +49,4 @@ class MacOSInputHelper:
             return False, msg
 
     def get_current_language(self):
-        False, "Not Implemented" 
+        return False, "Not Implemented" 

--- a/polyhost/res/overlay-mapping.poly.yaml
+++ b/polyhost/res/overlay-mapping.poly.yaml
@@ -14,7 +14,7 @@ chrome,google-chrome:
 nxplayer:
   remote: true
   title: .*NoMachine.*
-gimp-2.0,gimp-2.8,gimp-3.0,gimp,gimp-3:
+gimp-2.0,gimp-2.8,gimp-3.0,gimp,gimp-3,org.gimp.GIMP:
   overlay: gimp_template.mods.png
 zoom:
   overlay: zoom_template.mods.png

--- a/polyhost/settings.py
+++ b/polyhost/settings.py
@@ -28,14 +28,16 @@ class PolySettings:
             "irradiance_min": 1.8,
             "irradiance_max": 6.5,
             "irradiance_prescaler": 0.75,
-            "debug_window_detection_if_not_connected_to_poly_kybd": False,
             "max_hid_message_before_delay": 15,
             "delay_time_after_max_hid_messages": 0.3,
+            "hid_reconnect_retries": 5,
             "overlay_mru_cache_enabled": False,
             "dev_mock_enabled": False,
-            "dev_mock_overlay_mru_cache_enabled": True
+            "dev_mock_overlay_mru_cache_enabled": True,
+            "dev_run_window_detection_if_not_connected_to_poly_kybd": False,
         }
         self._legacy_key_renames = {
+            "debug_window_detection_if_not_connected_to_poly_kybd": "dev_run_window_detection_if_not_connected_to_poly_kybd",
             "overlay_lru_cache_enabled": "overlay_mru_cache_enabled",
             "dev_mock_overlay_lru_cache_enabled": "dev_mock_overlay_mru_cache_enabled",
         }

--- a/polyhost/util/log_util.py
+++ b/polyhost/util/log_util.py
@@ -1,0 +1,35 @@
+import logging
+import sys
+
+DEBUG_DETAILED = 8  # Custom level below DEBUG (10)
+
+logging.addLevelName(DEBUG_DETAILED, "DEBUG_DETAILED")
+
+
+def _debug_detailed(self, message, *args, **kwargs):
+    if self.isEnabledFor(DEBUG_DETAILED):
+        self._log(DEBUG_DETAILED, message, args, **kwargs)
+
+
+logging.Logger.debug_detailed = _debug_detailed
+
+
+class ColorFormatter(logging.Formatter):
+    _COLORS = {
+        logging.ERROR:   "\033[91m",        # bright red
+        logging.WARNING: "\033[38;5;208m",  # orange
+        logging.INFO:    "\033[92m",         # bright green
+        logging.DEBUG:   "\033[36m",         # teal
+        DEBUG_DETAILED:  "\033[38;5;86m",   # aquamarine
+    }
+    _RESET = "\033[0m"
+
+    def format(self, record):
+        color = self._COLORS.get(record.levelno, "")
+        return f"{color}{super().format(record)}{self._RESET}" if color else super().format(record)
+
+
+def make_stream_handler(fmt: str) -> logging.StreamHandler:
+    handler = logging.StreamHandler(stream=sys.stdout)
+    handler.setFormatter(ColorFormatter(fmt) if sys.stdout.isatty() else logging.Formatter(fmt))
+    return handler

--- a/tests/device/cmd_composer_test.py
+++ b/tests/device/cmd_composer_test.py
@@ -4,7 +4,10 @@ from unittest.mock import MagicMock
 from polyhost.device.cmd_composer import (
     compose_cmd_str, compose_cmd, compose_roi_header, expect
 )
+from polyhost.device.command_ids import HidId
 from polyhost.device.keys import Modifier
+
+P = HidId.ID_POLYKYBD.value  # protocol prefix byte
 
 
 class TestUtilityFunctions(unittest.TestCase):
@@ -15,17 +18,17 @@ class TestUtilityFunctions(unittest.TestCase):
 
     def test_compose_cmd_str(self):
         result = compose_cmd_str(self.mock_cmd, "test")
-        expected = bytearray.fromhex("0901") + b"test"
+        expected = bytearray([P, 0x01]) + b"test"
         self.assertEqual(result, expected)
 
     def test_compose_cmd_no_extra(self):
         result = compose_cmd(self.mock_cmd)
-        expected = bytearray.fromhex("0901")
+        expected = bytearray([P, 0x01])
         self.assertEqual(result, expected)
 
     def test_compose_cmd_with_extra(self):
         result = compose_cmd(self.mock_cmd, 0x02, 0x03, 0x04)
-        expected = bytearray.fromhex("0901020304")
+        expected = bytearray([P, 0x01, 0x02, 0x03, 0x04])
         self.assertEqual(result, expected)
 
     def test_compose_roi_header_uncompressed(self):
@@ -36,11 +39,10 @@ class TestUtilityFunctions(unittest.TestCase):
         overlay.right = 0x2A
 
         result = compose_roi_header(self.mock_cmd, 0x10, Modifier.CTRL_ALT, overlay, compressed=False)
-        expected = bytearray(b'\x09\x01\x10\x05\x2b\x1f\x2a')
+        expected = bytearray([P, 0x01, 0x10, 0x05, 0x2b, 0x1f, 0x2a])
         self.assertEqual(result, expected)
 
     def test_compose_roi_header_compressed(self):
-        # Updated overlay parameters
         overlay = MagicMock()
         overlay.top = 0x05
         overlay.bottom = 0x0C
@@ -48,7 +50,7 @@ class TestUtilityFunctions(unittest.TestCase):
         overlay.right = 0x3B
 
         result = compose_roi_header(self.mock_cmd, 0x20, Modifier.GUI_KEY, overlay, compressed=True)
-        expected = bytearray(b'\x09\x01\x20\x18\x31\x2f\xbb')
+        expected = bytearray([P, 0x01, 0x20, 0x18, 0x31, 0x2f, 0xbb])
         self.assertEqual(result, expected)
 
     def test_expect(self):


### PR DESCRIPTION
## Summary

- **HID reconnect**: Keyboard now reconnects automatically after reset or reflash without restarting PolyHost. The existing HID handle is retried up to `hid_reconnect_retries` times (default 5, configurable in Settings) before USB is re-enumerated and a fresh handle is opened.
- **Stale overlay fix**: On every new connection the keyboard's overlay buffer is cleared and the MRU cache reset. The active window's overlay is immediately requeued for resend so the keyboard shows the right keys without needing a window switch. The HID reset is deferred one event-loop tick to avoid a race with the startup HID command burst.
- **Colour-coded console logging**: Log output to stdout is now colour-coded by level (ERROR=red, WARNING=orange, INFO=green, DEBUG=teal, DEBUG\_DETAILED=aquamarine) with a TTY guard so piped output stays clean. Shared via the new `polyhost/util/log_util.py` module; applied to both PolyHost and PolyForwarder.
- **PolyKybdMock bug fixes**: `self.settings` → `self.device_settings` in `send_overlay` and `send_overlays_mru`; missing `key_counter` initialisation in `send_overlays`.
- **`settings` → `device_settings` rename**: `ImageConverter` and `OverlayData` now use `device_settings` consistently with the rest of the codebase.
- **KDE/macOS helper fix**: Missing `return` in `get_current_language()` on both helpers.
- **KWin reporter fix**: Guard against empty response; fix constructor to pass the full list rather than the first element string.
- **Settings rename**: `debug_window_detection_if_not_connected_to_poly_kybd` → `dev_run_window_detection_if_not_connected_to_poly_kybd` (legacy key migration included).
- **Overlay mapping**: Add `org.gimp.GIMP` (Flatpak app ID) to the GIMP entry.

## Test plan

- [ ] Connect keyboard → restart PolyHost → verify no stale overlay icons visible
- [ ] With PolyHost running, reset keyboard → verify reconnects within ~5 s without restarting host
- [ ] Flash new firmware → same reconnect behaviour
- [ ] Switch to a mapped app after reconnect → overlay appears without needing a second window switch
- [ ] Run with `--debug 1` → verify colour-coded output in terminal; pipe to file → verify no escape codes in file
- [ ] Run in forwarder mode → same colour coding
- [ ] Enable `dev_mock_enabled` + `dev_mock_overlay_mru_cache_enabled` → verify no AttributeError on overlay send
- [ ] Check Settings dialog → `hid_reconnect_retries` spin box present under "Hid" group

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve device reconnect robustness, fix stale overlay and window reporting issues, and introduce shared colour-coded logging across host and forwarder.

New Features:
- Add configurable HID reconnect retries so the keyboard can automatically recover after reset or reflash without restarting the host.
- Introduce colour-coded console logging with TTY-aware formatting shared between PolyHost and PolyForwarder.
- Extend overlay application mapping to recognise the GIMP Flatpak app ID.

Bug Fixes:
- Clear keyboard overlays and MRU cache on new connections and force a resend so stale overlays are not displayed after reconnect.
- Correct the KDE and macOS language helpers to return a proper result tuple instead of falling through without a return value.
- Fix KWin reporter parsing and construction to handle empty responses and pass the full response structure to the KWin wrapper.
- Fix PolyKybdMock to use device settings consistently and initialise the key counter when sending overlays, avoiding AttributeError and counter issues.

Enhancements:
- Extract logging level and colour formatting into a shared utility module and standardise host and forwarder logging configuration on it.
- Rename image and overlay components to use device_settings consistently with the rest of the codebase.
- Rename the window-detection debug setting to a dev_* flag with legacy key migration for existing configurations.
- Add an explicit force-resend hook in the active window handler and defer overlay state reset to avoid races on startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More reliable device reconnection with configurable retry attempts.
  * Automatic overlay resend/reset when a device connects.
  * Improved logging with richer debug level and colored console output.

* **Bug Fixes**
  * Fixed language detection behavior on macOS and Linux.
  * More robust KDE window parsing and error handling.

* **Configuration Changes**
  * Added settings: reconnect retry count, HID message delay limit, and new window-detection flag.
* **Tests**
  * Updated tests to use protocol-aware prefixes for HID-related expectations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thpoll83/PolyKybdHost/pull/7?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->