### PR TITLE
Bump host version to 0.8.1

### DIFF
--- a/polyhost/_version.py
+++ b/polyhost/_version.py
@@ -1,4 +1,4 @@
 __major__ = 0
 __minor__ = 8
-__patch__ = 0
+__patch__ = 1
 __version__ = str(__major__) + "." + str(__minor__) + "." + str(__patch__)


### PR DESCRIPTION
Bumps the host version `0.8.0` → `0.8.1` (`__patch__` in `polyhost/_version.py`; `__version__` now resolves to `0.8.1`).

Keeps the host in sync with the keyboard firmware `0.8.1` (companion firmware PR in qmk_firmware). With both at `0.8.1`, the host's version-match check no longer raises its minor-version-mismatch warning.

Version-only change.

https://claude.ai/code/session_01Ei4DVL1GtqmgBeHrLFeApM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ei4DVL1GtqmgBeHrLFeApM)_

## Summary by Sourcery

Enhancements:
- Update the internal version constants so the resolved host version string is now 0.8.1.