### PR TITLE
Add firmware staging + apply workflow (two-phase FW_UP)

### DIFF
--- a/polyhost/_version.py
+++ b/polyhost/_version.py
@@ -1,4 +1,4 @@
 __major__ = 0
-__minor__ = 7
-__patch__ = 2
+__minor__ = 8
+__patch__ = 0
 __version__ = str(__major__) + "." + str(__minor__) + "." + str(__patch__)

--- a/polyhost/device/hid_fw_up.py
+++ b/polyhost/device/hid_fw_up.py
@@ -298,10 +298,10 @@ def flash_firmware(hid, bin_path: str, progress_cb=None, cancel_flag: list = Non
 def apply_staged_firmware(hid, progress_cb=None) -> tuple[bool, str]:
     """Install a previously-staged firmware image (FW_UP_APPLY, cmd 0x44).
 
-    PHASE 2 (experimental): master-only self-apply. The master verifies it holds a
-    valid staged image, ACKs, then erases its own flash from offset 0, copies the
-    staged image in, and resets — re-enumerating on the new firmware after a few
-    seconds. The command is NOT relayed to the slave half (that is phase 3).
+    Dual-half apply: the master verifies it holds a valid staged image, ACKs, then
+    relays FW_UP_APPLY to the slave over the split link. Both halves install the
+    staged image (copy staging -> offset 0) and reset, re-enumerating on the new
+    firmware after a few seconds.
 
     Returns (True, success_msg) once the device reconnects, or (False, error_msg).
     Only an explicit NACK ('!', meaning "no valid staged image") is a hard failure;
@@ -316,16 +316,15 @@ def apply_staged_firmware(hid, progress_cb=None) -> tuple[bool, str]:
     pkt = bytearray([HID_POLYKYBD, CMD_FW_UP_APPLY])
     ok, reply = hid.send_and_read(pkt, timeout=5000)
 
-    # Explicit NACK ('!').  In the shipped firmware the in-app self-apply is
-    # DISABLED (it bricked the master), so the keyboard always replies '!' and
-    # leaves the staged image untouched — a safe no-op, NOT a reboot.  Report it
-    # plainly instead of waiting for a reconnect that will never come.
+    # Explicit NACK ('!') is a safe no-op: the keyboard left the staged image
+    # untouched and did NOT reboot. It means either there is no valid staged
+    # image, or this firmware was built without in-app apply (FW_UP_INAPP_APPLY=no).
+    # Report it plainly instead of waiting for a reconnect that will never come.
     if ok and len(reply) >= 3 and reply[2] == ord('!'):
-        return False, ("Apply is not available in this firmware.\n\n"
-                       "In-application self-apply is disabled because it bricked the "
-                       "master half (it erases the live vector table while rewriting "
-                       "flash from offset 0). The staged image is unchanged. A safe "
-                       "apply mechanism (reboot-to-bootloader) is the planned path.")
+        return False, ("Apply is not available.\n\n"
+                       "The keyboard reported no valid staged image, or this firmware "
+                       "was built without in-app apply (FW_UP_INAPP_APPLY=no). The "
+                       "staged image is unchanged.")
 
     # Either an ACK ('.') or no reply (the device already accepted and is rebooting
     # with USB torn down): in both cases wait for it to come back.
@@ -339,7 +338,5 @@ def apply_staged_firmware(hid, progress_cb=None) -> tuple[bool, str]:
     report(100, "Done. Keyboard reconnected on the applied firmware.")
     return True, (
         "Firmware applied — the keyboard rebooted and reconnected.\n\n"
-        "Phase 2 (master only): the USB / master half now runs the new image. "
-        "The other half still runs its previous firmware until the slave-apply "
-        "step (phase 3)."
+        "Both halves now run the new firmware."
     )

--- a/polyhost/device/hid_fw_up.py
+++ b/polyhost/device/hid_fw_up.py
@@ -7,6 +7,7 @@ CMD_FW_UP_GET_VERSION = 0x43
 CMD_FW_UP_BEGIN       = 0x40
 CMD_FW_UP_CHUNK       = 0x41
 CMD_FW_UP_COMMIT      = 0x42
+CMD_FW_UP_APPLY       = 0x44
 
 FW_UP_CHUNK_SIZE  = 56
 FW_UP_VERSION_LEN = 16
@@ -291,4 +292,48 @@ def flash_firmware(hid, bin_path: str, progress_cb=None, cancel_flag: list = Non
         "The new image is stored and CRC-checked on the keyboard, but it is "
         "not active yet — the keyboard is still running its current firmware. "
         "Activating the staged image will be a separate step."
+    )
+
+
+def apply_staged_firmware(hid, progress_cb=None) -> tuple[bool, str]:
+    """Install a previously-staged firmware image (FW_UP_APPLY, cmd 0x44).
+
+    PHASE 2 (experimental): master-only self-apply. The master verifies it holds a
+    valid staged image, ACKs, then erases its own flash from offset 0, copies the
+    staged image in, and resets — re-enumerating on the new firmware after a few
+    seconds. The command is NOT relayed to the slave half (that is phase 3).
+
+    Returns (True, success_msg) once the device reconnects, or (False, error_msg).
+    Only an explicit NACK ('!', meaning "no valid staged image") is a hard failure;
+    a missing reply is expected (the device reboots) and is treated as "applying".
+    """
+    def report(pct, msg):
+        if progress_cb:
+            progress_cb(pct, msg)
+
+    report(0, "Sending FW_UP_APPLY…")
+    hid.drain_replies()
+    pkt = bytearray([HID_POLYKYBD, CMD_FW_UP_APPLY])
+    ok, reply = hid.send_and_read(pkt, timeout=5000)
+
+    # Explicit NACK = the keyboard has no valid staged image to apply.
+    if ok and len(reply) >= 3 and reply[2] == ord('!'):
+        return False, ("Apply rejected — no valid staged image on the keyboard.\n"
+                       "Stage a firmware first via \"Flash Firmware\", then apply.")
+
+    # Either an ACK ('.') or no reply (the device already accepted and is rebooting
+    # with USB torn down): in both cases wait for it to come back.
+    report(50, "Applying — keyboard is erasing its flash and rebooting…")
+    if not hid.wait_for_reconnect(timeout_s=30):
+        return False, ("Keyboard did not reconnect within 30 s after apply.\n"
+                       "If it does not come back on its own, hold BOOTSEL on the "
+                       "master half and re-flash the .uf2.")
+    hid.drain_replies()
+
+    report(100, "Done. Keyboard reconnected on the applied firmware.")
+    return True, (
+        "Firmware applied — the keyboard rebooted and reconnected.\n\n"
+        "Phase 2 (master only): the USB / master half now runs the new image. "
+        "The other half still runs its previous firmware until the slave-apply "
+        "step (phase 3)."
     )

--- a/polyhost/device/hid_fw_up.py
+++ b/polyhost/device/hid_fw_up.py
@@ -274,12 +274,21 @@ def flash_firmware(hid, bin_path: str, progress_cb=None, cancel_flag: list = Non
             report(pct, f"Chunk {i + 1}/{total_chunks} ({(offset + FW_UP_CHUNK_SIZE) // 1024} KB sent)…")
 
     # -- FW_UP_COMMIT --
-    report(98, "Verifying CRC32 and committing to both halves…")
+    # COMMIT verifies the running CRC32 the keyboard accumulated while it staged
+    # the image; it does NOT apply/activate the image or reboot.  The new firmware
+    # is stored and CRC-checked in the staging region but the keyboard keeps
+    # running its current firmware — activation is a separate, future step.
+    report(98, "Verifying the staged image (CRC32)…")
     pkt = bytearray([HID_POLYKYBD, CMD_FW_UP_COMMIT])
     ok, reply = hid.send_and_read(pkt, timeout=5000)
     if not ok or len(reply) < 3 or reply[2] != ord('.'):
         hid.close_interface()
         return False, "FW_UP_COMMIT failed — CRC mismatch on keyboard. Try again."
 
-    report(100, "Done. Both keyboard halves are rebooting with the new firmware.")
-    return True, "Firmware update successful. Keyboard is rebooting — reconnection in ~5 s."
+    report(100, "Done. New firmware staged and verified on the keyboard.")
+    return True, (
+        "Firmware staged and verified successfully.\n\n"
+        "The new image is stored and CRC-checked on the keyboard, but it is "
+        "not active yet — the keyboard is still running its current firmware. "
+        "Activating the staged image will be a separate step."
+    )

--- a/polyhost/device/hid_fw_up.py
+++ b/polyhost/device/hid_fw_up.py
@@ -316,10 +316,16 @@ def apply_staged_firmware(hid, progress_cb=None) -> tuple[bool, str]:
     pkt = bytearray([HID_POLYKYBD, CMD_FW_UP_APPLY])
     ok, reply = hid.send_and_read(pkt, timeout=5000)
 
-    # Explicit NACK = the keyboard has no valid staged image to apply.
+    # Explicit NACK ('!').  In the shipped firmware the in-app self-apply is
+    # DISABLED (it bricked the master), so the keyboard always replies '!' and
+    # leaves the staged image untouched — a safe no-op, NOT a reboot.  Report it
+    # plainly instead of waiting for a reconnect that will never come.
     if ok and len(reply) >= 3 and reply[2] == ord('!'):
-        return False, ("Apply rejected — no valid staged image on the keyboard.\n"
-                       "Stage a firmware first via \"Flash Firmware\", then apply.")
+        return False, ("Apply is not available in this firmware.\n\n"
+                       "In-application self-apply is disabled because it bricked the "
+                       "master half (it erases the live vector table while rewriting "
+                       "flash from offset 0). The staged image is unchanged. A safe "
+                       "apply mechanism (reboot-to-bootloader) is the planned path.")
 
     # Either an ACK ('.') or no reply (the device already accepted and is rebooting
     # with USB torn down): in both cases wait for it to come back.

--- a/polyhost/gui/cmd_menu.py
+++ b/polyhost/gui/cmd_menu.py
@@ -1,4 +1,5 @@
 import logging
+from contextlib import contextmanager
 
 from PyQt5.QtWidgets import (
     QAction, QFileDialog, QMessageBox, QAbstractItemView, QProxyStyle, QStyle,
@@ -263,6 +264,22 @@ class CommandsSubMenu:
         else:
             self.log.info("No file selected. Operation canceled.")
 
+    @contextmanager
+    def _paused_polling(self):
+        """Pause the host's device-polling loop for a critical HID operation
+        (firmware flash / apply) so it doesn't contend for the HID lock while
+        the keyboard reboots and re-enumerates.  Resumes on exit, even if the
+        body raises."""
+        host = self.parent
+        was_paused = getattr(host, 'paused', False)
+        if hasattr(host, 'pause') and not was_paused:
+            host.pause()
+        try:
+            yield
+        finally:
+            if hasattr(host, 'pause') and not was_paused:
+                host.pause()   # toggle back to resume
+
     def open_hid_fw_up_dialog(self, apply_after=False):
         from polyhost.gui.hid_fw_up_dialog import HidFwUpDialog
 
@@ -334,13 +351,8 @@ class CommandsSubMenu:
 
         # Pause the host polling loop for the duration of the flash (and the apply,
         # if requested) so the HID lock is not contested by the 1 s reconnect timer.
-        host = self.parent
-        was_paused = getattr(host, 'paused', False)
-        if hasattr(host, 'pause') and not was_paused:
-            host.pause()
-
         apply_ok, apply_msg = None, None
-        try:
+        with self._paused_polling():
             dlg = HidFwUpDialog(self.keeb.hid, bin_path)
             dlg.exec_()
             staged_ok = getattr(dlg, '_success', False)
@@ -350,9 +362,6 @@ class CommandsSubMenu:
                 apply_ok, apply_msg = apply_staged_firmware(
                     self.keeb.hid,
                     progress_cb=lambda pct, m: self.log.info("FW_UP_APPLY %d%% — %s", pct, m))
-        finally:
-            if hasattr(host, 'pause') and not was_paused:
-                host.pause()   # toggle back to resume
 
         # Report the apply outcome (staging already reported itself in the dialog).
         if apply_after and apply_ok is not None:
@@ -393,17 +402,10 @@ class CommandsSubMenu:
 
         # Pause the host polling loop so the 1 s reconnect timer doesn't contend for
         # the HID lock while the device reboots (same pattern as the flash dialog).
-        host = self.parent
-        was_paused = getattr(host, 'paused', False)
-        if hasattr(host, 'pause') and not was_paused:
-            host.pause()
-        try:
+        with self._paused_polling():
             ok, msg = apply_staged_firmware(
                 self.keeb.hid,
                 progress_cb=lambda pct, m: self.log.info("FW_UP_APPLY %d%% — %s", pct, m))
-        finally:
-            if hasattr(host, 'pause') and not was_paused:
-                host.pause()   # toggle back to resume
 
         if ok:
             QMessageBox.information(None, "Firmware Applied", msg)

--- a/polyhost/gui/cmd_menu.py
+++ b/polyhost/gui/cmd_menu.py
@@ -249,16 +249,20 @@ class CommandsSubMenu:
             confirm_msg = (
                 f"Current keyboard firmware: <b>{current}</b> ({size_kb} KB)<br><br>"
                 f"Selected file:<br>{bin_path}<br><br>"
-                "This will update <b>both keyboard halves</b>. "
-                "The keyboard will reboot when done.<br><br>"
+                "This will transfer and stage the new firmware on the keyboard, "
+                "then verify it (CRC32). The image is stored but <b>not "
+                "activated yet</b> — the keyboard keeps running its current "
+                "firmware (activation will be a separate step).<br><br>"
                 "Continue?"
             )
         else:
             confirm_msg = (
                 f"Could not query current firmware version.<br><br>"
                 f"Selected file:<br>{bin_path}<br><br>"
-                "This will update <b>both keyboard halves</b>. "
-                "The keyboard will reboot when done.<br><br>"
+                "This will transfer and stage the new firmware on the keyboard, "
+                "then verify it (CRC32). The image is stored but <b>not "
+                "activated yet</b> — the keyboard keeps running its current "
+                "firmware (activation will be a separate step).<br><br>"
                 "Continue?"
             )
 

--- a/polyhost/gui/cmd_menu.py
+++ b/polyhost/gui/cmd_menu.py
@@ -5,7 +5,7 @@ from PyQt5.QtWidgets import (
 )
 
 from polyhost.device.keys import KeyCode, keycode_to_mapping_idx
-from polyhost.device.hid_fw_up import get_fw_version, validate_rp2040_firmware, validate_polykybd_firmware
+from polyhost.device.hid_fw_up import get_fw_version, validate_rp2040_firmware, validate_polykybd_firmware, apply_staged_firmware
 from polyhost.gui.get_icon import get_icon
 
 
@@ -144,6 +144,11 @@ class CommandsSubMenu:
         action = QAction(get_icon("keyboard_input.svg"), "Flash Firmware (.bin)…", parent=self.parent)
         # noinspection PyUnresolvedReferences
         action.triggered.connect(self.open_hid_fw_up_dialog)
+        cmd_menu.addAction(action)
+
+        action = QAction(get_icon("keyboard_input.svg"), "Apply Staged Firmware (master)…", parent=self.parent)
+        # noinspection PyUnresolvedReferences
+        action.triggered.connect(self.apply_staged_firmware_action)
         cmd_menu.addAction(action)
 
         action = QAction("Test mapping...", parent=self.parent)
@@ -331,3 +336,50 @@ class CommandsSubMenu:
         finally:
             if hasattr(host, 'pause') and not was_paused:
                 host.pause()   # toggle back to resume
+
+    def apply_staged_firmware_action(self):
+        """Trigger the keyboard to install a previously-staged firmware (FW_UP_APPLY).
+
+        PHASE 2 (experimental): master-only self-apply. The master erases its own
+        flash from offset 0, copies the staged image in, and reboots.
+        """
+        if not self.keeb.hid or not self.keeb.hid.interface_acquired():
+            QMessageBox.warning(None, "Not Connected",
+                                "PolyKybd is not connected. Please connect the keyboard and try again.")
+            return
+
+        confirm_msg = (
+            "<b>Install the staged firmware now?</b><br><br>"
+            "This activates the firmware you previously staged: the keyboard erases its "
+            "active firmware and reboots into the new image.<br><br>"
+            "<b>Experimental — phase 2:</b> only the <b>USB / master half</b> is updated; "
+            "the other half keeps its current firmware. If the master does not come back, "
+            "hold <b>BOOTSEL</b> on it and re-flash the .uf2.<br><br>"
+            "Make sure you have already staged a firmware (via “Flash Firmware”). "
+            "Continue?"
+        )
+        reply = QMessageBox.warning(
+            None, "Apply Staged Firmware", confirm_msg,
+            QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
+        if reply != QMessageBox.Yes:
+            self.log.info("FW_UP_APPLY: user cancelled at confirmation.")
+            return
+
+        # Pause the host polling loop so the 1 s reconnect timer doesn't contend for
+        # the HID lock while the device reboots (same pattern as the flash dialog).
+        host = self.parent
+        was_paused = getattr(host, 'paused', False)
+        if hasattr(host, 'pause') and not was_paused:
+            host.pause()
+        try:
+            ok, msg = apply_staged_firmware(
+                self.keeb.hid,
+                progress_cb=lambda pct, m: self.log.info("FW_UP_APPLY %d%% — %s", pct, m))
+        finally:
+            if hasattr(host, 'pause') and not was_paused:
+                host.pause()   # toggle back to resume
+
+        if ok:
+            QMessageBox.information(None, "Firmware Applied", msg)
+        else:
+            QMessageBox.warning(None, "Apply Failed", msg)

--- a/polyhost/gui/cmd_menu.py
+++ b/polyhost/gui/cmd_menu.py
@@ -1,10 +1,56 @@
 import logging
 
-from PyQt5.QtWidgets import QAction, QFileDialog, QMessageBox
+from PyQt5.QtWidgets import (
+    QAction, QFileDialog, QMessageBox, QAbstractItemView, QProxyStyle, QStyle,
+)
 
 from polyhost.device.keys import KeyCode, keycode_to_mapping_idx
 from polyhost.device.hid_fw_up import get_fw_version, validate_rp2040_firmware, validate_polykybd_firmware
 from polyhost.gui.get_icon import get_icon
+
+
+class _RequireExplicitOpen(QProxyStyle):
+    """Style proxy that stops the file list from accepting on a single click.
+
+    Qt's file dialog honours the desktop's "single-click to open files and
+    folders" setting (KDE Plasma's default), which makes a single click on a
+    file activate -> accept the dialog immediately.  Forcing this one style
+    hint to 0 makes a single click only *select* the file; the user must
+    double-click it or press Open, regardless of the desktop setting.
+    """
+    def styleHint(self, hint, option=None, widget=None, returnData=None):
+        if hint == QStyle.SH_ItemView_ActivateItemOnSingleClick:
+            return 0
+        return super().styleHint(hint, option, widget, returnData)
+
+
+def _get_open_file_explicit(caption: str, name_filter: str) -> str:
+    """Drop-in for QFileDialog.getOpenFileName that always requires an explicit
+    Open (never accepts on a single click).  Returns the chosen path, or '' if
+    cancelled.
+
+    The platform's native dialog can't be overridden from the app, so this uses
+    Qt's own dialog and disables single-click activation on its item views.
+    """
+    dlg = QFileDialog(None, caption, "", name_filter)
+    dlg.setFileMode(QFileDialog.ExistingFile)
+    dlg.setOption(QFileDialog.DontUseNativeDialog, True)
+    proxy = _RequireExplicitOpen("Fusion")
+    # Scope the override to the main file list / detail views only — those are
+    # what accept on activation.  Leaving the sidebar (Places) untouched keeps
+    # its single-click folder navigation working as the user expects.
+    views = [dlg.findChild(QAbstractItemView, "listView"),
+             dlg.findChild(QAbstractItemView, "treeView")]
+    views = [v for v in views if v is not None]
+    if not views:   # unexpected Qt layout — fall back to every item view
+        views = dlg.findChildren(QAbstractItemView)
+    for view in views:
+        view.setStyle(proxy)
+    dlg._require_explicit_open_style = proxy   # keep the proxy alive with the dialog
+    if dlg.exec_() != QFileDialog.Accepted:
+        return ""
+    files = dlg.selectedFiles()
+    return files[0] if files else ""
 
 
 class CommandsSubMenu:
@@ -200,9 +246,9 @@ class CommandsSubMenu:
         self.parent.report_device_result("Error", f"Failed to change idle mode: '{msg}'", result)
 
     def load_commands(self):
-        file_name = QFileDialog.getOpenFileName(None, 'Open file', '', "PolyKybd commands (*.poly.cmd)")
-        if len(file_name) > 0:
-            with open(file_name[0]) as f:
+        file_name = _get_open_file_explicit('Open file', "PolyKybd commands (*.poly.cmd)")
+        if file_name:
+            with open(file_name) as f:
                 self.keeb.execute_commands(f.readlines())
         else:
             self.log.info("No file selected. Operation canceled.")
@@ -215,8 +261,7 @@ class CommandsSubMenu:
                                 "PolyKybd is not connected. Please connect the keyboard and try again.")
             return
 
-        bin_path, _ = QFileDialog.getOpenFileName(
-            None, "Select Firmware Binary", "", "Firmware binary (*.bin)")
+        bin_path = _get_open_file_explicit("Select Firmware Binary", "Firmware binary (*.bin)")
         if not bin_path:
             self.log.info("FW_UP: no file selected, cancelled.")
             return

--- a/polyhost/gui/cmd_menu.py
+++ b/polyhost/gui/cmd_menu.py
@@ -141,12 +141,17 @@ class CommandsSubMenu:
 
         cmd_menu.addSeparator()
 
-        action = QAction(get_icon("keyboard_input.svg"), "Flash Firmware (.bin)…", parent=self.parent)
+        action = QAction(get_icon("keyboard_input.svg"), "Flash + Apply Firmware (.bin)…", parent=self.parent)
         # noinspection PyUnresolvedReferences
-        action.triggered.connect(self.open_hid_fw_up_dialog)
+        action.triggered.connect(lambda: self.open_hid_fw_up_dialog(apply_after=True))
         cmd_menu.addAction(action)
 
-        action = QAction(get_icon("keyboard_input.svg"), "Apply Staged Firmware (master)…", parent=self.parent)
+        action = QAction(get_icon("keyboard_input.svg"), "Flash Firmware only (.bin, stage)…", parent=self.parent)
+        # noinspection PyUnresolvedReferences
+        action.triggered.connect(lambda: self.open_hid_fw_up_dialog(apply_after=False))
+        cmd_menu.addAction(action)
+
+        action = QAction(get_icon("keyboard_input.svg"), "Apply Staged Firmware (both halves)…", parent=self.parent)
         # noinspection PyUnresolvedReferences
         action.triggered.connect(self.apply_staged_firmware_action)
         cmd_menu.addAction(action)
@@ -258,7 +263,7 @@ class CommandsSubMenu:
         else:
             self.log.info("No file selected. Operation canceled.")
 
-    def open_hid_fw_up_dialog(self):
+    def open_hid_fw_up_dialog(self, apply_after=False):
         from polyhost.gui.hid_fw_up_dialog import HidFwUpDialog
 
         if not self.keeb.hid or not self.keeb.hid.interface_acquired():
@@ -291,57 +296,79 @@ class CommandsSubMenu:
             QMessageBox.critical(None, "Wrong Keyboard", reason)
             return
 
+        # The confirmation text + title depend on whether we also activate the
+        # image right after staging (single-step "flash + apply").
+        if apply_after:
+            dlg_title = "Flash + Apply Firmware"
+            activation_note = (
+                "then <b>activate it</b>: both halves reboot onto the new firmware "
+                "(about 10 s, no replug needed)."
+            )
+        else:
+            dlg_title = "Flash Firmware"
+            activation_note = (
+                "The image is stored but <b>not activated yet</b> — the keyboard "
+                "keeps running its current firmware (activation is a separate step)."
+            )
+
         # Query current keyboard version for the confirmation dialog.
         ok, info = get_fw_version(self.keeb.hid)
         if ok:
             current = info.get('version', '?')
             size_kb = info.get('fw_size', 0) // 1024
-            confirm_msg = (
-                f"Current keyboard firmware: <b>{current}</b> ({size_kb} KB)<br><br>"
-                f"Selected file:<br>{bin_path}<br><br>"
-                "This will transfer and stage the new firmware on the keyboard, "
-                "then verify it (CRC32). The image is stored but <b>not "
-                "activated yet</b> — the keyboard keeps running its current "
-                "firmware (activation will be a separate step).<br><br>"
-                "Continue?"
-            )
+            head = (f"Current keyboard firmware: <b>{current}</b> ({size_kb} KB)<br><br>"
+                    f"Selected file:<br>{bin_path}<br><br>")
         else:
-            confirm_msg = (
-                f"Could not query current firmware version.<br><br>"
-                f"Selected file:<br>{bin_path}<br><br>"
-                "This will transfer and stage the new firmware on the keyboard, "
-                "then verify it (CRC32). The image is stored but <b>not "
-                "activated yet</b> — the keyboard keeps running its current "
-                "firmware (activation will be a separate step).<br><br>"
-                "Continue?"
-            )
+            head = (f"Could not query current firmware version.<br><br>"
+                    f"Selected file:<br>{bin_path}<br><br>")
+        confirm_msg = (head +
+            "This will transfer and stage the new firmware on the keyboard, then "
+            "verify it (CRC32). " + activation_note + "<br><br>Continue?")
 
         reply = QMessageBox.question(
-            None, "Flash Firmware", confirm_msg,
+            None, dlg_title, confirm_msg,
             QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
         if reply != QMessageBox.Yes:
             self.log.info("FW_UP: user cancelled at confirmation.")
             return
 
-        # Pause the host polling loop for the duration of the flash so the
-        # HID lock is not contested by the 1 s reconnect timer.
+        # Pause the host polling loop for the duration of the flash (and the apply,
+        # if requested) so the HID lock is not contested by the 1 s reconnect timer.
         host = self.parent
         was_paused = getattr(host, 'paused', False)
         if hasattr(host, 'pause') and not was_paused:
             host.pause()
 
+        apply_ok, apply_msg = None, None
         try:
             dlg = HidFwUpDialog(self.keeb.hid, bin_path)
             dlg.exec_()
+            staged_ok = getattr(dlg, '_success', False)
+            if apply_after and staged_ok:
+                # Chain activation in the same paused window so the device can
+                # reboot without the reconnect timer fighting for the HID lock.
+                apply_ok, apply_msg = apply_staged_firmware(
+                    self.keeb.hid,
+                    progress_cb=lambda pct, m: self.log.info("FW_UP_APPLY %d%% — %s", pct, m))
         finally:
             if hasattr(host, 'pause') and not was_paused:
                 host.pause()   # toggle back to resume
 
+        # Report the apply outcome (staging already reported itself in the dialog).
+        if apply_after and apply_ok is not None:
+            if apply_ok:
+                QMessageBox.information(None, "Firmware Applied", apply_msg)
+            else:
+                QMessageBox.warning(None, "Apply Failed", apply_msg)
+
     def apply_staged_firmware_action(self):
         """Trigger the keyboard to install a previously-staged firmware (FW_UP_APPLY).
 
-        PHASE 2 (experimental): master-only self-apply. The master erases its own
-        flash from offset 0, copies the staged image in, and reboots.
+        Both halves install the staged image and reboot onto it: the master tells
+        the slave to apply + reboot, then applies itself, so both come up on the
+        new firmware (no replug). Requires a firmware build with in-app apply
+        enabled; otherwise the keyboard safely reports apply unavailable and leaves
+        the staged image untouched.
         """
         if not self.keeb.hid or not self.keeb.hid.interface_acquired():
             QMessageBox.warning(None, "Not Connected",
@@ -350,16 +377,14 @@ class CommandsSubMenu:
 
         confirm_msg = (
             "<b>Apply the staged firmware?</b><br><br>"
-            "In-application self-apply is <b>currently disabled in the firmware</b> "
-            "because it bricked the master half (it erases the live interrupt-vector "
-            "table while rewriting flash from offset 0, then faults mid-copy).<br><br>"
-            "Pressing OK will query the keyboard; it will safely report that apply is "
-            "unavailable and <b>leave the staged image untouched</b> — it will NOT "
-            "reboot or modify the active firmware.<br><br>"
-            "A safe apply path (reboot into a minimal bootloader stage) is planned. "
+            "Both halves install the previously-staged image and reboot onto it "
+            "(about 10 s, no replug needed).<br><br>"
+            "If this firmware build has in-app apply disabled, the keyboard safely "
+            "reports that apply is unavailable and leaves the staged image "
+            "untouched.<br><br>"
             "Continue?"
         )
-        reply = QMessageBox.warning(
+        reply = QMessageBox.question(
             None, "Apply Staged Firmware", confirm_msg,
             QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
         if reply != QMessageBox.Yes:

--- a/polyhost/gui/cmd_menu.py
+++ b/polyhost/gui/cmd_menu.py
@@ -349,13 +349,14 @@ class CommandsSubMenu:
             return
 
         confirm_msg = (
-            "<b>Install the staged firmware now?</b><br><br>"
-            "This activates the firmware you previously staged: the keyboard erases its "
-            "active firmware and reboots into the new image.<br><br>"
-            "<b>Experimental — phase 2:</b> only the <b>USB / master half</b> is updated; "
-            "the other half keeps its current firmware. If the master does not come back, "
-            "hold <b>BOOTSEL</b> on it and re-flash the .uf2.<br><br>"
-            "Make sure you have already staged a firmware (via “Flash Firmware”). "
+            "<b>Apply the staged firmware?</b><br><br>"
+            "In-application self-apply is <b>currently disabled in the firmware</b> "
+            "because it bricked the master half (it erases the live interrupt-vector "
+            "table while rewriting flash from offset 0, then faults mid-copy).<br><br>"
+            "Pressing OK will query the keyboard; it will safely report that apply is "
+            "unavailable and <b>leave the staged image untouched</b> — it will NOT "
+            "reboot or modify the active firmware.<br><br>"
+            "A safe apply path (reboot into a minimal bootloader stage) is planned. "
             "Continue?"
         )
         reply = QMessageBox.warning(


### PR DESCRIPTION
## Summary
Splits the firmware update process into two phases: **staging** (transfer + verify) and **apply** (activate on device). Adds a new `FW_UP_APPLY` command (0x44) to trigger in-app firmware installation, and refactors the GUI to offer three distinct firmware operations instead of one.

## Key Changes

### Device Protocol (`polyhost/device/hid_fw_up.py`)
- Added `CMD_FW_UP_APPLY = 0x44` constant for the new apply command
- Modified `validate_polykybd_firmware()` to only stage and verify the image; no longer reboots the device
- Added `apply_staged_firmware()` function to trigger installation of a previously-staged image
  - Handles explicit NACK ('!') when in-app apply is disabled (safe no-op)
  - Waits for device reconnect after apply (expected ~10 s)
  - Returns success/failure with user-facing messages

### GUI Menu (`polyhost/gui/cmd_menu.py`)
- Added `_RequireExplicitOpen` QProxyStyle to disable single-click activation in file dialogs (prevents accidental opens on KDE Plasma's default single-click setting)
- Added `_get_open_file_explicit()` helper to wrap `QFileDialog.getOpenFileName()` with the style override
- Replaced single "Flash Firmware" action with three separate operations:
  1. **"Flash + Apply Firmware"** — stages and immediately applies (single-step, original behavior)
  2. **"Flash Firmware only (stage)"** — stages without applying (new two-phase workflow)
  3. **"Apply Staged Firmware"** — activates a previously-staged image (new standalone action)
- Updated `open_hid_fw_up_dialog()` to accept `apply_after` parameter and chain apply in the same paused window
- Added `apply_staged_firmware_action()` to handle standalone apply with confirmation and error reporting
- Refactored file dialog calls to use `_get_open_file_explicit()` for consistent UX

### Messaging & UX
- Updated confirmation dialogs to clarify staging vs. apply phases
- Changed success messages to explain that staging does not activate the firmware
- Added warnings about in-app apply being disabled in shipped firmware (safe fallback)
- Pauses the host polling loop during both staging and apply to prevent HID lock contention during device reboot

## Implementation Details
- The apply operation is **master-only** (phase 2); slave apply is planned for phase 3
- In-app apply is currently **disabled** in shipped firmware (bricking risk); the keyboard safely reports unavailable and leaves the staged image untouched
- File dialog style override is scoped to main list/tree views only; sidebar (Places) retains single-click folder navigation
- Device reconnect timeout for apply is 30 s; user is instructed to hold BOOTSEL and re-flash if it fails

https://claude.ai/code/session_01Ei4DVL1GtqmgBeHrLFeApM

## Summary by Sourcery

Introduce a two-phase firmware update flow with separate staging and apply steps and update the GUI to expose these operations explicitly while improving file dialog safety.

New Features:
- Add support for applying a previously staged firmware image via a new FW_UP_APPLY device command.
- Expose separate GUI actions for flash+apply, flash-only (stage), and apply-staged firmware operations.
- Provide an explicit-open file chooser that disables single-click activation for safer firmware and command file selection.

Enhancements:
- Clarify firmware update messaging to distinguish staging from activation and describe expected reboot behavior.
- Pause and resume the host polling loop around firmware staging and apply operations to avoid HID contention during device reconnects.