### PR TITLE
Colorize log lines in the log viewer to match stdout

### DIFF
--- a/polyhost/gui/log_viewer.py
+++ b/polyhost/gui/log_viewer.py
@@ -1,5 +1,7 @@
+import html
 import logging
 import os
+import re
 import subprocess
 import sys
 
@@ -8,6 +10,14 @@ from PyQt5.QtGui import QFont
 from PyQt5.QtWidgets import QVBoxLayout, QPlainTextEdit, QHBoxLayout, QPushButton, QMainWindow, QWidget, QTabWidget
 
 from polyhost.gui.get_icon import get_icon
+from polyhost.util.log_util import LEVEL_HEX_COLORS
+
+# Matches "[timestamp] LEVELNAME" at the start of a formatted log line.
+# Continuation lines (e.g. tracebacks) won't match and inherit the previous color.
+_LEVEL_NAME_TO_NO = {logging.getLevelName(lvl): lvl for lvl in LEVEL_HEX_COLORS}
+_LEVEL_RE = re.compile(
+    r"^\[[^\]]+\]\s+(" + "|".join(re.escape(n) for n in _LEVEL_NAME_TO_NO) + r")\b"
+)
 
 
 class LogViewerDialog(QMainWindow):
@@ -78,14 +88,38 @@ class LogViewerDialog(QMainWindow):
 
     def load_log(self):
         for tab_name, tab_log_file_name in self.log_files.items():
+            text_edit = self.log_text[tab_name]
             try:
                 with open(tab_log_file_name, encoding='utf-8') as f:
                     log_content = f.read()
-                text_edit = self.log_text[tab_name]
-                text_edit.setPlainText(log_content)
-                text_edit.moveCursor(text_edit.textCursor().End)
             except Exception as e:
-                self.log_text[tab_name].setPlainText(f"Failed to load log file '{tab_log_file_name}': {e}")
+                text_edit.setPlainText(f"Failed to load log file '{tab_log_file_name}': {e}")
+                continue
+            text_edit.clear()
+            text_edit.appendHtml(self._colorize(log_content))
+            text_edit.moveCursor(text_edit.textCursor().End)
+
+    @staticmethod
+    def _colorize(log_content: str) -> str:
+        """Wrap each log line in a coloured <span> based on its level.
+
+        Continuation lines (no "[time] LEVEL" prefix) inherit the previous
+        line's colour so multi-line records stay visually grouped.
+        """
+        out = ['<pre style="margin:0; font-family:Courier; white-space:pre-wrap;">']
+        current_color = None
+        for line in log_content.splitlines():
+            m = _LEVEL_RE.match(line)
+            if m:
+                current_color = LEVEL_HEX_COLORS.get(_LEVEL_NAME_TO_NO[m.group(1)])
+            escaped = html.escape(line)
+            if current_color:
+                out.append(f'<span style="color:{current_color};">{escaped}</span>')
+            else:
+                out.append(escaped)
+            out.append("<br>")
+        out.append("</pre>")
+        return "".join(out)
 
 
     def open_file_directory(self):

--- a/polyhost/gui/log_viewer.py
+++ b/polyhost/gui/log_viewer.py
@@ -7,7 +7,7 @@ import sys
 
 from PyQt5.QtCore import QSize
 from PyQt5.QtGui import QFont
-from PyQt5.QtWidgets import QVBoxLayout, QPlainTextEdit, QHBoxLayout, QPushButton, QMainWindow, QWidget, QTabWidget
+from PyQt5.QtWidgets import QVBoxLayout, QTextEdit, QHBoxLayout, QPushButton, QMainWindow, QWidget, QTabWidget
 
 from polyhost.gui.get_icon import get_icon
 from polyhost.util.log_util import LEVEL_HEX_COLORS
@@ -42,9 +42,10 @@ class LogViewerDialog(QMainWindow):
         self.log_files = log_files
 
         for tab_name in log_files:
-            # a read-only QPlainTextEdit
-            log_text = QPlainTextEdit(self)
+            # a read-only QTextEdit (HTML for per-line colouring)
+            log_text = QTextEdit(self)
             log_text.setReadOnly(True)
+            log_text.setLineWrapMode(QTextEdit.NoWrap)
             log_text.setFont(QFont("Courier", 10))
         
             tab = QWidget()
@@ -95,8 +96,7 @@ class LogViewerDialog(QMainWindow):
             except Exception as e:
                 text_edit.setPlainText(f"Failed to load log file '{tab_log_file_name}': {e}")
                 continue
-            text_edit.clear()
-            text_edit.appendHtml(self._colorize(log_content))
+            text_edit.setHtml(self._colorize(log_content))
             text_edit.moveCursor(text_edit.textCursor().End)
 
     @staticmethod

--- a/polyhost/util/log_util.py
+++ b/polyhost/util/log_util.py
@@ -14,6 +14,15 @@ def _debug_detailed(self, message, *args, **kwargs):
 logging.Logger.debug_detailed = _debug_detailed
 
 
+LEVEL_HEX_COLORS = {
+    logging.ERROR:   "#ff5555",  # bright red
+    logging.WARNING: "#ff8700",  # orange (xterm 208)
+    logging.INFO:    "#22cc22",  # green, readable on light & dark
+    logging.DEBUG:   "#00afaf",  # teal
+    DEBUG_DETAILED:  "#5fd7af",  # aquamarine
+}
+
+
 class ColorFormatter(logging.Formatter):
     _COLORS = {
         logging.ERROR:   "\033[91m",        # bright red


### PR DESCRIPTION
Parse the level token from each formatted record and apply the same
palette ColorFormatter uses for the terminal. Continuation lines
(tracebacks, multi-line messages) inherit the previous record's color.

## Summary by Sourcery

Colorize log viewer output to reflect log levels using the same palette as terminal logging.

New Features:
- Add HTML-based colorization of log viewer lines based on parsed log levels, including inheritance of colors for continuation lines.

Enhancements:
- Expose a shared mapping of log levels to hex colors in logging utilities for reuse by the GUI log viewer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Log viewer now color-codes lines by severity (ERROR/WARNING/INFO/DEBUG) and preserves color for multi-line entries, improving readability.
  * Viewer uses rich text rendering so colors display correctly and the view auto-scrolls to the end on load.

* **Bug Fixes**
  * Shows a clear error message in the log view if a log file fails to load.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thpoll83/PolyKybdHost/pull/9?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->