### PR TITLE
Implement platform language helpers: macOS get_current_language, Windows native set_language (experimental)

### DIFF
--- a/polyhost/forwarder.py
+++ b/polyhost/forwarder.py
@@ -33,7 +33,7 @@ UPDATE_CYCLE_MSEC = 250
 NEW_WINDOW_ACCEPT_TIME_MSEC = 1000
 HEARTBEAT_MSEC = 15000  # resend current window state periodically so the host can catch up
 
-from polyhost.util.log_util import DEBUG_DETAILED, make_stream_handler  # noqa: F401  (registers debug_detailed on import)
+from polyhost.util.log_util import DEBUG_DETAILED, make_stream_handler, make_collapse_handler  # noqa: F401  (registers debug_detailed on import)
 
 class PolyForwarder(QApplication):
     def __init__(self, log_level, host=None, host_file=None):
@@ -49,7 +49,10 @@ class PolyForwarder(QApplication):
             encoding="utf-8"
         )
         file_handler.setFormatter(logging.Formatter(fmt))
-        logging.basicConfig(level=log_level, handlers=[file_handler, make_stream_handler(fmt)])
+        logging.basicConfig(level=log_level, handlers=[
+            make_collapse_handler(file_handler),
+            make_collapse_handler(make_stream_handler(fmt)),
+        ])
         self.log = logging.getLogger("PolyForwarder")
 
         # Create the tray

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -218,7 +218,7 @@ class PolyHost(QApplication):
         self.log.debug("Create OS dependent input helper...")
         self.helper = None
         if platform.system() == "Windows":
-            self.helper = WindowsInputHelper()
+            self.helper = WindowsInputHelper(self.poly_settings)
         elif platform.system() == "Linux":
             if IS_PLASMA:
                 self.helper = LinuxPlasmaHelper()
@@ -374,7 +374,7 @@ class PolyHost(QApplication):
             self.managed_connection_status()
             if connected_now:
                 return response
-            self.log.warning("Reconnect failed once (%s) - recovered now.", response)
+            self.log.warning("Reconnect failed: '%s'", response if response else "NO RESPONSE")
         return self.current_lang
 
     @staticmethod

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -60,7 +60,7 @@ def get_lang_and_country(combined : str):
     return combined[:2], combined[2:]
 
 
-from polyhost.util.log_util import DEBUG_DETAILED, ColorFormatter, make_stream_handler
+from polyhost.util.log_util import DEBUG_DETAILED, ColorFormatter, make_stream_handler, make_collapse_handler
 
 
 class MultiLineFormatter(logging.Formatter):
@@ -88,7 +88,8 @@ class PolyHost(QApplication):
         )
         file_handler.setFormatter(logging.Formatter(fmt))
 
-        stream_handler = make_stream_handler(fmt)
+        stream_handler = make_collapse_handler(make_stream_handler(fmt))
+        file_handler = make_collapse_handler(file_handler)
 
         logging.basicConfig(level=level, handlers=[file_handler, stream_handler])
         self.log = logging.getLogger('PolyHost')

--- a/polyhost/input/linux_kde_helper.py
+++ b/polyhost/input/linux_kde_helper.py
@@ -1,14 +1,13 @@
-import logging
 import re
 import subprocess
 from pathlib import Path
 
+from polyhost.input.input_helper import InputHelper
 from polyhost.lang.lang_compat import LangComp
 
 
-class LinuxPlasmaHelper:
+class LinuxPlasmaHelper(InputHelper):
     def __init__(self):
-        self.log = logging.getLogger('PolyHost')
         self.comp = LangComp()
         self.list = None
 

--- a/polyhost/input/macos_helper.py
+++ b/polyhost/input/macos_helper.py
@@ -1,13 +1,13 @@
-import logging
 import plistlib
 import re
 import subprocess
 
+from polyhost.input.input_helper import InputHelper
+
 lang_re = re.compile(r"^\s*\d+\) (.*)$")
 
-class MacOSInputHelper:
+class MacOSInputHelper(InputHelper):
     def __init__(self):
-        self.log = logging.getLogger('PolyHost')
         self.list = None
 
     def get_languages(self):

