### PR TITLE
Replace HTML-based log coloring with QSyntaxHighlighter

### DIFF
--- a/polyhost/gui/log_viewer.py
+++ b/polyhost/gui/log_viewer.py
@@ -1,4 +1,3 @@
-import html
 import logging
 import os
 import re
@@ -6,8 +5,9 @@ import subprocess
 import sys
 
 from PyQt5.QtCore import QSize
-from PyQt5.QtGui import QFont
-from PyQt5.QtWidgets import QVBoxLayout, QTextEdit, QHBoxLayout, QPushButton, QMainWindow, QWidget, QTabWidget
+from PyQt5.QtGui import QColor, QFont, QSyntaxHighlighter, QTextCharFormat, QTextCursor
+from PyQt5.QtWidgets import (QHBoxLayout, QMainWindow, QPlainTextEdit,
+                              QPushButton, QTabWidget, QVBoxLayout, QWidget)
 
 from polyhost.gui.get_icon import get_icon
 from polyhost.util.log_util import LEVEL_HEX_COLORS
@@ -19,6 +19,37 @@ _LEVEL_RE = re.compile(
     r"^\[[^\]]+\]\s+(" + "|".join(re.escape(n) for n in _LEVEL_NAME_TO_NO) + r")\b"
 )
 
+# Encode each level as a block-state integer so continuation lines inherit color.
+# State 0 means "no color"; states 1..N correspond to levels in LEVEL_HEX_COLORS.
+_LEVEL_TO_STATE = {lvl: i + 1 for i, lvl in enumerate(LEVEL_HEX_COLORS)}
+_STATE_TO_COLOR = {
+    state: QColor(LEVEL_HEX_COLORS[lvl])
+    for lvl, state in _LEVEL_TO_STATE.items()
+}
+
+
+class _LogHighlighter(QSyntaxHighlighter):
+    """Syntax highlighter that colours each line by its log level.
+
+    Runs lazily — Qt only calls highlightBlock() for visible/dirty blocks,
+    so opening large log files is near-instant.
+    """
+
+    def highlightBlock(self, text: str) -> None:
+        m = _LEVEL_RE.match(text)
+        if m:
+            state = _LEVEL_TO_STATE[_LEVEL_NAME_TO_NO[m.group(1)]]
+        else:
+            # Inherit previous block's state (-1 on the very first block → 0 = no color)
+            state = max(self.previousBlockState(), 0)
+
+        color = _STATE_TO_COLOR.get(state)
+        if color:
+            fmt = QTextCharFormat()
+            fmt.setForeground(color)
+            self.setFormat(0, len(text), fmt)
+        self.setCurrentBlockState(state)
+
 
 class LogViewerDialog(QMainWindow):
     def __init__(self, log_files):
@@ -27,59 +58,50 @@ class LogViewerDialog(QMainWindow):
         self.setWindowTitle("Log Viewer")
         self.setWindowIcon(get_icon("pcolor.png"))
 
-        # Main vertical layout
         central_widget = QWidget()
         self.setCentralWidget(central_widget)
 
         self.layout = QVBoxLayout(central_widget)
         self.layout.setContentsMargins(0, 0, 0, 10)
 
-         # Tab widget to hold multiple tabs
         self.tab_widget = QTabWidget(self)
         self.layout.addWidget(self.tab_widget)
 
         self.log_text = {}
         self.log_files = log_files
+        # Keep highlighters alive — QSyntaxHighlighter is GC'd if not referenced.
+        self._highlighters = {}
 
         for tab_name in log_files:
-            # a read-only QTextEdit (HTML for per-line colouring)
-            log_text = QTextEdit(self)
+            log_text = QPlainTextEdit(self)
             log_text.setReadOnly(True)
-            log_text.setLineWrapMode(QTextEdit.NoWrap)
+            log_text.setLineWrapMode(QPlainTextEdit.NoWrap)
             log_text.setFont(QFont("Courier", 10))
-        
+
+            self._highlighters[tab_name] = _LogHighlighter(log_text.document())
+
             tab = QWidget()
             tab_layout = QVBoxLayout(tab)
             tab_layout.addWidget(log_text)
             self.tab_widget.addTab(tab, tab_name)
             self.log_text[tab_name] = log_text
 
-        # Horizontal layout for buttons
         button_layout = QHBoxLayout()
