### PR TITLE
Use native file picker on Windows and macOS

### DIFF
--- a/polyhost/gui/cmd_menu.py
+++ b/polyhost/gui/cmd_menu.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from contextlib import contextmanager
 
 from PyQt5.QtWidgets import (
@@ -30,9 +31,15 @@ def _get_open_file_explicit(caption: str, name_filter: str) -> str:
     Open (never accepts on a single click).  Returns the chosen path, or '' if
     cancelled.
 
-    The platform's native dialog can't be overridden from the app, so this uses
-    Qt's own dialog and disables single-click activation on its item views.
+    On Windows and macOS the OS-native picker is used directly.  On Linux the
+    Qt dialog is used instead, with single-click activation disabled — needed
+    because KDE Plasma's default "activate on single click" setting would
+    otherwise accept the dialog the moment the user clicks a file.
     """
+    if sys.platform in ('win32', 'darwin'):
+        path, _ = QFileDialog.getOpenFileName(None, caption, "", name_filter)
+        return path
+
     dlg = QFileDialog(None, caption, "", name_filter)
     dlg.setFileMode(QFileDialog.ExistingFile)
     dlg.setOption(QFileDialog.DontUseNativeDialog, True)


### PR DESCRIPTION
## Summary

On Windows and macOS, use the OS-native file picker dialog directly instead of Qt's dialog. Qt's dialog on these platforms was being forced to use a non-native implementation to work around a KDE Plasma issue that only affects Linux.

The change:
- Detects the platform via `sys.platform`
- On Windows (`win32`) and macOS (`darwin`), calls `QFileDialog.getOpenFileName()` directly to use the native picker
- On Linux, continues using Qt's dialog with single-click activation disabled (needed for KDE Plasma compatibility)

This provides a better user experience on Windows and macOS by using the platform's standard file picker, while maintaining the workaround for Linux where it's actually needed.

## Version bump label

`bump:minor`

## Testing

N/A — this is a straightforward platform detection change that delegates to existing Qt APIs. The native pickers are standard OS components; Qt's `getOpenFileName()` is well-tested.

https://claude.ai/code/session_015TqxTLmGaBsuXFc3or6Gc6

## Summary by Sourcery

Use the OS-native file picker on Windows and macOS while retaining the custom non-native Qt dialog behavior on Linux for KDE Plasma compatibility.

New Features:
- Enable native file picker dialogs on Windows and macOS when selecting files from the command menu.

Bug Fixes:
- Preserve the Linux-specific workaround that disables single-click activation in the Qt file dialog to avoid accidental acceptance under KDE Plasma.