### PR TITLE
fix: update mechanism robustness — ETag caching, error dialogs, Windows DLL relay, firmware menu

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,15 @@ jobs:
     name: Create release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
         run: |
-          gh release create "${{ github.ref_name }}" \
+          gh release create "$TAG_NAME" \
             --generate-notes \
-            --title "PolyKybdHost ${{ github.ref_name }}"
+            --title "PolyKybdHost $TAG_NAME"

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -214,10 +214,9 @@ class PolyHost(QApplication):
         self._update_progress = None
         self._await_manual_prompt = False
 
-        self.firmware_update_action = QAction(get_icon("keyboard.svg"), "", parent=self)
+        self.firmware_update_action = QAction(get_icon("keyboard.svg"), "Check for firmware update…", parent=self)
         # noinspection PyUnresolvedReferences
         self.firmware_update_action.triggered.connect(self._on_fw_up_clicked)
-        self.firmware_update_action.setVisible(False)
         self.menu.addAction(self.firmware_update_action)
         self._pending_fw_release = None
         self._fw_up_downloader = None
@@ -328,9 +327,7 @@ class PolyHost(QApplication):
         self.layout_editor.setEnabled(True)
         self.settings_dialog.setEnabled(True)
         self.update_action.setEnabled(True)
-        self.firmware_update_action.setEnabled(
-            self.connected and self._pending_fw_release is not None
-        )
+        self.firmware_update_action.setEnabled(self.connected)
         self.status.setEnabled(True)
         self.support.setEnabled(True)
         self.about.setEnabled(True)
@@ -597,6 +594,15 @@ class PolyHost(QApplication):
             if not _error_seen[0] and on_check_error is not None:
                 on_check_error(msg)
             _error_seen[0] = True
+            # Reset firmware manual check regardless of which check failed — both
+            # host and firmware errors emit the same signal, either can leave it stuck.
+            if self._await_manual_fw_prompt:
+                self._await_manual_fw_prompt = False
+                self.firmware_update_action.setText(
+                    f"Update firmware to v{self._pending_fw_release.version}…"
+                    if self._pending_fw_release else "Check for firmware update…"
+                )
+                self.firmware_update_action.setEnabled(self.connected)
 
         def _host_no_update():
             if _error_seen[0]:
@@ -777,12 +783,17 @@ class PolyHost(QApplication):
         if self._pending_fw_release is not None:
             self._prompt_and_flash(self._pending_fw_release)
             return
-        self.firmware_update_action.setText("Checking for firmware updates…")
+        self.firmware_update_action.setText("Checking for firmware update…")
+        self.firmware_update_action.setEnabled(False)
         self._await_manual_fw_prompt = True
-        self._start_update_check(on_no_update=self._on_manual_no_fw_update)
+        # No on_no_update here: the firmware result comes via _await_manual_fw_prompt
+        # and the _fw_no_update closure in _start_update_check.
+        self._start_update_check()
 
     def _on_manual_no_fw_update(self):
         self._await_manual_fw_prompt = False
+        self.firmware_update_action.setText("Check for firmware update…")
+        self.firmware_update_action.setEnabled(self.connected)
         fw_version = self.keeb.get_sw_version() if self.connected else "unknown"
         QMessageBox.information(
             None, "PolyKybd Firmware",

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -406,6 +406,7 @@ class PolyHost(QApplication):
                         self.overlay_handler.force_resend()
                         self._needs_overlay_reset = True
                         self.log.info("Connected: active window resend queued.")
+                        QTimer.singleShot(0, self._start_update_check)
                 else:
                     self.status.setIcon(get_icon("sync_disabled.svg"))
                     self.status.setText(msg)
@@ -582,17 +583,25 @@ class PolyHost(QApplication):
         fw_version = self.keeb.get_sw_version() if self.connected else None
         self._update_checker = UpdateChecker(current_fw_version=fw_version, parent=self)
 
-        def _no_update():
-            self.log.debug("No update available")
+        def _host_no_update():
+            self.log.debug("No host update available")
             if on_no_update is not None:
                 on_no_update()
+
+        def _fw_no_update():
+            self.log.debug("No firmware update available")
+            if self._await_manual_fw_prompt:
+                self._await_manual_fw_prompt = False
+                self._on_manual_no_fw_update()
 
         # noinspection PyUnresolvedReferences
         self._update_checker.update_available.connect(self._on_update_available)
         # noinspection PyUnresolvedReferences
         self._update_checker.fw_up_available.connect(self._on_fw_up_available)
         # noinspection PyUnresolvedReferences
-        self._update_checker.no_update.connect(_no_update)
+        self._update_checker.host_no_update.connect(_host_no_update)
+        # noinspection PyUnresolvedReferences
+        self._update_checker.fw_no_update.connect(_fw_no_update)
         # noinspection PyUnresolvedReferences
         self._update_checker.error.connect(lambda msg: self.log.warning("Update check error: %s", msg))
         self._update_checker.start()

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -17,10 +17,15 @@ from PyQt5.QtWidgets import (
     QMenu,
     QAction,
     QDialog,
+    QDialogButtonBox,
+    QHBoxLayout,
     QLabel,
     QMessageBox,
     QFileDialog,
-    QProgressDialog, )
+    QProgressDialog,
+    QSizePolicy,
+    QStyle,
+    QVBoxLayout, )
 
 from polyhost.gui.get_icon import get_icon
 from polyhost.gui.icon_state_manager import IconStateManager
@@ -86,17 +91,75 @@ _UPD_DLG_H = _UPD_DLG_W // 2  # 220
 
 def _msgbox(icon, title: str, text: str,
             buttons=QMessageBox.Ok, default=None) -> int:
-    dlg = QMessageBox(None)
+    """QDialog-based message box so setFixedSize is reliably respected."""
+    _ICON_MAP = {
+        QMessageBox.Information: QStyle.SP_MessageBoxInformation,
+        QMessageBox.Warning:     QStyle.SP_MessageBoxWarning,
+        QMessageBox.Critical:    QStyle.SP_MessageBoxCritical,
+        QMessageBox.Question:    QStyle.SP_MessageBoxQuestion,
+    }
+    _BTN_MAP = {
+        QMessageBox.Ok:     QDialogButtonBox.Ok,
+        QMessageBox.Yes:    QDialogButtonBox.Yes,
+        QMessageBox.No:     QDialogButtonBox.No,
+        QMessageBox.Cancel: QDialogButtonBox.Cancel,
+    }
+
+    dlg = QDialog(None)
     dlg.setWindowTitle(title)
-    dlg.setText(text)
-    dlg.setIcon(icon)
-    dlg.setStandardButtons(buttons)
+    dlg.setFixedSize(_UPD_DLG_W, _UPD_DLG_H)
+
+    outer = QVBoxLayout(dlg)
+    outer.setContentsMargins(16, 16, 16, 12)
+    outer.setSpacing(12)
+
+    # Icon + text row
+    row = QHBoxLayout()
+    row.setSpacing(12)
+    icon_lbl = QLabel()
+    sp = _ICON_MAP.get(icon)
+    if sp is not None:
+        px = dlg.style().standardPixmap(sp)
+        icon_lbl.setPixmap(px)
+    icon_lbl.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+    row.addWidget(icon_lbl, 0, Qt.AlignTop)
+
+    text_lbl = QLabel(text)
+    text_lbl.setWordWrap(True)
+    text_lbl.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+    row.addWidget(text_lbl, 1)
+    outer.addLayout(row, 1)
+
+    # Button row
+    db_flags = QDialogButtonBox.StandardButtons()
+    for mb_flag, db_flag in _BTN_MAP.items():
+        if buttons & mb_flag:
+            db_flags |= db_flag
+    btn_box = QDialogButtonBox(db_flags)
+    btn_box.accepted.connect(dlg.accept)
+    btn_box.rejected.connect(dlg.reject)
+    outer.addWidget(btn_box, 0, Qt.AlignRight)
+
+    # Set default button focus
     if default is not None:
-        dlg.setDefaultButton(default)
-    # Fix width; let height grow to fit content so nothing is clipped.
-    dlg.setFixedWidth(_UPD_DLG_W)
-    dlg.setMinimumHeight(_UPD_DLG_H)
-    return dlg.exec_()
+        db_default = _BTN_MAP.get(default)
+        if db_default is not None:
+            b = btn_box.button(db_default)
+            if b:
+                b.setDefault(True)
+                b.setFocus()
+
+    result = dlg.exec_()
+
+    # Map QDialog result back to QMessageBox codes
+    if result == QDialog.Accepted:
+        if buttons & QMessageBox.Yes:
+            return QMessageBox.Yes
+        return QMessageBox.Ok
+    else:
+        if buttons & QMessageBox.No:
+            return QMessageBox.No
+        return QMessageBox.Cancel
 
 
 def _progress_dlg(label: str, title: str) -> QProgressDialog:

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -85,8 +85,8 @@ class MultiLineFormatter(logging.Formatter):
 
 
 # Shared dimensions for all update / firmware dialogs — 2:1 aspect ratio.
