### PR TITLE
fix(updater): install requirements.txt after applying update

### DIFF
--- a/polyhost/services/updater.py
+++ b/polyhost/services/updater.py
@@ -148,24 +148,37 @@ def download_and_extract(tarball_url: str, tmpdir: Path,
     return children[0]
 
 
+def _run_pip(args: list, label: str) -> None:
+    """Run `pip <args>` in the active interpreter; log on non-zero exit."""
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "pip", *args],
+            check=False, capture_output=True, text=True, timeout=300,
+        )
+        if result.returncode != 0:
+            log.warning("pip %s after update returned %d: %s",
+                        label, result.returncode, result.stderr.strip()[-500:])
+    except (subprocess.SubprocessError, OSError) as e:
+        log.warning("pip %s after update failed to run: %s", label, e)
+
+
 def apply_update(extracted_dir: Path, install_root: Path) -> None:
-    """Copy files from `extracted_dir` over `install_root`, then refresh deps."""
+    """Copy files from `extracted_dir` over `install_root`, then refresh deps.
+
+    Runs `pip install -e .` to pick up `setup.py` changes and, if a
+    `requirements.txt` is present, `pip install -r requirements.txt` so new
+    runtime deps declared only there are installed into the active venv.
+    """
     shutil.copytree(
         extracted_dir,
         install_root,
         dirs_exist_ok=True,
         ignore=shutil.ignore_patterns(*EXCLUDES),
     )
-    try:
-        result = subprocess.run(
-            [sys.executable, "-m", "pip", "install", "-e", str(install_root)],
-            check=False, capture_output=True, text=True, timeout=300,
-        )
-        if result.returncode != 0:
-            log.warning("pip install after update returned %d: %s",
-                        result.returncode, result.stderr.strip()[-500:])
-    except (subprocess.SubprocessError, OSError) as e:
-        log.warning("pip install after update failed to run: %s", e)
+    _run_pip(["install", "-e", str(install_root)], "install -e .")
+    requirements = install_root / "requirements.txt"
+    if requirements.is_file():
+        _run_pip(["install", "-r", str(requirements)], "install -r requirements.txt")
 
 
 def restart_app() -> None:

--- a/polyhost/services/updater.py
+++ b/polyhost/services/updater.py
@@ -156,8 +156,9 @@ def _run_pip(args: list, label: str) -> None:
             check=False, capture_output=True, text=True, timeout=300,
         )
         if result.returncode != 0:
+            details = (result.stderr or "").strip() or (result.stdout or "").strip()
             log.warning("pip %s after update returned %d: %s",
-                        label, result.returncode, result.stderr.strip()[-500:])
+                        label, result.returncode, details[-500:])
     except (subprocess.SubprocessError, OSError) as e:
         log.warning("pip %s after update failed to run: %s", label, e)
 

--- a/tests/services/updater_test.py
+++ b/tests/services/updater_test.py
@@ -244,9 +244,45 @@ class TestApplyUpdate(unittest.TestCase):
             install = Path(td) / "install"
             install.mkdir()
             with mock.patch.object(updater.subprocess, "run") as mock_run:
-                mock_run.return_value = mock.Mock(returncode=1, stderr="boom")
+                mock_run.return_value = mock.Mock(returncode=1, stderr="boom", stdout="")
                 updater.apply_update(src, install)
             self.assertTrue((install / "marker").exists())
