### PR TITLE
Replace keyboard reply error popups with warning logs

### DIFF
--- a/polyhost/gui/cmd_menu.py
+++ b/polyhost/gui/cmd_menu.py
@@ -99,43 +99,43 @@ class CommandsSubMenu:
 
     def reset_dynamic_keymap(self):
         result, msg = self.keeb.reset_dynamic_keymap()
-        self.parent.show_mb("Error", f"Failed resetting dynamic keymap: {msg}", result)
+        self.parent.report_device_result("Error", f"Failed resetting dynamic keymap: {msg}", result)
 
     def reset_overlay_mapping(self):
         result, msg = self.keeb.reset_overlay_mapping()
-        self.parent.show_mb("Error", f"Failed clearing overlays: '{msg}'", result)
+        self.parent.report_device_result("Error", f"Failed clearing overlays: '{msg}'", result)
 
     def set_all_overlay_usage(self):
         result, msg = self.keeb.set_all_overlay_usage()
-        self.parent.show_mb("Error", f"Failed setting all overlay usage: '{msg}'", result)
+        self.parent.report_device_result("Error", f"Failed setting all overlay usage: '{msg}'", result)
 
     def reset_overlays_and_usage(self):
         result, msg = self.keeb.reset_overlays_and_usage()
-        self.parent.show_mb("Error", f"Failed clearing overlays and usage: '{msg}'", result)
+        self.parent.report_device_result("Error", f"Failed clearing overlays and usage: '{msg}'", result)
 
     def reset_overlay_usage(self):
         result, msg = self.keeb.reset_overlay_usage()
-        self.parent.show_mb("Error", f"Failed clearing overlay usage: '{msg}'", result)
+        self.parent.report_device_result("Error", f"Failed clearing overlay usage: '{msg}'", result)
 
     def reset_overlays(self):
         result, msg = self.keeb.reset_overlays()
-        self.parent.show_mb("Error", f"Failed clearing overlays: '{msg}'", result)
+        self.parent.report_device_result("Error", f"Failed clearing overlays: '{msg}'", result)
 
     def enable_overlays(self):
         result, msg = self.keeb.enable_overlays()
-        self.parent.show_mb("Error", f"Failed enabling overlays: '{msg}'", result)
+        self.parent.report_device_result("Error", f"Failed enabling overlays: '{msg}'", result)
 
     def disable_overlays(self):
         result, msg = self.keeb.disable_overlays()
-        self.parent.show_mb("Error", f"Failed disabling overlays: '{msg}'", result)
+        self.parent.report_device_result("Error", f"Failed disabling overlays: '{msg}'", result)
 
     def set_brightness(self):
         result, msg = self.keeb.set_brightness(self.parent.sender().data())
-        self.parent.show_mb("Error", f"Failed disabling overlays: '{msg}'", result)
+        self.parent.report_device_result("Error", f"Failed disabling overlays: '{msg}'", result)
 
     def change_idle(self):
         result, msg = self.keeb.set_idle(self.parent.sender().data())
-        self.parent.show_mb("Error", f"Failed to change idle mode: '{msg}'", result)
+        self.parent.report_device_result("Error", f"Failed to change idle mode: '{msg}'", result)
 
     def mapping_test(self):
         from_to = {}
@@ -189,7 +189,7 @@ class CommandsSubMenu:
         from_to[to_key] = from_key
         
         result, msg = self.keeb.send_overlay_mapping(from_to)
-        self.parent.show_mb("Error", f"Failed to change idle mode: '{msg}'", result)
+        self.parent.report_device_result("Error", f"Failed to change idle mode: '{msg}'", result)
 
     def load_commands(self):
         file_name = QFileDialog.getOpenFileName(None, 'Open file', '', "PolyKybd commands (*.poly.cmd)")

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -315,14 +315,7 @@ class PolyHost(QApplication):
 
     def show_mb(self, title, msg, result=False):
         if not result:
-            if self.connected:
-                mbox = QMessageBox()
-                mbox.setWindowTitle(title)
-                mbox.setText(msg)
-                mbox.setIcon(QMessageBox.Warning if title == "Error" else QMessageBox.Information)
-                mbox.exec_()
-            else:
-                self.log.warning("%s: %s", title, msg)
+            self.log.warning("%s: %s", title, msg)
 
     def pause(self):
         self.paused = not self.paused

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -313,9 +313,11 @@ class PolyHost(QApplication):
         else:
             self.icon_manager.set_disconnected()
 
-    def show_mb(self, title, msg, result=False):
+    def report_device_result(self, title, msg, result=False):
+        # Logs only; no UI popup. Errors go to warning, anything else to info.
         if not result:
-            self.log.warning("%s: %s", title, msg)
+            level = logging.WARNING if title == "Error" else logging.INFO
+            self.log.log(level, "%s: %s", title, msg)
 
     def pause(self):
         self.paused = not self.paused
@@ -502,7 +504,7 @@ class PolyHost(QApplication):
         if not result:
             msg = f"Changing input language to '{requested_lang}' failed with:\n\"{output}\""
             self.icon_manager.set_warning(msg)
-            self.show_mb("Error", msg)
+            self.report_device_result("Error", msg)
         else:
             self.log.info("Change input language to '%s'.", requested_lang)
         


### PR DESCRIPTION
Unexpected replies from the keyboard would surface as modal QMessageBox
dialogs via show_mb(), which interrupted workflow. The 12 device command
call sites in cmd_menu.py all funnel through this helper, so logging a
warning instead of popping a dialog silences the interruptions while
still leaving a trace in host_log.txt.

## Summary by Sourcery

Enhancements:
- Always log keyboard reply warnings instead of displaying modal QMessageBox dialogs, avoiding workflow interruptions while retaining traceability in logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Changed how warning messages are handled during specific conditions—warnings are now logged instead of displayed as pop-up notifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thpoll83/PolyKybdHost/pull/10?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->