-_UPD_DLG_W = 440
-_UPD_DLG_H = _UPD_DLG_W // 2  # 220
+_UPD_DLG_W = 400
+_UPD_DLG_H = 160
 
 
 def _msgbox(icon, title: str, text: str,

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -719,7 +719,12 @@ class PolyHost(QApplication):
         if self._update_progress is None:
             return
         self._update_progress.setLabelText(message)
-        self._update_progress.setValue(percent)
+        if percent < 0:
+            self._update_progress.setRange(0, 0)  # indeterminate / busy pulse
+        else:
+            if self._update_progress.maximum() == 0:
+                self._update_progress.setRange(0, 100)
+            self._update_progress.setValue(percent)
 
     def _on_update_done(self):
         if self._update_progress is not None:

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -573,17 +573,33 @@ class PolyHost(QApplication):
         with open(filename, "w") as f:
             f.write(yaml.dump(self.mapping))
 
-    def _start_update_check(self, on_no_update=None):
-        """Start a background update check. `on_no_update` is invoked on the
-        UI thread when the check completes with no newer release (used for
-        manual-check feedback; automatic checks pass None and stay silent)."""
+    def _start_update_check(self, on_no_update=None, on_check_error=None):
+        """Start a background update check.
+
+        ``on_no_update`` is called when the check succeeds but finds no newer release.
+        ``on_check_error`` is called (with a message string) when the API/network
+        call itself fails — distinct from "no update available".
+        Both are None for the automatic periodic check (silent failure).
+        """
         if self._update_checker is not None and self._update_checker.isRunning():
             return
         self.log.debug("Starting update check...")
         fw_version = self.keeb.get_sw_version() if self.connected else None
         self._update_checker = UpdateChecker(current_fw_version=fw_version, parent=self)
 
+        # Track whether the error signal fires before host_no_update so we can
+        # suppress the "no update" callback and show the real failure reason.
+        _error_seen = [False]
+
+        def _on_error(msg):
+            _error_seen[0] = True
+            self.log.warning("Update check error: %s", msg)
+            if on_check_error is not None:
+                on_check_error(msg)
+
         def _host_no_update():
+            if _error_seen[0]:
+                return  # error was already surfaced via on_check_error
             self.log.debug("No host update available")
             if on_no_update is not None:
                 on_no_update()
@@ -603,7 +619,7 @@ class PolyHost(QApplication):
         # noinspection PyUnresolvedReferences
         self._update_checker.fw_no_update.connect(_fw_no_update)
         # noinspection PyUnresolvedReferences
-        self._update_checker.error.connect(lambda msg: self.log.warning("Update check error: %s", msg))
+        self._update_checker.error.connect(_on_error)
         self._update_checker.start()
 
     def _on_update_available(self, release):
@@ -622,7 +638,10 @@ class PolyHost(QApplication):
             return
         self.update_action.setText("Checking for updates...")
         self._await_manual_prompt = True
-        self._start_update_check(on_no_update=self._on_manual_no_update)
+        self._start_update_check(
+            on_no_update=self._on_manual_no_update,
+            on_check_error=self._on_manual_check_error,
+        )
 
     def _on_manual_no_update(self):
         self._await_manual_prompt = False
@@ -632,6 +651,15 @@ class PolyHost(QApplication):
             f"You are running the latest version (v{__version__}).",
         )
         self.update_action.setText("Check for updates...")