-
-        # Spacer to center buttons
         button_layout.addStretch(1)
 
-        # Open button
         button = QPushButton("Open Folder")
         button.clicked.connect(self.open_file_directory)
         button_layout.addWidget(button)
 
-        # OK/Close button
         button = QPushButton("Reload")
         button.clicked.connect(self.load_log)
         button_layout.addWidget(button)
 
-
-        # OK/Close button
         button = QPushButton("Close")
         button.clicked.connect(self.close)
         button_layout.addWidget(button)
 
-        # Spacer to center buttons
         button_layout.addStretch(1)
-
-        # Add button layout to main layout
         self.layout.addLayout(button_layout)
 
         self.load_log()
@@ -96,40 +118,17 @@ class LogViewerDialog(QMainWindow):
             except Exception as e:
                 text_edit.setPlainText(f"Failed to load log file '{tab_log_file_name}': {e}")
                 continue
-            text_edit.setHtml(self._colorize(log_content))
-            text_edit.moveCursor(text_edit.textCursor().End)
-
-    @staticmethod
-    def _colorize(log_content: str) -> str:
-        """Wrap each log line in a coloured <span> based on its level.
-
-        Continuation lines (no "[time] LEVEL" prefix) inherit the previous
-        line's colour so multi-line records stay visually grouped.
-        """
-        out = ['<pre style="margin:0; font-family:Courier; white-space:pre-wrap;">']
-        current_color = None
-        for line in log_content.splitlines():
-            m = _LEVEL_RE.match(line)
-            if m:
-                current_color = LEVEL_HEX_COLORS.get(_LEVEL_NAME_TO_NO[m.group(1)])
-            escaped = html.escape(line)
-            if current_color:
-                out.append(f'<span style="color:{current_color};">{escaped}</span>')
-            else:
-                out.append(escaped)
-            out.append("<br>")
-        out.append("</pre>")
-        return "".join(out)
-
+            text_edit.setPlainText(log_content)
+            text_edit.moveCursor(QTextCursor.End)
 
     def open_file_directory(self):
-        file = list(self.log_files.values())[0] # maybe also the focus tab is possible
-        
-        if sys.platform.startswith('darwin'):  # macOS
+        file = list(self.log_files.values())[0]
+
+        if sys.platform.startswith('darwin'):
             subprocess.run(['open', '-R', file])
-        elif sys.platform.startswith('win'):  # Windows
+        elif sys.platform.startswith('win'):
             subprocess.run(['explorer', '/select,', os.path.normpath(file)])
-        elif sys.platform.startswith('linux'):  # Linux
+        elif sys.platform.startswith('linux'):
             self.reveal_in_linux_file_manager(file)
         else:
             logging.warning("Platform %s not supported", sys.platform)
@@ -139,7 +138,6 @@ class LogViewerDialog(QMainWindow):
         file_path = os.path.abspath(file_path)
         desktop = os.environ.get("XDG_CURRENT_DESKTOP", "").lower()
 
-        # Priority mapping
         preferred = []
         if "kde" in desktop:
             preferred = [
@@ -165,7 +163,6 @@ class LogViewerDialog(QMainWindow):
                 ['caja', '--no-desktop', '--browser', '--select', file_path],
             ]
 