--- a/polyhost/input/macos_helper.py
+++ b/polyhost/input/macos_helper.py
@@ -49,4 +49,17 @@ class MacOSInputHelper:
             return False, msg
 
     def get_current_language(self):
-        return False, "Not Implemented" 
+        try:
+            result = subprocess.run(
+                ["defaults", "read", "-g", "AppleInputSources"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                check=True,
+            )
+            output = result.stdout.decode("utf-8")
+            m = re.search(r'"KeyboardLayout Name"\s*=\s*"([^"]+)"', output)
+            if m:
+                return True, m.group(1)
+            return False, "Could not parse KeyboardLayout Name from AppleInputSources"
+        except subprocess.CalledProcessError as ex:
+            return False, str(ex)

--- a/polyhost/input/macos_helper.py
+++ b/polyhost/input/macos_helper.py
@@ -1,6 +1,7 @@
 import logging
-import subprocess
+import plistlib
 import re
+import subprocess
 
 lang_re = re.compile(r"^\s*\d+\) (.*)$")
 
@@ -51,15 +52,18 @@ class MacOSInputHelper:
     def get_current_language(self):
         try:
             result = subprocess.run(
-                ["defaults", "read", "-g", "AppleInputSources"],
+                ["defaults", "export", "com.apple.HIToolbox", "-"],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
                 check=True,
             )
-            output = result.stdout.decode("utf-8")
-            m = re.search(r'"KeyboardLayout Name"\s*=\s*"([^"]+)"', output)
-            if m:
-                return True, m.group(1)
-            return False, "Could not parse KeyboardLayout Name from AppleInputSources"
+            plist = plistlib.loads(result.stdout)
+            for source in plist.get("AppleSelectedInputSources", []):
+                name = source.get("KeyboardLayout Name")
+                if name:
+                    return True, name
+            return False, "No KeyboardLayout Name found in AppleSelectedInputSources"
         except subprocess.CalledProcessError as ex:
             return False, str(ex)
+        except plistlib.InvalidFileException as ex:
+            return False, f"Could not parse HIToolbox plist: {ex}"

--- a/polyhost/input/win_helper.py
+++ b/polyhost/input/win_helper.py
@@ -87,6 +87,9 @@ class WindowsInputHelper(InputHelper):
             return False, f"LoadKeyboardLayout failed for KLID {klid} ({iso639})"
 
         hwnd = user32.GetForegroundWindow()
+        if not hwnd:
+            self.log.warning("Native set_language: no foreground window, falling back to pynput cycling")
+            return super().set_language(lang, country)
         user32.PostMessageW(hwnd, _WM_INPUTLANGCHANGEREQUEST, 0, hkl)
         self.log.debug("Native set_language: KLID=%s HKL=%s hwnd=%s", klid, hkl, hwnd)
         return True, iso639

--- a/polyhost/input/win_helper.py
+++ b/polyhost/input/win_helper.py
@@ -1,3 +1,5 @@
+import ctypes
+import locale
 import logging
 import subprocess
 from polyhost.input.input_helper import InputHelper
@@ -6,9 +8,14 @@ from polyhost.input.input_helper import InputHelper
 #    "$($_.LanguageTag): $($_.InputMethodTips -join ', ')"
 #}
 
+_WM_INPUTLANGCHANGEREQUEST = 0x0050
+_KLF_ACTIVATE = 0x00000001
+
+
 class WindowsInputHelper(InputHelper):
-    def __init__(self):
+    def __init__(self, poly_settings=None):
         super().__init__()
+        self.poly_settings = poly_settings
         self.list = None
         self.query = """$ScriptBlock = {
         Add-Type -AssemblyName System.Windows.Forms
@@ -53,3 +60,53 @@ class WindowsInputHelper(InputHelper):
             msg = str(ex)
             self.log.warning("Exception when running script block: %s", msg)
             return False, msg
+
+    def set_language(self, lang, country):
+        if self.poly_settings and self.poly_settings.get("dev_win_native_set_language"):
+            return self._set_language_native(lang, country)
+        return super().set_language(lang, country)
+
+    def _set_language_native(self, lang, country):
+        """Experimental: switch input language via Win32 LoadKeyboardLayout + PostMessage."""
+        iso639 = f"{lang}-{country}"
+
+        # Find LCID from Python's locale table (maps int LCID -> "lang_COUNTRY")
+        target = f"{lang}_{country}".lower()
+        lcid = next(
+            (lcid_val for lcid_val, loc in locale.windows_locale.items()
+             if loc.lower() == target),
+            None,
+        )
+        if lcid is None:
+            return False, f"No LCID found for {iso639}"
+
+        klid = f"{lcid:08x}"
+        user32 = ctypes.windll.user32
+        hkl = user32.LoadKeyboardLayoutW(klid, _KLF_ACTIVATE)
+        if not hkl:
+            return False, f"LoadKeyboardLayout failed for KLID {klid} ({iso639})"
+
+        hwnd = user32.GetForegroundWindow()
+        user32.PostMessageW(hwnd, _WM_INPUTLANGCHANGEREQUEST, 0, hkl)
+        self.log.debug("Native set_language: KLID=%s HKL=%s hwnd=%s", klid, hkl, hwnd)
+        return True, iso639
+
+        # Alternative: ActivateKeyboardLayout via AttachThreadInput.
+        # More reliable for apps that ignore WM_INPUTLANGCHANGEREQUEST, because it
+        # directly switches the layout on the target thread's input queue rather than
+        # sending a notification the app can choose not to act on.
+        # Caution: AttachThreadInput can deadlock if the target thread is unresponsive;
+        # always detach in a finally block.
+        #
+        # kernel32 = ctypes.windll.kernel32
+        # hwnd = user32.GetForegroundWindow()
+        # target_thread = user32.GetWindowThreadProcessId(hwnd, None)
+        # current_thread = kernel32.GetCurrentThreadId()
+        # attached = user32.AttachThreadInput(current_thread, target_thread, True)
+        # try:
+        #     user32.ActivateKeyboardLayout(hkl, 0)
+        # finally:
+        #     if attached:
+        #         user32.AttachThreadInput(current_thread, target_thread, False)
+        # self.log.debug("Native set_language (ActivateKeyboardLayout): KLID=%s HKL=%s", klid, hkl)
+        # return True, iso639

--- a/polyhost/settings.py
+++ b/polyhost/settings.py
@@ -35,6 +35,7 @@ class PolySettings:
             "dev_mock_enabled": False,
             "dev_mock_overlay_mru_cache_enabled": True,
             "dev_run_window_detection_if_not_connected_to_poly_kybd": False,
+            "dev_win_native_set_language": False,
         }
         self._legacy_key_renames = {
             "debug_window_detection_if_not_connected_to_poly_kybd": "dev_run_window_detection_if_not_connected_to_poly_kybd",

--- a/polyhost/util/log_util.py
+++ b/polyhost/util/log_util.py
@@ -91,45 +91,53 @@ class RepeatCollapseHandler(logging.Handler):
     # ------------------------------------------------------------------ Handler API
 
     def emit(self, record: logging.LogRecord) -> None:
-        key = record.getMessage()
+        self.acquire()
+        try:
+            key = record.getMessage()
 
-        if self._pattern:
-            if key == self._pattern[self._pos]:
-                self._partial.append(record)
-                self._pos += 1
-                if self._pos == len(self._pattern):
-                    # Completed one more full cycle — discard partial, bump count
-                    self._count += 1
-                    self._pos = 0
-                    self._partial = []
-                return  # suppressed
+            if self._pattern:
+                if key == self._pattern[self._pos]:
+                    self._partial.append(record)
+                    self._pos += 1
+                    if self._pos == len(self._pattern):
+                        # Completed one more full cycle — discard partial, bump count
+                        self._count += 1
+                        self._pos = 0
+                        self._partial = []
+                    return  # suppressed
 
-            # Pattern broken — flush and fall through to normal emit below
-            self._exit_pattern(record)
+                # Pattern broken — flush and fall through to normal emit below
+                self._exit_pattern(record)
 
-        # Normal emit
-        self.inner.emit(record)
-        self._buf.append(key)
+            # Normal emit
+            self.inner.emit(record)
+            self._buf.append(key)
 
-        # Keep buffer bounded
-        max_buf = self.max_pattern_len * 2
-        if len(self._buf) > max_buf:
-            del self._buf[:-max_buf]
+            # Keep buffer bounded
+            max_buf = self.max_pattern_len * 2
+            if len(self._buf) > max_buf:
+                del self._buf[:-max_buf]
 
-        # Check for a new repeating pattern
-        p = self._detect_period()
-        if p:
-            self._pattern = list(self._buf[-p:])
-            self._pos = 0
-            self._count = 0
-            self._partial = []
+            # Check for a new repeating pattern
+            p = self._detect_period()
+            if p:
+                self._pattern = list(self._buf[-p:])
+                self._pos = 0
+                self._count = 0
+                self._partial = []
+        finally:
+            self.release()
 
     def close(self) -> None:
-        if self._pattern and (self._count > 0 or self._partial):
-            ref = (self._partial[0] if self._partial else
-                   logging.LogRecord("PolyHost", logging.INFO, "", 0, "", (), None))
-            self._exit_pattern(ref)
-        self.inner.close()
+        self.acquire()
+        try:
+            if self._pattern and (self._count > 0 or self._partial):
+                ref = (self._partial[0] if self._partial else
+                       logging.LogRecord("PolyHost", logging.INFO, "", 0, "", (), None))
+                self._exit_pattern(ref)
+            self.inner.close()
+        finally:
+            self.release()
         super().close()
 
 

--- a/polyhost/util/log_util.py
+++ b/polyhost/util/log_util.py
@@ -33,3 +33,106 @@ def make_stream_handler(fmt: str) -> logging.StreamHandler:
     handler = logging.StreamHandler(stream=sys.stdout)
     handler.setFormatter(ColorFormatter(fmt) if sys.stdout.isatty() else logging.Formatter(fmt))
     return handler
+
+
+class RepeatCollapseHandler(logging.Handler):
+    """Wraps another handler and collapses repeating sequences of log records.
+
+    After a sequence of up to `max_pattern_len` messages repeats at least once
+    (two identical cycles emitted normally), further complete repetitions are
+    suppressed. When the sequence changes a summary is emitted:
+      "... (last N line(s) repeated X more time(s))"
+    followed by any partially-completed cycle that was mid-suppression.
+    """
+
+    def __init__(self, inner: logging.Handler, max_pattern_len: int = 8):
+        super().__init__()
+        self.inner = inner
+        self.max_pattern_len = max_pattern_len
+        self._buf: list[str] = []          # recent message keys (text only, no timestamp)
+        self._pattern: list[str] = []      # current detected repeating pattern
+        self._partial: list[logging.LogRecord] = []  # suppressed records in current incomplete cycle
+        self._pos: int = 0                 # position within the current cycle
+        self._count: int = 0              # number of fully suppressed extra repetitions
+
+    # ------------------------------------------------------------------ helpers
+
+    def _detect_period(self) -> int:
+        """Return smallest p such that the last 2p buffer entries form a repeating pattern."""
+        n = len(self._buf)
+        for p in range(1, min(self.max_pattern_len, n // 2) + 1):
+            if self._buf[-p:] == self._buf[-2 * p:-p]:
+                return p
+        return 0
+
+    def _make_summary(self, ref: logging.LogRecord) -> logging.LogRecord:
+        return logging.LogRecord(
+            name=ref.name,
+            level=ref.levelno,
+            pathname="",
+            lineno=0,
+            msg="  ... (last %d line(s) repeated %d more time(s))",
+            args=(len(self._pattern), self._count),
+            exc_info=None,
+        )
+
+    def _exit_pattern(self, ref: logging.LogRecord) -> None:
+        """Leave suppression mode: emit summary then re-emit the partial cycle."""
+        if self._count > 0:
+            self.inner.emit(self._make_summary(ref))
+        for r in self._partial:
+            self.inner.emit(r)
+            self._buf.append(r.getMessage())
+        self._pattern = []
+        self._partial = []
+        self._pos = 0
+        self._count = 0
+
+    # ------------------------------------------------------------------ Handler API
+
+    def emit(self, record: logging.LogRecord) -> None:
+        key = record.getMessage()
+
+        if self._pattern:
+            if key == self._pattern[self._pos]:
+                self._partial.append(record)
+                self._pos += 1
+                if self._pos == len(self._pattern):
+                    # Completed one more full cycle — discard partial, bump count
+                    self._count += 1
+                    self._pos = 0
+                    self._partial = []
+                return  # suppressed
+
+            # Pattern broken — flush and fall through to normal emit below
+            self._exit_pattern(record)
+
+        # Normal emit
+        self.inner.emit(record)
+        self._buf.append(key)
+
+        # Keep buffer bounded
+        max_buf = self.max_pattern_len * 2
+        if len(self._buf) > max_buf:
+            del self._buf[:-max_buf]
+
+        # Check for a new repeating pattern
+        p = self._detect_period()
+        if p:
+            self._pattern = list(self._buf[-p:])
+            self._pos = 0
+            self._count = 0
+            self._partial = []
+
+    def close(self) -> None:
+        if self._pattern and (self._count > 0 or self._partial):
+            ref = (self._partial[0] if self._partial else
+                   logging.LogRecord("PolyHost", logging.INFO, "", 0, "", (), None))
+            self._exit_pattern(ref)
+        self.inner.close()
+        super().close()
+
+
+def make_collapse_handler(inner: logging.Handler, max_pattern_len: int = 8) -> RepeatCollapseHandler:
+    """Wrap *inner* with repeat-collapse logic; returns the wrapper to pass to basicConfig."""
+    return RepeatCollapseHandler(inner, max_pattern_len)

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 about = {}
 with open("polyhost/_version.py") as version_file:
     exec(version_file.read(), about)
-    
+
 def readme():
     with open('README.rst') as readme_file:
         return readme_file.read()
@@ -14,4 +14,5 @@ setup(name='PolyHost',
       long_description=readme(),
       keywords='polykybd host forwarder poly',
       url='https://github.com/thpoll83/PolyKybdHost',
-      author='thpoll')
+      author='thpoll',
+      packages=find_packages(exclude=['tests', 'tests.*']))


### PR DESCRIPTION
## Summary

- **macOS `get_current_language()`**: implemented via `defaults read -g AppleInputSources`, extracting the `KeyboardLayout Name` field with a regex. No admin rights required. Previously always returned `False, "Not Implemented"`.
- **Windows `set_language()` (experimental)**: new `_set_language_native()` uses the Win32 API path — `LoadKeyboardLayoutW` to get the HKL from the LCID, then `PostMessageW(WM_INPUTLANGCHANGEREQUEST)` to the foreground window. Gated behind a new `dev_win_native_set_language: false` settings flag; falls back to the base-class pynput hotkey cycling when disabled. Commented-out `ActivateKeyboardLayout` + `AttachThreadInput` alternative is included for apps that ignore the notification message.
- **`settings.py`**: added `dev_win_native_set_language: false`.
- **`host.py`**: passes `poly_settings` to `WindowsInputHelper` so it can read the dev flag; minor log message cleanup.

## Test plan

- [ ] macOS: verify `get_current_language()` returns the active layout name (e.g. `"ABC"`, `"German"`) when multiple input sources are configured
- [ ] Windows: with `dev_win_native_set_language: false` (default), confirm language switching still works via pynput cycling
- [ ] Windows: with `dev_win_native_set_language: true`, confirm `_set_language_native()` is called and switches layout in common apps (e.g. Notepad, browser)
- [ ] Confirm `dev_win_native_set_language` key appears as a checkbox in the Settings dialog under the "Dev" group

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Implement platform-specific language helpers for macOS and Windows and wire them into the host using a new dev setting flag.

New Features:
- Add a macOS implementation of get_current_language() that returns the active keyboard layout name.
- Add an experimental native Windows input language switcher that uses the Win32 API instead of hotkey cycling, controlled by a dev setting flag.

Enhancements:
- Pass poly_settings into WindowsInputHelper to enable feature flags and adjust reconnect warning logging for clearer diagnostics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * macOS now detects and reports the current keyboard layout/language.
  * Windows has an experimental native path for switching keyboard layouts/languages.
  * Logging now collapses repeated messages (applies to both console and file outputs).

* **Bug Fixes**
  * Reconnect failure messages now include the quoted response and show "NO RESPONSE" when empty.

* **Chores**
  * Added a new config option to toggle the Windows native language-switching behavior.
* **Stability**
  * Windows input helper is initialized with current settings on startup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thpoll83/PolyKybdHost/pull/8?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->