### PR TITLE
Add exception handling to HID device initialization in PolyKybd

### DIFF
--- a/polyhost/device/poly_kybd.py
+++ b/polyhost/device/poly_kybd.py
@@ -54,17 +54,30 @@ class PolyKybd:
         self.stat_croi = 0  # compressed region of interest
         self.stat_best = 0
 
+    def _open_interfaces(self) -> bool:
+        """(Re-)open the HID and serial interfaces.
+
+        Returns True on success. On failure both handles are reset to None so
+        the device is left in a clean, fully-disconnected state and the next
+        reconnect attempt starts from scratch. HidHelper re-raises
+        hid.HIDException when the device shows up in enumeration but can't be
+        opened yet — a race that happens while the firmware comes back up after
+        a flash — so this must never propagate out of connect()."""
+        try:
+            self.hid = HidHelper(self.device_settings)
+            self.serial = SerialHelper(self.device_settings)
+            return True
+        except Exception as e:
+            self.log.warning("Failed to open HID device: %s", e)
+            self.hid = None
+            self.serial = None
+            return False
+
     def connect(self):
         """Connect to PolyKybd"""
         if not self.hid:
             self.log.debug("Connecting to PolyKybd for the first time...")
-            try:
-                self.hid = HidHelper(self.device_settings)
-                self.serial = SerialHelper(self.device_settings)
-            except Exception as e:
-                self.log.warning("Failed to open HID device: %s", e)
-                self.hid = None
-                return False
+            return self._open_interfaces()
         else:
             retries = self.poly_settings.get("hid_reconnect_retries")
             for attempt in range(retries):
@@ -75,15 +88,9 @@ class PolyKybd:
             # All retries exhausted — HID handle is stale after a reset/reflash;
             # re-enumerate so the new USB path is picked up.
             self.log.warning("Re-enumerating HID after %d failed attempts...", retries)
-            try:
-                self.hid = HidHelper(self.device_settings)
-                self.serial = SerialHelper(self.device_settings)
-            except Exception as e:
-                self.log.warning("Failed to re-open HID device: %s", e)
-                self.hid = None
+            if not self._open_interfaces():
                 return False
             return self.hid.interface_acquired()
-        return True
 
     def read_serial(self):
         if self.serial:

--- a/polyhost/device/poly_kybd.py
+++ b/polyhost/device/poly_kybd.py
@@ -58,8 +58,13 @@ class PolyKybd:
         """Connect to PolyKybd"""
         if not self.hid:
             self.log.debug("Connecting to PolyKybd for the first time...")
-            self.hid = HidHelper(self.device_settings)
-            self.serial = SerialHelper(self.device_settings)
+            try:
+                self.hid = HidHelper(self.device_settings)
+                self.serial = SerialHelper(self.device_settings)
+            except Exception as e:
+                self.log.warning("Failed to open HID device: %s", e)
+                self.hid = None
+                return False
         else:
             retries = self.poly_settings.get("hid_reconnect_retries")
             for attempt in range(retries):
@@ -70,8 +75,13 @@ class PolyKybd:
             # All retries exhausted — HID handle is stale after a reset/reflash;
             # re-enumerate so the new USB path is picked up.
             self.log.warning("Re-enumerating HID after %d failed attempts...", retries)
-            self.hid = HidHelper(self.device_settings)
-            self.serial = SerialHelper(self.device_settings)
+            try:
+                self.hid = HidHelper(self.device_settings)
+                self.serial = SerialHelper(self.device_settings)
+            except Exception as e:
+                self.log.warning("Failed to re-open HID device: %s", e)
+                self.hid = None
+                return False
             return self.hid.interface_acquired()
         return True
 


### PR DESCRIPTION
## Summary
Add try-catch exception handling around HID and Serial device initialization in the `PolyKybd.connect()` method to gracefully handle initialization failures and prevent unhandled exceptions from crashing the application.

## Changes
- Wrapped `HidHelper` and `SerialHelper` instantiation in try-except blocks at two locations in `connect()`:
  - Initial connection attempt (first-time connection)
  - Re-enumeration attempt (after failed reconnect retries)
- On exception, log a warning message with the error details, set `self.hid = None`, and return `False` to signal connection failure
- Allows the application to continue running and retry connection rather than crashing on HID device access errors

## Implementation Details
- Both exception handlers follow the same pattern: catch generic `Exception`, log with context-specific message ("Failed to open" vs "Failed to re-open"), and return `False`
- The `self.hid = None` assignment ensures the device state is reset on failure, allowing subsequent `connect()` calls to attempt re-initialization
- Maintains existing behavior for successful connections (returns `True` or result of `self.hid.interface_acquired()`)

https://claude.ai/code/session_019gL39ZSgHTZwaxNcXUuFV8

## Summary by Sourcery

Bug Fixes:
- Prevent crashes by gracefully handling exceptions when opening HID and serial devices during initial connection and re-enumeration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard device connection stability: initialization and HID re-enumeration now handle interface-open failures gracefully, logging warnings and avoiding crashes. Reconnection attempts that fail no longer propagate errors, resulting in more robust connect/reconnect behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thpoll83/PolyKybdHost/pull/12?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->