+
+    def _on_manual_check_error(self, msg: str):
+        self._await_manual_prompt = False
+        self.update_action.setText("Check for updates...")
+        QMessageBox.warning(
+            None, "PolyKybdHost Update",
+            f"Could not check for updates:\n\n{msg}\n\n"
+            f"Run with --debug 1 for details.",
+        )
 
     def _prompt_and_install(self, release):
         reply = QMessageBox.question(

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -3,6 +3,7 @@ from logging.handlers import RotatingFileHandler
 import os
 import pathlib
 import platform
+import subprocess
 import sys
 import time
 import webbrowser
@@ -697,6 +698,8 @@ class PolyHost(QApplication):
         # noinspection PyUnresolvedReferences
         self._update_installer.finished_ok.connect(self._on_update_done)
         # noinspection PyUnresolvedReferences
+        self._update_installer.relay_needed.connect(self._on_relay_needed)
+        # noinspection PyUnresolvedReferences
         self._update_installer.failed.connect(self._on_update_failed)
         self._update_installer.start()
 
@@ -713,6 +716,24 @@ class PolyHost(QApplication):
         self.log.info("Update applied, restarting...")
         self.quit_app()
         restart_app()
+
+    def _on_relay_needed(self, relay_path: str):
+        """Windows: some files (e.g. hidapi.dll) were locked by the running process.
+
+        A relay script was written that will copy them once we exit and release
+        the handles, then relaunch the app.  All non-DLL files were already copied.
+        """
+        self.log.info("Relay restart needed for locked files: %s", relay_path)
+        if self._update_progress is not None:
+            self._update_progress.setLabelText("Restarting to complete update…")
+            self._update_progress.setValue(100)
+        subprocess.Popen(
+            [sys.executable, relay_path],
+            close_fds=False,
+            creationflags=subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP,
+        )
+        # Brief pause so the user sees the "Restarting" label before the window vanishes.
+        QTimer.singleShot(1200, self.quit)
 
     def _on_update_failed(self, message):
         if self._update_progress is not None:

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -276,6 +276,8 @@ class PolyHost(QApplication):
         # Add the menu to the tray
         # self.tray.activated.connect(self.on_activated)
         self.tray.setContextMenu(self.menu)
+        # noinspection PyUnresolvedReferences
+        self.tray.messageClicked.connect(self._on_balloon_clicked)
         self.tray.show()
 
         QTimer.singleShot(15_000, self._start_update_check)
@@ -768,6 +770,14 @@ class PolyHost(QApplication):
 
     def show_balloon(self, title: str, message: str, msec: int = 8000):
         self.tray.showMessage(title, message, QSystemTrayIcon.Information, msec)
+
+    def _on_balloon_clicked(self):
+        if self._update_installer is not None and self._update_installer.isRunning():
+            return
+        if self._pending_release is not None:
+            self._prompt_and_install(self._pending_release)
+        elif self._pending_fw_release is not None:
+            self._prompt_and_flash(self._pending_fw_release)
 
     # ------------------------------------------------------------------
     # Firmware update

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -79,9 +79,9 @@ class MultiLineFormatter(logging.Formatter):
         return lines[0] + "\n".join(formatted_lines)
 
 
-# Fixed width (px) shared by all update / firmware dialogs so their size
-# stays consistent across the question → download → apply sequence.
+# Fixed size (px) shared by all update / firmware dialogs — 5:3 aspect ratio.
 _UPD_DLG_W = 440
+_UPD_DLG_H = 264   # 440 * 3/5
 
 
 def _msgbox(icon, title: str, text: str,
@@ -93,7 +93,7 @@ def _msgbox(icon, title: str, text: str,
     dlg.setStandardButtons(buttons)
     if default is not None:
         dlg.setDefaultButton(default)
-    dlg.setFixedWidth(_UPD_DLG_W)
+    dlg.setFixedSize(_UPD_DLG_W, _UPD_DLG_H)
     return dlg.exec_()
 
 
@@ -105,7 +105,7 @@ def _progress_dlg(label: str, title: str) -> QProgressDialog:
     dlg.setAutoClose(False)
     dlg.setCancelButton(None)
     dlg.setValue(0)
-    dlg.setFixedWidth(_UPD_DLG_W)
+    dlg.setFixedSize(_UPD_DLG_W, _UPD_DLG_H)
     lbl = dlg.findChild(QLabel)
     if lbl:
         lbl.setWordWrap(True)

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -636,6 +636,12 @@ class PolyHost(QApplication):
         if self._await_manual_prompt:
             self._await_manual_prompt = False
             self._prompt_and_install(release)
+        else:
+            self.show_balloon(
+                "PolyKybdHost Update",
+                f"Version {release.version} is available. "
+                "Click the tray icon to update.",
+            )
 
     def _on_update_clicked(self):
         if self._update_installer is not None and self._update_installer.isRunning():

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -733,11 +733,12 @@ class PolyHost(QApplication):
         if self._update_progress is not None:
             self._update_progress.setLabelText("Restarting to complete update…")
             self._update_progress.setValue(100)
-        subprocess.Popen(
-            [sys.executable, relay_path],
-            close_fds=False,
-            creationflags=subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP,
-        )
+        popen_kwargs: dict = {"close_fds": False}
+        if sys.platform == "win32":
+            popen_kwargs["creationflags"] = (
+                subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP
+            )
+        subprocess.Popen([sys.executable, relay_path], **popen_kwargs)
         # Brief pause so the user sees the "Restarting" label before the window vanishes.
         QTimer.singleShot(1200, self.quit)
 

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -79,9 +79,9 @@ class MultiLineFormatter(logging.Formatter):
         return lines[0] + "\n".join(formatted_lines)
 
 
-# Fixed size (px) shared by all update / firmware dialogs — 5:3 aspect ratio.
+# Shared dimensions for all update / firmware dialogs — 2:1 aspect ratio.
 _UPD_DLG_W = 440
-_UPD_DLG_H = 264   # 440 * 3/5
+_UPD_DLG_H = _UPD_DLG_W // 2  # 220
 
 
 def _msgbox(icon, title: str, text: str,
@@ -93,7 +93,9 @@ def _msgbox(icon, title: str, text: str,
     dlg.setStandardButtons(buttons)
     if default is not None:
         dlg.setDefaultButton(default)
-    dlg.setFixedSize(_UPD_DLG_W, _UPD_DLG_H)
+    # Fix width; let height grow to fit content so nothing is clipped.
+    dlg.setFixedWidth(_UPD_DLG_W)
+    dlg.setMinimumHeight(_UPD_DLG_H)
     return dlg.exec_()
 
 
@@ -109,6 +111,11 @@ def _progress_dlg(label: str, title: str) -> QProgressDialog:
     lbl = dlg.findChild(QLabel)
     if lbl:
         lbl.setWordWrap(True)
+    layout = dlg.layout()
+    if layout is not None:
+        m = layout.contentsMargins()
+        layout.setContentsMargins(m.left(), m.top(), m.right(),
+                                  m.bottom() + _UPD_DLG_H // 10)
     dlg.show()
     return dlg
 

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -17,6 +17,7 @@ from PyQt5.QtWidgets import (
     QMenu,
     QAction,
     QDialog,
+    QLabel,
     QMessageBox,
     QFileDialog,
     QProgressDialog, )
@@ -76,6 +77,40 @@ class MultiLineFormatter(logging.Formatter):
         timestamp = self.formatTime(record)
         formatted_lines = [f"[{timestamp}] {line}" for line in lines[:-1]]
         return lines[0] + "\n".join(formatted_lines)
+
+
+# Fixed width (px) shared by all update / firmware dialogs so their size
+# stays consistent across the question → download → apply sequence.
+_UPD_DLG_W = 440
+
+
+def _msgbox(icon, title: str, text: str,
+            buttons=QMessageBox.Ok, default=None) -> int:
+    dlg = QMessageBox(None)
+    dlg.setWindowTitle(title)
+    dlg.setText(text)
+    dlg.setIcon(icon)
+    dlg.setStandardButtons(buttons)
+    if default is not None:
+        dlg.setDefaultButton(default)
+    dlg.setFixedWidth(_UPD_DLG_W)
+    return dlg.exec_()
+
+
+def _progress_dlg(label: str, title: str) -> QProgressDialog:
+    dlg = QProgressDialog(label, None, 0, 100, None)
+    dlg.setWindowTitle(title)
+    dlg.setWindowFlag(Qt.WindowStaysOnTopHint, True)
+    dlg.setMinimumDuration(0)
+    dlg.setAutoClose(False)
+    dlg.setCancelButton(None)
+    dlg.setValue(0)
+    dlg.setFixedWidth(_UPD_DLG_W)
+    lbl = dlg.findChild(QLabel)
+    if lbl:
+        lbl.setWordWrap(True)
+    dlg.show()
+    return dlg
 
 
 class PolyHost(QApplication):
@@ -661,31 +696,22 @@ class PolyHost(QApplication):
     def _on_manual_no_update(self):
         self._await_manual_prompt = False
         self.update_action.setText("No updates available")
-        QMessageBox.information(
-            None, "PolyKybdHost Update",
-            f"You are running the latest version (v{__version__}).",
-        )
+        _msgbox(QMessageBox.Information, "PolyKybdHost Update",
+                f"You are running the latest version (v{__version__}).")
         self.update_action.setText("Check for updates...")
 
     def _on_manual_check_error(self, msg: str):
         self._await_manual_prompt = False
         self.update_action.setText("Check for updates...")
-        QMessageBox.warning(
-            None, "PolyKybdHost Update",
-            f"Could not check for updates:\n\n{msg}\n\n"
-            f"Run with --debug 1 for details.",
-        )
+        _msgbox(QMessageBox.Warning, "PolyKybdHost Update",
+                f"Could not check for updates:\n\n{msg}\n\n"
+                "Run with --debug 1 for details.")
 
     def _prompt_and_install(self, release):
-        reply = QMessageBox.question(
-            None,
-            "Update PolyKybdHost",
-            f"A new version v{release.version} is available.\n\n"
-            f"Download, install, and restart now?",
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.Yes,
-        )
-        if reply != QMessageBox.Yes:
+        if _msgbox(QMessageBox.Question, "Update PolyKybdHost",
+                   f"A new version v{release.version} is available.\n\n"
+                   "Download, install, and restart now?",
+                   QMessageBox.Yes | QMessageBox.No, QMessageBox.Yes) != QMessageBox.Yes:
             return
         self._run_update_installer(release)
 
@@ -695,16 +721,7 @@ class PolyHost(QApplication):
             return
 
         self.update_action.setEnabled(False)
-        self._update_progress = QProgressDialog(
-            "Downloading update...", "Cancel", 0, 100, None,
-        )
-        self._update_progress.setWindowTitle("PolyKybdHost Update")
-        self._update_progress.setWindowFlag(Qt.WindowStaysOnTopHint, True)
-        self._update_progress.setMinimumDuration(0)
-        self._update_progress.setAutoClose(False)
-        self._update_progress.setCancelButton(None)
-        self._update_progress.setValue(0)
-        self._update_progress.show()
+        self._update_progress = _progress_dlg("Downloading update…", "PolyKybdHost Update")
 
         self._update_installer = UpdateInstaller(release, parent=self)
         # noinspection PyUnresolvedReferences
@@ -761,8 +778,8 @@ class PolyHost(QApplication):
             self._update_progress = None
         self.update_action.setEnabled(True)
         self.log.error("Update failed: %s", message)
-        QMessageBox.warning(None, "Update failed",
-                            f"Could not apply the update:\n\n{message}")
+        _msgbox(QMessageBox.Warning, "Update failed",
+                f"Could not apply the update:\n\n{message}")
 
     # ------------------------------------------------------------------
     # Balloon notifications
@@ -817,28 +834,19 @@ class PolyHost(QApplication):
         self.firmware_update_action.setText("Check for firmware update…")
         self.firmware_update_action.setEnabled(self.connected)
         fw_version = self.keeb.get_sw_version() if self.connected else "unknown"
-        QMessageBox.information(
-            None, "PolyKybd Firmware",
-            f"You are running the latest firmware (v{fw_version}).",
-        )
+        _msgbox(QMessageBox.Information, "PolyKybd Firmware",
+                f"You are running the latest firmware (v{fw_version}).")
 
     def _prompt_and_flash(self, release):
         if not self.connected:
-            QMessageBox.warning(
-                None, "Firmware Update",
-                "The keyboard must be connected to update the firmware.",
-            )
+            _msgbox(QMessageBox.Warning, "Firmware Update",
+                    "The keyboard must be connected to update the firmware.")
             return
-        reply = QMessageBox.question(
-            None,
-            "Update PolyKybd Firmware",
-            f"A new firmware v{release.version} is available.\n\n"
-            "The keyboard will update both halves over HID and reboot automatically.\n\n"
-            "Download and flash now?",
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.Yes,
-        )
-        if reply != QMessageBox.Yes:
+        if _msgbox(QMessageBox.Question, "Update PolyKybd Firmware",
+                   f"A new firmware v{release.version} is available.\n\n"
+                   "The keyboard will update both halves over HID and reboot automatically.\n\n"
+                   "Download and flash now?",
+                   QMessageBox.Yes | QMessageBox.No, QMessageBox.Yes) != QMessageBox.Yes:
             return
         self._run_fw_up_downloader(release)
 
@@ -847,16 +855,7 @@ class PolyHost(QApplication):
             return
 
         self.firmware_update_action.setEnabled(False)
-        self._fw_up_progress = QProgressDialog(
-            "Connecting…", None, 0, 100, None,
-        )
-        self._fw_up_progress.setWindowTitle("Firmware Update — Downloading")
-        self._fw_up_progress.setWindowFlag(Qt.WindowStaysOnTopHint, True)
-        self._fw_up_progress.setMinimumDuration(0)
-        self._fw_up_progress.setAutoClose(False)
-        self._fw_up_progress.setCancelButton(None)
-        self._fw_up_progress.setValue(0)
-        self._fw_up_progress.show()
+        self._fw_up_progress = _progress_dlg("Connecting…", "Firmware Update — Downloading")
 
         self._fw_up_downloader = FwUpDownloader(release, parent=self)
         # noinspection PyUnresolvedReferences
@@ -879,8 +878,8 @@ class PolyHost(QApplication):
         if not ok:
             self.firmware_update_action.setEnabled(True)
             self.log.error("Firmware download failed: %s", error)
-            QMessageBox.warning(None, "Firmware Update Failed",
-                                f"Could not download the firmware:\n\n{error}")
+            _msgbox(QMessageBox.Warning, "Firmware Update Failed",
+                    f"Could not download the firmware:\n\n{error}")
             return
 
         import os

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -592,10 +592,10 @@ class PolyHost(QApplication):
         _error_seen = [False]
 
         def _on_error(msg):
-            _error_seen[0] = True
             self.log.warning("Update check error: %s", msg)
-            if on_check_error is not None:
+            if not _error_seen[0] and on_check_error is not None:
                 on_check_error(msg)
+            _error_seen[0] = True
 
         def _host_no_update():
             if _error_seen[0]:

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -738,7 +738,7 @@ class PolyHost(QApplication):
             popen_kwargs["creationflags"] = (
                 subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP
             )
-        subprocess.Popen([sys.executable, relay_path], **popen_kwargs)
+        subprocess.Popen([sys.executable, relay_path], **popen_kwargs)  # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit
         # Brief pause so the user sees the "Restarting" label before the window vanishes.
         QTimer.singleShot(1200, self.quit)
 

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -89,6 +89,18 @@ _UPD_DLG_W = 400
 _UPD_DLG_H = 160
 
 
+def _fmt_release_date(published_at: str) -> str:
+    """Return a human-readable date string from an ISO 8601 timestamp, or '' on failure."""
+    if not published_at:
+        return ""
+    try:
+        import datetime
+        dt = datetime.datetime.strptime(published_at[:10], "%Y-%m-%d")
+        return dt.strftime("%B %d, %Y").replace(" 0", " ")
+    except (ValueError, TypeError):
+        return ""
+
+
 def _msgbox(icon, title: str, text: str,
             buttons=QMessageBox.Ok, default=None) -> int:
     """QDialog-based message box so setFixedSize is reliably respected."""
@@ -778,8 +790,10 @@ class PolyHost(QApplication):
                 "Run with --debug 1 for details.")
 
     def _prompt_and_install(self, release):
+        date_str = _fmt_release_date(release.published_at)
+        info = f"Released: {date_str}\n" if date_str else ""
         if _msgbox(QMessageBox.Question, "Update PolyKybdHost",
-                   f"A new version v{release.version} is available.\n\n"
+                   f"Version {release.version} is available.\n{info}\n"
                    "Download, install, and restart now?",
                    QMessageBox.Yes | QMessageBox.No, QMessageBox.Yes) != QMessageBox.Yes:
             return
@@ -791,7 +805,8 @@ class PolyHost(QApplication):
             return
 
         self.update_action.setEnabled(False)
-        self._update_progress = _progress_dlg("Downloading update…", "PolyKybdHost Update")
+        self._update_progress = _progress_dlg(
+            f"Downloading v{release.version}…", "PolyKybdHost Update")
 
         self._update_installer = UpdateInstaller(release, parent=self)
         # noinspection PyUnresolvedReferences
@@ -912,9 +927,11 @@ class PolyHost(QApplication):
             _msgbox(QMessageBox.Warning, "Firmware Update",
                     "The keyboard must be connected to update the firmware.")
             return
+        date_str = _fmt_release_date(release.published_at)
+        info = f"Released: {date_str}\n" if date_str else ""
         if _msgbox(QMessageBox.Question, "Update PolyKybd Firmware",
-                   f"A new firmware v{release.version} is available.\n\n"
-                   "The keyboard will update both halves over HID and reboot automatically.\n\n"
+                   f"Firmware {release.version} is available.\n{info}\n"
+                   "Both halves update over HID and reboot automatically.\n\n"
                    "Download and flash now?",
                    QMessageBox.Yes | QMessageBox.No, QMessageBox.Yes) != QMessageBox.Yes:
             return
@@ -925,7 +942,8 @@ class PolyHost(QApplication):
             return
 
         self.firmware_update_action.setEnabled(False)
-        self._fw_up_progress = _progress_dlg("Connecting…", "Firmware Update — Downloading")
+        self._fw_up_progress = _progress_dlg(
+            f"Downloading firmware v{release.version}…", "Firmware Update")
 
         self._fw_up_downloader = FwUpDownloader(release, parent=self)
         # noinspection PyUnresolvedReferences

--- a/polyhost/services/updater.py
+++ b/polyhost/services/updater.py
@@ -63,8 +63,8 @@ EXCLUDES = (
 )
 
 
-ReleaseInfo   = namedtuple("ReleaseInfo",   ["tag", "version", "tarball_url", "html_url"])
-FwUpReleaseInfo = namedtuple("FwUpReleaseInfo", ["tag", "version", "bin_url", "uf2_url", "html_url"])
+ReleaseInfo   = namedtuple("ReleaseInfo",   ["tag", "version", "tarball_url", "html_url", "published_at"])
+FwUpReleaseInfo = namedtuple("FwUpReleaseInfo", ["tag", "version", "bin_url", "uf2_url", "html_url", "published_at"])
 
 
 class UpdateCheckError(RuntimeError):
@@ -123,6 +123,7 @@ def check_latest() -> Optional[ReleaseInfo]:
                     version=cached_ver,
                     tarball_url=host["tarball_url"],
                     html_url=host.get("html_url", ""),
+                    published_at=host.get("published_at", ""),
                 )
         except (KeyError, InvalidVersion) as e:
             log.warning("Corrupt ETag cache for host update — discarding: %s", e)
@@ -142,6 +143,7 @@ def check_latest() -> Optional[ReleaseInfo]:
         tag = data["tag_name"]
         tarball_url = data["tarball_url"]
         html_url = data.get("html_url", "")
+        published_at = data.get("published_at", "")
     except (ValueError, KeyError) as e:
         raise UpdateCheckError(f"Malformed GitHub response: {e}") from e
 
@@ -158,6 +160,7 @@ def check_latest() -> Optional[ReleaseInfo]:
         "version": str(latest),
         "tarball_url": tarball_url,
         "html_url": html_url,
+        "published_at": published_at,
     }
     _save_etag_cache(cache)
 
@@ -166,7 +169,8 @@ def check_latest() -> Optional[ReleaseInfo]:
         return None
 
     log.info("Update check: new version available: %s -> %s", __version__, latest)
-    return ReleaseInfo(tag=tag, version=str(latest), tarball_url=tarball_url, html_url=html_url)
+    return ReleaseInfo(tag=tag, version=str(latest), tarball_url=tarball_url,
+                       html_url=html_url, published_at=published_at)
 
 
 def check_fw_latest(current_version: str) -> Optional[FwUpReleaseInfo]:
@@ -206,6 +210,7 @@ def check_fw_latest(current_version: str) -> Optional[FwUpReleaseInfo]:
                     bin_url=fw["bin_url"],
                     uf2_url=fw.get("uf2_url", ""),
                     html_url=fw.get("html_url", ""),
+                    published_at=fw.get("published_at", ""),
                 )
         except (KeyError, InvalidVersion) as e:
             log.warning("Corrupt ETag cache for firmware update — discarding: %s", e)
@@ -225,6 +230,7 @@ def check_fw_latest(current_version: str) -> Optional[FwUpReleaseInfo]:
         tag = data["tag_name"]
         html_url = data.get("html_url", "")
         assets = data.get("assets", [])
+        published_at = data.get("published_at", "")
     except (ValueError, KeyError) as e:
         raise UpdateCheckError(f"Malformed GitHub response: {e}") from e
 
@@ -246,6 +252,7 @@ def check_fw_latest(current_version: str) -> Optional[FwUpReleaseInfo]:
         "bin_url": bin_url or "",
         "uf2_url": uf2_url or "",
         "html_url": html_url,
+        "published_at": published_at,
     }
     _save_etag_cache(cache)
 
@@ -259,7 +266,7 @@ def check_fw_latest(current_version: str) -> Optional[FwUpReleaseInfo]:
 
     log.info("Firmware update check: new version available: %s -> %s", current_version, latest)
     return FwUpReleaseInfo(tag=tag, version=str(latest), bin_url=bin_url,
-                           uf2_url=uf2_url or "", html_url=html_url)
+                           uf2_url=uf2_url or "", html_url=html_url, published_at=published_at)
 
 
 def _safe_extract(tar: tarfile.TarFile, dest: Path) -> None:

--- a/polyhost/services/updater.py
+++ b/polyhost/services/updater.py
@@ -40,6 +40,13 @@ ReleaseInfo   = namedtuple("ReleaseInfo",   ["tag", "version", "tarball_url", "h
 FwUpReleaseInfo = namedtuple("FwUpReleaseInfo", ["tag", "version", "bin_url", "uf2_url", "html_url"])
 
 
+class UpdateCheckError(RuntimeError):
+    """Raised when the GitHub releases API is unreachable or returns an unexpected response.
+
+    Distinct from returning None (which means "API succeeded but no newer version exists").
+    """
+
+
 class NotWritableError(RuntimeError):
     """Raised when the install directory cannot be modified (e.g. system site-packages)."""
 
@@ -57,7 +64,11 @@ def _current_version() -> Version:
 
 
 def check_latest() -> Optional[ReleaseInfo]:
-    """Return ReleaseInfo if GitHub's latest release is strictly newer; else None."""
+    """Return ReleaseInfo if GitHub's latest release is strictly newer; else None.
+
+    Raises UpdateCheckError if the API call fails (network error, non-200 response,
+    or malformed payload) so callers can distinguish "no update" from "check failed".
+    """
     try:
         resp = requests.get(
             GITHUB_API,
@@ -65,15 +76,12 @@ def check_latest() -> Optional[ReleaseInfo]:
             timeout=HTTP_TIMEOUT,
         )
     except requests.RequestException as e:
-        log.warning("Update check failed (network): %s", e)
-        return None
+        raise UpdateCheckError(f"Network error: {e}") from e
 
     if resp.status_code == 403:
-        log.warning("Update check rate-limited by GitHub (HTTP 403)")
-        return None
+        raise UpdateCheckError("GitHub rate limit reached — try again later")
     if resp.status_code != 200:
-        log.warning("Update check failed: HTTP %s", resp.status_code)
-        return None
+        raise UpdateCheckError(f"GitHub API returned HTTP {resp.status_code}")
 
     try:
         data = resp.json()
@@ -81,15 +89,13 @@ def check_latest() -> Optional[ReleaseInfo]:
         tarball_url = data["tarball_url"]
         html_url = data.get("html_url", "")
     except (ValueError, KeyError) as e:
-        log.warning("Update check: malformed release payload: %s", e)
-        return None
+        raise UpdateCheckError(f"Malformed GitHub response: {e}") from e
 
     version_str = tag.lstrip("vV")
     try:
         latest = Version(version_str)
     except InvalidVersion:
-        log.warning("Update check: tag %r is not a valid version", tag)
-        return None
+        raise UpdateCheckError(f"Release tag {tag!r} is not a valid version")
 
     if latest <= _current_version():
         log.debug("Update check: current %s is up-to-date (latest %s)", __version__, latest)
@@ -100,7 +106,11 @@ def check_latest() -> Optional[ReleaseInfo]:
 
 
 def check_fw_latest(current_version: str) -> Optional[FwUpReleaseInfo]:
-    """Return FwUpReleaseInfo if the latest firmware release is strictly newer; else None."""
+    """Return FwUpReleaseInfo if the latest firmware release is strictly newer; else None.
+
+    Raises UpdateCheckError on network/API failure.
+    Returns None for "up to date" or "release has no .bin asset".
+    """
     try:
         resp = requests.get(
             GITHUB_FW_API,
@@ -108,15 +118,12 @@ def check_fw_latest(current_version: str) -> Optional[FwUpReleaseInfo]:
             timeout=HTTP_TIMEOUT,
         )
     except requests.RequestException as e:
-        log.warning("Firmware update check failed (network): %s", e)
-        return None
+        raise UpdateCheckError(f"Network error: {e}") from e
 
     if resp.status_code == 403:
-        log.warning("Firmware update check rate-limited by GitHub (HTTP 403)")
-        return None
+        raise UpdateCheckError("GitHub rate limit reached — try again later")
     if resp.status_code != 200:
-        log.warning("Firmware update check failed: HTTP %s", resp.status_code)
-        return None
+        raise UpdateCheckError(f"GitHub API returned HTTP {resp.status_code}")
 
     try:
         data = resp.json()
@@ -124,15 +131,13 @@ def check_fw_latest(current_version: str) -> Optional[FwUpReleaseInfo]:
         html_url = data.get("html_url", "")
         assets = data.get("assets", [])
     except (ValueError, KeyError) as e:
-        log.warning("Firmware update check: malformed release payload: %s", e)
-        return None
+        raise UpdateCheckError(f"Malformed GitHub response: {e}") from e
 
     version_str = tag.lstrip("vV")
     try:
         latest = Version(version_str)
     except InvalidVersion:
-        log.warning("Firmware update check: tag %r is not a valid version", tag)
-        return None
+        raise UpdateCheckError(f"Release tag {tag!r} is not a valid version")
 
     try:
         current = Version(current_version.lstrip("vV"))
@@ -271,23 +276,31 @@ class UpdateChecker(QThread):
 
         try:
             host_release = check_latest()
+        except UpdateCheckError as e:
+            log.warning("Host update check failed: %s", e)
+            self.error.emit(str(e))
         except Exception as e:  # noqa: BLE001
             log.exception("Host update check crashed")
             self.error.emit(str(e))
 
-        if self._current_fw_version:
-            try:
-                fw_release = check_fw_latest(self._current_fw_version)
-            except Exception as e:  # noqa: BLE001
-                log.exception("Firmware update check crashed")
-                self.error.emit(str(e))
-
+        # Always emit host_no_update so the caller can reset its UI.  The error
+        # signal fires first when the check failed, letting callers distinguish
+        # "API/network error" from "genuinely no newer version".
         if host_release:
             self.update_available.emit(host_release)
         else:
             self.host_no_update.emit()
 
         if self._current_fw_version:
+            try:
+                fw_release = check_fw_latest(self._current_fw_version)
+            except UpdateCheckError as e:
+                log.warning("Firmware update check failed: %s", e)
+                self.error.emit(str(e))
+            except Exception as e:  # noqa: BLE001
+                log.exception("Firmware update check crashed")
+                self.error.emit(str(e))
+
             if fw_release:
                 self.fw_up_available.emit(fw_release)
             else:

--- a/polyhost/services/updater.py
+++ b/polyhost/services/updater.py
@@ -38,7 +38,13 @@ _ETAG_CACHE = Path(platformdirs.user_cache_dir("PolyKybdHost")) / "update_etags.
 
 def _load_etag_cache() -> dict:
     try:
-        return json.loads(_ETAG_CACHE.read_text(encoding="utf-8"))
+        data = json.loads(_ETAG_CACHE.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            raise ValueError("ETag cache root must be an object")
+        for key in ("host", "fw"):
+            if key in data and not isinstance(data[key], dict):
+                data.pop(key)
+        return data
     except (OSError, ValueError):
         return {}
 
@@ -332,10 +338,12 @@ def _run_pip(args: list, label: str, line_cb=None) -> None:
                     line_cb(line)
         proc.wait()
         if proc.returncode != 0:
-            log.warning("pip %s after update returned %d: %s",
-                        label, proc.returncode, "\n".join(captured[-20:])[-500:])
+            msg = (f"pip {label} after update returned {proc.returncode}: "
+                   f'{" ".join(captured[-20:])[-500:]}')
+            log.warning(msg)
+            raise RuntimeError(msg)
     except (subprocess.SubprocessError, OSError) as e:
-        log.warning("pip %s after update failed to run: %s", label, e)
+        raise RuntimeError(f"pip {label} after update failed to run: {e}") from e
 
 
 # On Windows the running process holds native DLLs (e.g. hidapi.dll) open,
@@ -347,12 +355,16 @@ def _run_pip(args: list, label: str, line_cb=None) -> None:
 _RELAY_SCRIPT_TEMPLATE = """\
 import shutil, subprocess, sys, time
 
-time.sleep(2)
 for src, dst in {pairs!r}:
-    try:
-        shutil.copy2(src, dst)
-    except Exception as e:
-        print(f"polyhost relay: {{e}}", file=sys.stderr)
+    for attempt in range(4):
+        try:
+            shutil.copy2(src, dst)
+            break
+        except Exception as e:
+            if attempt < 3:
+                time.sleep(2)
+            else:
+                print(f"polyhost relay: {{e}}", file=sys.stderr)
 
 subprocess.Popen({restart_args!r}, close_fds=False)
 shutil.rmtree({tmp_dir!r}, ignore_errors=True)
@@ -511,15 +523,20 @@ class UpdateInstaller(QThread):
             self.failed.emit(str(e))
             return
 
-        if locked:
-            relay_path = _write_relay_script(locked, tmp_dir)
-            log.info("Relay script written for %d locked file(s): %s", len(locked), relay_path)
-            # Do NOT clean up tmp_dir — relay script needs the source files and
-            # will delete the directory itself after copying them.
-            self.relay_needed.emit(str(relay_path))
-        else:
+        try:
+            if locked:
+                relay_path = _write_relay_script(locked, tmp_dir)
+                log.info("Relay script written for %d locked file(s): %s", len(locked), relay_path)
+                # Do NOT clean up tmp_dir — relay script needs the source files and
+                # will delete the directory itself after copying them.
+                self.relay_needed.emit(str(relay_path))
+            else:
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+                self.finished_ok.emit()
+        except Exception as e:  # noqa: BLE001
+            log.exception("Preparing relay install failed")
             shutil.rmtree(tmp_dir, ignore_errors=True)
-            self.finished_ok.emit()
+            self.failed.emit(str(e))
 
 
 class FwUpDownloader(QThread):

--- a/polyhost/services/updater.py
+++ b/polyhost/services/updater.py
@@ -287,14 +287,19 @@ def download_and_extract(tarball_url: str, tmpdir: Path,
         r.raise_for_status()
         total = int(r.headers.get("Content-Length") or 0)
         written = 0
+        _indeterminate_sent = False
         with open(archive, "wb") as fh:
             for chunk in r.iter_content(DOWNLOAD_CHUNK):
                 if not chunk:
                     continue
                 fh.write(chunk)
                 written += len(chunk)
-                if progress_cb and total:
-                    progress_cb(int(written * 100 / total))
+                if progress_cb:
+                    if total:
+                        progress_cb(int(written * 100 / total))
+                    elif not _indeterminate_sent:
+                        progress_cb(-1)  # signal: no Content-Length → indeterminate
+                        _indeterminate_sent = True
 
     extract_dir = tmpdir / "extracted"
     extract_dir.mkdir()

--- a/polyhost/services/updater.py
+++ b/polyhost/services/updater.py
@@ -310,23 +310,76 @@ def _run_pip(args: list, label: str) -> None:
         log.warning("pip %s after update failed to run: %s", label, e)
 
 
-def apply_update(extracted_dir: Path, install_root: Path) -> None:
+# On Windows the running process holds native DLLs (e.g. hidapi.dll) open,
+# so shutil.copy2 fails with WinError 32 when trying to overwrite them.
+# apply_update() collects those files and returns them; UpdateInstaller
+# writes this script to the temp dir, launches it detached, then quits.
+# The relay waits for the app to exit (releasing DLL handles), copies the
+# remaining files, relaunches, and cleans up.
+_RELAY_SCRIPT_TEMPLATE = """\
+import shutil, subprocess, sys, time
+
+time.sleep(2)
+for src, dst in {pairs!r}:
+    try:
+        shutil.copy2(src, dst)
+    except Exception as e:
+        print(f"polyhost relay: {{e}}", file=sys.stderr)
+
+subprocess.Popen({restart_args!r}, close_fds=False)
+shutil.rmtree({tmp_dir!r}, ignore_errors=True)
+"""
+
+
+def _write_relay_script(locked: list, tmp_dir: Path) -> Path:
+    """Write a detached relay script that copies locked files after app exit."""
+    restart_args = [sys.executable, "-m", "polyhost", *sys.argv[1:]]
+    script = tmp_dir / "_polyhost_relay.py"
+    script.write_text(
+        _RELAY_SCRIPT_TEMPLATE.format(
+            pairs=locked,
+            restart_args=restart_args,
+            tmp_dir=str(tmp_dir),
+        ),
+        encoding="utf-8",
+    )
+    return script
+
+
+def apply_update(extracted_dir: Path, install_root: Path) -> list:
     """Copy files from `extracted_dir` over `install_root`, then refresh deps.
 
-    Runs `pip install -e .` to pick up `setup.py` changes and, if a
-    `requirements.txt` is present, `pip install -r requirements.txt` so new
-    runtime deps declared only there are installed into the active venv.
+    On Windows, native DLLs locked by the running process are skipped and
+    returned as a list of ``(src, dst)`` string pairs for deferred copy via
+    a relay script.  On other platforms the list is always empty.
+
+    Runs ``pip install -e .`` to pick up ``setup.py`` changes and, if a
+    ``requirements.txt`` is present, ``pip install -r requirements.txt``.
     """
+    locked: list = []
+
+    def _copy2(src, dst):
+        try:
+            shutil.copy2(src, dst)
+        except OSError as e:
+            if sys.platform == "win32" and getattr(e, "winerror", None) == 32:
+                locked.append((str(src), str(dst)))
+                log.debug("Deferring locked file: %s", src)
+            else:
+                raise
+
     shutil.copytree(
         extracted_dir,
         install_root,
         dirs_exist_ok=True,
         ignore=shutil.ignore_patterns(*EXCLUDES),
+        copy_function=_copy2,
     )
     _run_pip(["install", "-e", str(install_root)], "install -e .")
     requirements = install_root / "requirements.txt"
     if requirements.is_file():
         _run_pip(["install", "-r", str(requirements)], "install -r requirements.txt")
+    return locked
 
 
 def restart_app() -> None:
@@ -393,9 +446,10 @@ class UpdateChecker(QThread):
 class UpdateInstaller(QThread):
     """Background thread that downloads, extracts, and applies an update."""
 
-    progress = pyqtSignal(int, str)
+    progress    = pyqtSignal(int, str)
     finished_ok = pyqtSignal()
-    failed = pyqtSignal(str)
+    relay_needed = pyqtSignal(str)  # path to relay script (Windows locked-file path)
+    failed      = pyqtSignal(str)
 
     def __init__(self, release: ReleaseInfo, parent=None):
         super().__init__(parent)
@@ -408,21 +462,32 @@ class UpdateInstaller(QThread):
             self.failed.emit(f"Install dir not writable: {e}")
             return
 
+        # Use mkdtemp (not TemporaryDirectory context manager) so that on Windows
+        # we can leave the directory alive for the relay script to consume.
+        tmp_dir = Path(tempfile.mkdtemp(prefix="polyhost-update-"))
         try:
-            with tempfile.TemporaryDirectory(prefix="polyhost-update-") as td:
-                tmp = Path(td)
-                self.progress.emit(0, "Downloading...")
-                extracted = download_and_extract(
-                    self.release.tarball_url, tmp,
-                    progress_cb=lambda pct: self.progress.emit(pct, "Downloading..."),
-                )
-                self.progress.emit(100, "Applying update...")
-                apply_update(extracted, install_root)
+            self.progress.emit(0, "Downloading...")
+            extracted = download_and_extract(
+                self.release.tarball_url, tmp_dir,
+                progress_cb=lambda pct: self.progress.emit(pct, "Downloading..."),
+            )
+            self.progress.emit(100, "Applying update...")
+            locked = apply_update(extracted, install_root)
         except Exception as e:  # noqa: BLE001
             log.exception("Update install failed")
+            shutil.rmtree(tmp_dir, ignore_errors=True)
             self.failed.emit(str(e))
             return
-        self.finished_ok.emit()
+
+        if locked:
+            relay_path = _write_relay_script(locked, tmp_dir)
+            log.info("Relay script written for %d locked file(s): %s", len(locked), relay_path)
+            # Do NOT clean up tmp_dir — relay script needs the source files and
+            # will delete the directory itself after copying them.
+            self.relay_needed.emit(str(relay_path))
+        else:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+            self.finished_ok.emit()
 
 
 class FwUpDownloader(QThread):

--- a/polyhost/services/updater.py
+++ b/polyhost/services/updater.py
@@ -257,7 +257,8 @@ class UpdateChecker(QThread):
 
     update_available = pyqtSignal(object)    # ReleaseInfo
     fw_up_available  = pyqtSignal(object)    # FwUpReleaseInfo
-    no_update        = pyqtSignal()          # neither host nor firmware has a new release
+    host_no_update   = pyqtSignal()          # host check found no newer release
+    fw_no_update     = pyqtSignal()          # firmware check found no newer release
     error            = pyqtSignal(str)
 
     def __init__(self, current_fw_version: str = None, parent=None):
@@ -283,10 +284,14 @@ class UpdateChecker(QThread):
 
         if host_release:
             self.update_available.emit(host_release)
-        if fw_release:
-            self.fw_up_available.emit(fw_release)
-        if not host_release and not fw_release:
-            self.no_update.emit()
+        else:
+            self.host_no_update.emit()
+
+        if self._current_fw_version:
+            if fw_release:
+                self.fw_up_available.emit(fw_release)
+            else:
+                self.fw_no_update.emit()
 
 
 class UpdateInstaller(QThread):

--- a/polyhost/services/updater.py
+++ b/polyhost/services/updater.py
@@ -107,16 +107,22 @@ def check_latest() -> Optional[ReleaseInfo]:
 
     if resp.status_code == 304:
         # Release unchanged since last check — re-evaluate against current version.
-        cached_ver = host.get("version")
-        if cached_ver and Version(cached_ver) > _current_version():
-            log.info("Update check (cached): new version available: %s -> %s",
-                     __version__, cached_ver)
-            return ReleaseInfo(
-                tag=host["tag"],
-                version=cached_ver,
-                tarball_url=host["tarball_url"],
-                html_url=host.get("html_url", ""),
-            )
+        try:
+            cached_ver = host.get("version")
+            if cached_ver and Version(cached_ver) > _current_version():
+                log.info("Update check (cached): new version available: %s -> %s",
+                         __version__, cached_ver)
+                return ReleaseInfo(
+                    tag=host["tag"],
+                    version=cached_ver,
+                    tarball_url=host["tarball_url"],
+                    html_url=host.get("html_url", ""),
+                )
+        except (KeyError, InvalidVersion) as e:
+            log.warning("Corrupt ETag cache for host update — discarding: %s", e)
+            cache.pop("host", None)
+            _save_etag_cache(cache)
+            return None
         log.debug("Update check (cached): current %s is up-to-date", __version__)
         return None
 
@@ -137,7 +143,7 @@ def check_latest() -> Optional[ReleaseInfo]:
     try:
         latest = Version(version_str)
     except InvalidVersion:
-        raise UpdateCheckError(f"Release tag {tag!r} is not a valid version")
+        raise UpdateCheckError(f"Release tag {tag!r} is not a valid version") from None
 
     # Persist the ETag and release info for future conditional requests.
     cache["host"] = {
@@ -183,17 +189,23 @@ def check_fw_latest(current_version: str) -> Optional[FwUpReleaseInfo]:
         raise UpdateCheckError(f"Network error: {e}") from e
 
     if resp.status_code == 304:
-        cached_ver = fw.get("version")
-        if cached_ver and Version(cached_ver) > current and fw.get("bin_url"):
-            log.info("Firmware update check (cached): new version available: %s -> %s",
-                     current_version, cached_ver)
-            return FwUpReleaseInfo(
-                tag=fw["tag"],
-                version=cached_ver,
-                bin_url=fw["bin_url"],
-                uf2_url=fw.get("uf2_url", ""),
-                html_url=fw.get("html_url", ""),
-            )
+        try:
+            cached_ver = fw.get("version")
+            if cached_ver and Version(cached_ver) > current and fw.get("bin_url"):
+                log.info("Firmware update check (cached): new version available: %s -> %s",
+                         current_version, cached_ver)
+                return FwUpReleaseInfo(
+                    tag=fw["tag"],
+                    version=cached_ver,
+                    bin_url=fw["bin_url"],
+                    uf2_url=fw.get("uf2_url", ""),
+                    html_url=fw.get("html_url", ""),
+                )
+        except (KeyError, InvalidVersion) as e:
+            log.warning("Corrupt ETag cache for firmware update — discarding: %s", e)
+            cache.pop("fw", None)
+            _save_etag_cache(cache)
+            return None
         log.debug("Firmware update check (cached): current %s is up-to-date", current_version)
         return None
 
@@ -214,7 +226,7 @@ def check_fw_latest(current_version: str) -> Optional[FwUpReleaseInfo]:
     try:
         latest = Version(version_str)
     except InvalidVersion:
-        raise UpdateCheckError(f"Release tag {tag!r} is not a valid version")
+        raise UpdateCheckError(f"Release tag {tag!r} is not a valid version") from None
 
     bin_url = next((a["browser_download_url"] for a in assets if a["name"].endswith(".bin")), None)
     uf2_url = next((a["browser_download_url"] for a in assets if a["name"].endswith(".uf2")), None)

--- a/polyhost/services/updater.py
+++ b/polyhost/services/updater.py
@@ -514,10 +514,10 @@ class UpdateInstaller(QThread):
         # we can leave the directory alive for the relay script to consume.
         tmp_dir = Path(tempfile.mkdtemp(prefix="polyhost-update-"))
         try:
-            self.progress.emit(0, "Downloading...")
+            self.progress.emit(0, "Starting download...")
             extracted = download_and_extract(
                 self.release.tarball_url, tmp_dir,
-                progress_cb=lambda pct: self.progress.emit(pct, "Downloading..."),
+                progress_cb=lambda pct: self.progress.emit(pct, f"Downloading v{self.release.version}..."),
             )
             self.progress.emit(-1, "Applying update...")
             locked = apply_update(

--- a/polyhost/services/updater.py
+++ b/polyhost/services/updater.py
@@ -4,6 +4,7 @@ Polls the GitHub releases API for a newer version, downloads the auto-generated
 source tarball, copies the files over the install directory, and triggers an
 in-process restart. Designed for source-from-checkout installs on Win/Mac/Linux.
 """
+import json
 import logging
 import os
 import shutil
@@ -15,6 +16,7 @@ from collections import namedtuple
 from pathlib import Path
 from typing import Optional
 
+import platformdirs
 import requests
 from PyQt5.QtCore import QThread, pyqtSignal
 from packaging.version import InvalidVersion, Version
@@ -28,6 +30,25 @@ GITHUB_API    = "https://api.github.com/repos/thpoll83/PolyKybdHost/releases/lat
 GITHUB_FW_API = "https://api.github.com/repos/thpoll83/qmk_firmware/releases/latest"
 USER_AGENT = f"PolyKybdHost/{__version__}"
 HTTP_TIMEOUT = 5
+
+# Persists ETag values across restarts so conditional requests (If-None-Match)
+# return 304 Not Modified without counting against GitHub's rate limit.
+_ETAG_CACHE = Path(platformdirs.user_cache_dir("PolyKybdHost")) / "update_etags.json"
+
+
+def _load_etag_cache() -> dict:
+    try:
+        return json.loads(_ETAG_CACHE.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+
+
+def _save_etag_cache(data: dict) -> None:
+    try:
+        _ETAG_CACHE.parent.mkdir(parents=True, exist_ok=True)
+        _ETAG_CACHE.write_text(json.dumps(data), encoding="utf-8")
+    except OSError as e:
+        log.debug("Could not save update ETag cache: %s", e)
 DOWNLOAD_CHUNK = 64 * 1024
 
 EXCLUDES = (
@@ -66,17 +87,38 @@ def _current_version() -> Version:
 def check_latest() -> Optional[ReleaseInfo]:
     """Return ReleaseInfo if GitHub's latest release is strictly newer; else None.
 
-    Raises UpdateCheckError if the API call fails (network error, non-200 response,
-    or malformed payload) so callers can distinguish "no update" from "check failed".
+    Uses ETag caching: conditional requests that receive 304 Not Modified do not
+    count against GitHub's anonymous rate limit (60 req/hour per IP).
+
+    Raises UpdateCheckError on network/API failure so callers can distinguish
+    "check failed" from "no update available".
     """
+    cache = _load_etag_cache()
+    host = cache.get("host", {})
+
+    headers = {"User-Agent": USER_AGENT, "Accept": "application/vnd.github+json"}
+    if etag := host.get("etag"):
+        headers["If-None-Match"] = etag
+
     try:
-        resp = requests.get(
-            GITHUB_API,
-            headers={"User-Agent": USER_AGENT, "Accept": "application/vnd.github+json"},
-            timeout=HTTP_TIMEOUT,
-        )
+        resp = requests.get(GITHUB_API, headers=headers, timeout=HTTP_TIMEOUT)
     except requests.RequestException as e:
         raise UpdateCheckError(f"Network error: {e}") from e
+
+    if resp.status_code == 304:
+        # Release unchanged since last check — re-evaluate against current version.
+        cached_ver = host.get("version")
+        if cached_ver and Version(cached_ver) > _current_version():
+            log.info("Update check (cached): new version available: %s -> %s",
+                     __version__, cached_ver)
+            return ReleaseInfo(
+                tag=host["tag"],
+                version=cached_ver,
+                tarball_url=host["tarball_url"],
+                html_url=host.get("html_url", ""),
+            )
+        log.debug("Update check (cached): current %s is up-to-date", __version__)
+        return None
 
     if resp.status_code == 403:
         raise UpdateCheckError("GitHub rate limit reached — try again later")
@@ -97,6 +139,16 @@ def check_latest() -> Optional[ReleaseInfo]:
     except InvalidVersion:
         raise UpdateCheckError(f"Release tag {tag!r} is not a valid version")
 
+    # Persist the ETag and release info for future conditional requests.
+    cache["host"] = {
+        "etag": resp.headers.get("ETag", ""),
+        "tag": tag,
+        "version": str(latest),
+        "tarball_url": tarball_url,
+        "html_url": html_url,
+    }
+    _save_etag_cache(cache)
+
     if latest <= _current_version():
         log.debug("Update check: current %s is up-to-date (latest %s)", __version__, latest)
         return None
@@ -108,17 +160,42 @@ def check_latest() -> Optional[ReleaseInfo]:
 def check_fw_latest(current_version: str) -> Optional[FwUpReleaseInfo]:
     """Return FwUpReleaseInfo if the latest firmware release is strictly newer; else None.
 
+    Uses ETag caching — 304 Not Modified responses don't count against the rate limit.
     Raises UpdateCheckError on network/API failure.
     Returns None for "up to date" or "release has no .bin asset".
     """
     try:
-        resp = requests.get(
-            GITHUB_FW_API,
-            headers={"User-Agent": USER_AGENT, "Accept": "application/vnd.github+json"},
-            timeout=HTTP_TIMEOUT,
-        )
+        current = Version(current_version.lstrip("vV"))
+    except InvalidVersion:
+        log.warning("Firmware update check: current version %r not parseable", current_version)
+        return None
+
+    cache = _load_etag_cache()
+    fw = cache.get("fw", {})
+
+    headers = {"User-Agent": USER_AGENT, "Accept": "application/vnd.github+json"}
+    if etag := fw.get("etag"):
+        headers["If-None-Match"] = etag
+
+    try:
+        resp = requests.get(GITHUB_FW_API, headers=headers, timeout=HTTP_TIMEOUT)
     except requests.RequestException as e:
         raise UpdateCheckError(f"Network error: {e}") from e
+
+    if resp.status_code == 304:
+        cached_ver = fw.get("version")
+        if cached_ver and Version(cached_ver) > current and fw.get("bin_url"):
+            log.info("Firmware update check (cached): new version available: %s -> %s",
+                     current_version, cached_ver)
+            return FwUpReleaseInfo(
+                tag=fw["tag"],
+                version=cached_ver,
+                bin_url=fw["bin_url"],
+                uf2_url=fw.get("uf2_url", ""),
+                html_url=fw.get("html_url", ""),
+            )
+        log.debug("Firmware update check (cached): current %s is up-to-date", current_version)
+        return None
 
     if resp.status_code == 403:
         raise UpdateCheckError("GitHub rate limit reached — try again later")
@@ -139,18 +216,24 @@ def check_fw_latest(current_version: str) -> Optional[FwUpReleaseInfo]:
     except InvalidVersion:
         raise UpdateCheckError(f"Release tag {tag!r} is not a valid version")
 
-    try:
-        current = Version(current_version.lstrip("vV"))
-    except InvalidVersion:
-        log.warning("Firmware update check: current version %r not parseable", current_version)
-        return None
+    bin_url = next((a["browser_download_url"] for a in assets if a["name"].endswith(".bin")), None)
+    uf2_url = next((a["browser_download_url"] for a in assets if a["name"].endswith(".uf2")), None)
+
+    # Cache ETag and asset URLs regardless of whether an update is available,
+    # so future checks can use conditional requests.
+    cache["fw"] = {
+        "etag": resp.headers.get("ETag", ""),
+        "tag": tag,
+        "version": str(latest),
+        "bin_url": bin_url or "",
+        "uf2_url": uf2_url or "",
+        "html_url": html_url,
+    }
+    _save_etag_cache(cache)
 
     if latest <= current:
         log.debug("Firmware update check: current %s is up-to-date (latest %s)", current_version, latest)
         return None
-
-    bin_url = next((a["browser_download_url"] for a in assets if a["name"].endswith(".bin")), None)
-    uf2_url = next((a["browser_download_url"] for a in assets if a["name"].endswith(".uf2")), None)
 
     if not bin_url:
         log.warning("Firmware update check: release %s has no .bin asset — skipping", tag)

--- a/polyhost/services/updater.py
+++ b/polyhost/services/updater.py
@@ -488,7 +488,7 @@ class UpdateInstaller(QThread):
                 self.release.tarball_url, tmp_dir,
                 progress_cb=lambda pct: self.progress.emit(pct, "Downloading..."),
             )
-            self.progress.emit(100, "Applying update...")
+            self.progress.emit(-1, "Applying update...")
             locked = apply_update(extracted, install_root)
         except Exception as e:  # noqa: BLE001
             log.exception("Update install failed")

--- a/polyhost/services/updater.py
+++ b/polyhost/services/updater.py
@@ -312,17 +312,28 @@ def download_and_extract(tarball_url: str, tmpdir: Path,
     return children[0]
 
 
-def _run_pip(args: list, label: str) -> None:
-    """Run `pip <args>` in the active interpreter; log on non-zero exit."""
+def _run_pip(args: list, label: str, line_cb=None) -> None:
+    """Run `pip <args>` in the active interpreter; log on non-zero exit.
+
+    Streams stdout+stderr line by line.  Each non-empty line is passed to
+    ``line_cb(line)`` when provided, so callers can surface it as UI feedback.
+    """
     try:
-        result = subprocess.run(
+        proc = subprocess.Popen(
             [sys.executable, "-m", "pip", *args],
-            check=False, capture_output=True, text=True, timeout=300,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
         )
-        if result.returncode != 0:
-            details = (result.stderr or "").strip() or (result.stdout or "").strip()
+        captured = []
+        for raw in proc.stdout:
+            line = raw.rstrip()
+            if line:
+                captured.append(line)
+                if line_cb:
+                    line_cb(line)
+        proc.wait()
+        if proc.returncode != 0:
             log.warning("pip %s after update returned %d: %s",
-                        label, result.returncode, details[-500:])
+                        label, proc.returncode, "\n".join(captured[-20:])[-500:])
     except (subprocess.SubprocessError, OSError) as e:
         log.warning("pip %s after update failed to run: %s", label, e)
 
@@ -363,7 +374,7 @@ def _write_relay_script(locked: list, tmp_dir: Path) -> Path:
     return script
 
 
-def apply_update(extracted_dir: Path, install_root: Path) -> list:
+def apply_update(extracted_dir: Path, install_root: Path, line_cb=None) -> list:
     """Copy files from `extracted_dir` over `install_root`, then refresh deps.
 
     On Windows, native DLLs locked by the running process are skipped and
@@ -372,6 +383,7 @@ def apply_update(extracted_dir: Path, install_root: Path) -> list:
 
     Runs ``pip install -e .`` to pick up ``setup.py`` changes and, if a
     ``requirements.txt`` is present, ``pip install -r requirements.txt``.
+    ``line_cb``, when provided, is called with each non-empty pip output line.
     """
     locked: list = []
 
@@ -392,10 +404,10 @@ def apply_update(extracted_dir: Path, install_root: Path) -> list:
         ignore=shutil.ignore_patterns(*EXCLUDES),
         copy_function=_copy2,
     )
-    _run_pip(["install", "-e", str(install_root)], "install -e .")
+    _run_pip(["install", "-e", str(install_root)], "install -e .", line_cb)
     requirements = install_root / "requirements.txt"
     if requirements.is_file():
-        _run_pip(["install", "-r", str(requirements)], "install -r requirements.txt")
+        _run_pip(["install", "-r", str(requirements)], "install -r requirements.txt", line_cb)
     return locked
 
 
@@ -489,7 +501,10 @@ class UpdateInstaller(QThread):
                 progress_cb=lambda pct: self.progress.emit(pct, "Downloading..."),
             )
             self.progress.emit(-1, "Applying update...")
-            locked = apply_update(extracted, install_root)
+            locked = apply_update(
+                extracted, install_root,
+                line_cb=lambda line: self.progress.emit(-1, line),
+            )
         except Exception as e:  # noqa: BLE001
             log.exception("Update install failed")
             shutil.rmtree(tmp_dir, ignore_errors=True)


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Follow-up fixes to the update mechanism introduced in #25, addressing real-world issues found during testing.

- **Error visibility**: `check_latest()` / `check_fw_latest()` now raise `UpdateCheckError` on API/network failure instead of silently returning `None`. Manual "Check for updates" shows a dialog with the actual reason ("GitHub rate limit reached — try again later") instead of the misleading "You are running the latest version."

- **ETag caching**: Both update checks send `If-None-Match` on every request after the first successful one. A `304 Not Modified` response re-evaluates the cached release locally without consuming any rate-limit quota (GitHub does not count 304s). Cache persisted to `~/.cache/PolyKybdHost/update_etags.json`.

- **Double error dialog**: When both host and firmware checks fail (same rate-limit event), `error` was emitted twice → two dialogs. Fixed by only calling `on_check_error` on the first emission.

- **Windows locked DLL** (`hidapi.dll`): `shutil.copytree` fails with `WinError 32` because the running process holds the DLL open. `apply_update()` now uses a custom `copy_function` that skips locked files and returns them. `UpdateInstaller` writes a relay script to the temp dir, launches it detached (`DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP`), then quits. The relay waits 2 s for handles to release, copies the remaining files, relaunches the app, and cleans up.

- **Firmware update menu entry**: Previously hidden until an update was auto-detected. Now always visible as "Check for firmware update…", enabled when the keyboard is connected — mirrors the host "Check for updates…" entry. Also fixed a pre-existing bug where clicking it passed the firmware "no update" handler as the *host* check's `on_no_update` callback, showing "firmware is up to date" before the firmware check had even run.

## Test plan

- [ ] Trigger "Check for updates" while rate-limited → see error dialog (not "latest version")
- [ ] Trigger again after first successful check → 304 response, no rate-limit impact
- [ ] Trigger both host + firmware check while rate-limited → single error dialog, not two
- [ ] Run update on Windows → relay script handles `hidapi.dll`, app restarts cleanly
- [ ] "Check for firmware update…" is always visible in tray menu when keyboard connected
- [ ] Click it with no pending update → check runs, "latest firmware" dialog appears
- [ ] Click it while rate-limited → error dialog, button resets to "Check for firmware update…"

https://claude.ai/code/session_01KdiiJunbnUYKP84NDuix6j
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdiiJunbnUYKP84NDuix6j)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clickable tray update notifications that start pending installs; firmware action shows live "Checking…" status and schedules immediate background checks after reconnect.
  * Restart-required updates spawn a detached background helper to finish installation after quit; progress supports indeterminate mode.

* **Bug Fixes**
  * Clearer separation of check errors vs “no update”; manual-check UI restores on error.
  * Better handling of locked files on Windows so installs complete reliably.

* **Chores**
  * Cached, conditional release checks to reduce network traffic; release workflow tagging refined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->