+
+    def test_requirements_pip_failure_does_not_raise(self):
+        with tempfile.TemporaryDirectory() as td:
+            src = Path(td) / "src"
+            src.mkdir()
+            (src / "requirements.txt").write_text("requests\n")
+            install = Path(td) / "install"
+            install.mkdir()
+
+            def fake_run(cmd, **kwargs):
+                # First call (install -e .) succeeds; second (-r requirements.txt) fails.
+                if "-r" in cmd:
+                    return mock.Mock(returncode=1, stderr="resolve error", stdout="")
+                return mock.Mock(returncode=0, stderr="", stdout="")
+
+            with mock.patch.object(updater.subprocess, "run", side_effect=fake_run) as mock_run:
+                with mock.patch.object(updater.log, "warning") as mock_warn:
+                    updater.apply_update(src, install)
+
+            self.assertEqual(mock_run.call_count, 2)
+            warnings = " ".join(str(c) for c in mock_warn.call_args_list)
+            self.assertIn("install -r requirements.txt", warnings)
+
+    def test_pip_failure_falls_back_to_stdout_when_stderr_empty(self):
+        with tempfile.TemporaryDirectory() as td:
+            src = Path(td) / "src"
+            src.mkdir()
+            install = Path(td) / "install"
+            install.mkdir()
+            with mock.patch.object(updater.subprocess, "run") as mock_run, \
+                 mock.patch.object(updater.log, "warning") as mock_warn:
+                mock_run.return_value = mock.Mock(
+                    returncode=1, stderr="", stdout="diagnostic on stdout")
+                updater.apply_update(src, install)
+            warnings = " ".join(str(c) for c in mock_warn.call_args_list)
+            self.assertIn("diagnostic on stdout", warnings)
 
 
 if __name__ == "__main__":

--- a/tests/services/updater_test.py
+++ b/tests/services/updater_test.py
@@ -1,5 +1,6 @@
 import io
 import json
+import sys
 import tarfile
 import tempfile
 import unittest
@@ -213,6 +214,27 @@ class TestApplyUpdate(unittest.TestCase):
             self.assertFalse((install / "__pycache__").exists(),
                              "__pycache__ must be excluded")
             mock_run.assert_called_once()
+            self.assertEqual(mock_run.call_args.args[0][:4],
+                             [sys.executable, "-m", "pip", "install"])
+
+    def test_installs_requirements_when_present(self):
+        with tempfile.TemporaryDirectory() as td:
+            src = Path(td) / "src"
+            src.mkdir()
+            (src / "requirements.txt").write_text("requests\npackaging\n")
+            install = Path(td) / "install"
+            install.mkdir()
+
+            with mock.patch.object(updater.subprocess, "run") as mock_run:
+                mock_run.return_value = mock.Mock(returncode=0, stderr="")
+                updater.apply_update(src, install)
+
+            self.assertEqual(mock_run.call_count, 2)
+            cmds = [c.args[0] for c in mock_run.call_args_list]
+            self.assertIn("install", cmds[0])
+            self.assertIn("-e", cmds[0])
+            self.assertIn("-r", cmds[1])
+            self.assertEqual(cmds[1][-1], str(install / "requirements.txt"))
 
     def test_pip_failure_does_not_raise(self):
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## Summary

Follow-up to #22. The auto-updater currently only runs `pip install -e .` after copying the new source, which honors `setup.py`'s `install_requires` but skips `requirements.txt`. Since most of this project's runtime deps (PyQt5, hid, NumPy, pynput, PyYAML, pandas, pvlib, …) live only in `requirements.txt`, a release that adds a new dep there would land on disk but fail to import at next launch.

This change makes `apply_update()` also run `pip install -r requirements.txt` (when the file is present in the install root), against the same `sys.executable` so it lands in whichever venv the app is running from.

- Extracted a small `_run_pip` helper so both invocations share the same error-handling/logging.
- pip failures are logged but non-fatal — same behavior as before.

## Test plan
- [x] `python3 -m unittest tests.services.updater_test` — 16/16 pass
- [x] New test `test_installs_requirements_when_present` asserts both pip calls fire in order with the right args
- [ ] Manual smoke test against a real release that adds a dep to `requirements.txt`

## Version bump label
No label → patch bump (this is a gap fix in the recently-merged auto-update feature).

---
_Generated by [Claude Code](https://claude.ai/code/session_015q48trtsg8zuxxPUAcvBvx)_

## Summary by Sourcery

Ensure the auto-updater refreshes Python dependencies from both the editable install and requirements file after applying an update.

Bug Fixes:
- Install runtime dependencies listed only in requirements.txt when applying an update to avoid missing imports after upgrade.

Enhancements:
- Refactor updater pip invocation into a shared helper with consistent logging and error handling.

Tests:
- Extend updater tests to verify pip is invoked with the expected arguments and that requirements.txt is installed when present.