-        # Add universal fallback options
         fallback = [
             ['nautilus', '--select', file_path],
             ['dolphin', '--select', file_path],
@@ -181,7 +178,5 @@ class LogViewerDialog(QMainWindow):
             except FileNotFoundError:
                 continue
 
-        # Last fallback: open directory only
         dir_path = os.path.dirname(file_path)
         subprocess.run(['xdg-open', dir_path])
-

--- a/polyhost/gui/log_viewer.py
+++ b/polyhost/gui/log_viewer.py
@@ -22,10 +22,13 @@ _LEVEL_RE = re.compile(
 # Encode each level as a block-state integer so continuation lines inherit color.
 # State 0 means "no color"; states 1..N correspond to levels in LEVEL_HEX_COLORS.
 _LEVEL_TO_STATE = {lvl: i + 1 for i, lvl in enumerate(LEVEL_HEX_COLORS)}
-_STATE_TO_COLOR = {
-    state: QColor(LEVEL_HEX_COLORS[lvl])
-    for lvl, state in _LEVEL_TO_STATE.items()
-}
+
+# Pre-built QTextCharFormat per state — reused across every highlightBlock() call.
+_STATE_TO_FORMAT: dict[int, QTextCharFormat] = {}
+for _state, _lvl in ((s, l) for l, s in _LEVEL_TO_STATE.items()):
+    _fmt = QTextCharFormat()
+    _fmt.setForeground(QColor(LEVEL_HEX_COLORS[_lvl]))
+    _STATE_TO_FORMAT[_state] = _fmt
 
 
 class _LogHighlighter(QSyntaxHighlighter):
@@ -43,10 +46,8 @@ class _LogHighlighter(QSyntaxHighlighter):
             # Inherit previous block's state (-1 on the very first block → 0 = no color)
             state = max(self.previousBlockState(), 0)
 
-        color = _STATE_TO_COLOR.get(state)
-        if color:
-            fmt = QTextCharFormat()
-            fmt.setForeground(color)
+        fmt = _STATE_TO_FORMAT.get(state)
+        if fmt:
             self.setFormat(0, len(text), fmt)
         self.setCurrentBlockState(state)
 
@@ -70,7 +71,7 @@ class LogViewerDialog(QMainWindow):
         self.log_text = {}
         self.log_files = log_files
         # Keep highlighters alive — QSyntaxHighlighter is GC'd if not referenced.
-        self._highlighters = {}
+        self._highlighters = []
 
         for tab_name in log_files:
             log_text = QPlainTextEdit(self)
@@ -78,7 +79,7 @@ class LogViewerDialog(QMainWindow):
             log_text.setLineWrapMode(QPlainTextEdit.NoWrap)
             log_text.setFont(QFont("Courier", 10))
 
-            self._highlighters[tab_name] = _LogHighlighter(log_text.document())
+            self._highlighters.append(_LogHighlighter(log_text.document()))
 
             tab = QWidget()
             tab_layout = QVBoxLayout(tab)


### PR DESCRIPTION
## Summary
Refactored the log viewer to use Qt's `QSyntaxHighlighter` for per-line log-level coloring instead of generating HTML. This improves performance for large log files and simplifies the codebase.

## Key Changes
- **Replaced `QTextEdit` with `QPlainTextEdit`**: Better suited for plain-text display and works seamlessly with `QSyntaxHighlighter`
- **Introduced `_LogHighlighter` class**: Custom syntax highlighter that:
  - Parses each line's log level using the existing `_LEVEL_RE` regex
  - Colors lines based on their level using `LEVEL_HEX_COLORS`
  - Inherits color for continuation lines (multi-line log records) via block state
  - Runs lazily — Qt only highlights visible/dirty blocks, making large files near-instant to open
- **Removed `_colorize()` method**: Eliminated HTML generation and escaping logic; now handled by the highlighter
- **Updated imports**: Added `QColor`, `QSyntaxHighlighter`, `QTextCharFormat`, `QTextCursor`; removed `html` module
- **Cleaned up comments**: Removed redundant inline comments throughout the file
- **Fixed minor formatting**: Normalized whitespace and import organization

## Implementation Details
- Block state (0–N) encodes the current log level, allowing continuation lines to inherit the previous line's color without re-parsing
- State mapping (`_LEVEL_TO_STATE`, `_STATE_TO_COLOR`) is precomputed at module load
- Highlighters are stored in `self._highlighters` to prevent garbage collection (Qt doesn't hold a strong reference)
- `setPlainText()` replaces `setHtml()`, and cursor movement uses `QTextCursor.End` instead of the deprecated `textCursor().End`

https://claude.ai/code/session_01HSoGfyzEuDfnKgvY5gL5Se

## Summary by Sourcery

Switch the log viewer to use Qt's syntax highlighting for per-line log coloring instead of HTML generation, improving performance and simplifying the UI code.

New Features:
- Add a custom QSyntaxHighlighter-based _LogHighlighter to color log lines by level with support for continuation lines.
- Introduce per-tab highlighter instances tied to each log document to enable lazy, on-demand highlighting.

Bug Fixes:
- Ensure continuation log lines inherit their preceding line's color via block state rather than reparsing.

Enhancements:
- Replace QTextEdit with QPlainTextEdit for log display and switch to setPlainText for loading content.
- Simplify platform-specific file reveal logic and remove redundant comments and whitespace in the log viewer module.