### PR TITLE
fix(host): pause polling loop during auto-update firmware flash &amp; apply

### DIFF
--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -971,10 +971,23 @@ class PolyHost(QApplication):
             return
 
         import os
+        # Pause the device-polling loop for the whole flash + apply.  Otherwise the
+        # periodic reconnect() (active_window_reporter) keeps re-acquiring the HID
+        # device on the main thread while the flash worker is staging chunks and,
+        # crucially, while the keyboard reboots to apply — the loop grabs the
+        # re-enumerating device out from under the worker's wait_for_reconnect(),
+        # corrupting the transfer and dropping the link.  The manual Flash+Apply
+        # path (cmd_menu.open_hid_fw_up_dialog) already does this; the auto path
+        # must too.  pause() is a toggle, so only flip it when not already paused.
+        was_paused = self.paused
+        if not was_paused:
+            self.pause()
         try:
             dlg = HidFwUpDialog(self.keeb.hid, bin_path, parent=None, apply_after=True)
             dlg.exec_()
         finally:
+            if not was_paused:
+                self.pause()   # toggle back to resume polling
             if os.path.exists(bin_path):
                 os.unlink(bin_path)
 


### PR DESCRIPTION
## Summary

The **auto** firmware-update path ("Update firmware to v…" from the tray) failed to flash and **dropped the keyboard connection**, even though flashing the *exact same* `.bin` via the manual **Flash + Apply** menu works. Root cause is a host-side concurrency bug, not the firmware or the download.

## Root cause

Both paths open the same modal `HidFwUpDialog` (`apply_after=True`) and run the same `flash_firmware` on a worker thread. The difference:

| | Manual `cmd_menu.open_hid_fw_up_dialog` | Auto `host._on_fw_download_done` |
|---|---|---|
| Pauses the polling loop | ✅ `with self._paused_polling():` | ❌ missing |

A modal `exec_()` still runs Qt's event loop, so the `active_window_reporter` `QTimer` keeps firing during the flash. Its periodic `reconnect()` (`host.py:1032`) re-acquires the HID device on the main thread. When the keyboard **reboots to apply** the staged image, that `reconnect()` grabs the re-enumerating device out from under the flash worker's `wait_for_reconnect()` — corrupting the transfer and dropping the link. The manual path avoids this by pausing the loop; the auto path didn't.

## Fix

Bracket the auto flash + apply with the same pause/resume the manual path already uses (`host._on_fw_download_done`):

```python
was_paused = self.paused
if not was_paused:
    self.pause()
try:
    dlg = HidFwUpDialog(self.keeb.hid, bin_path, parent=None, apply_after=True)
    dlg.exec_()
finally:
    if not was_paused:
        self.pause()      # resume polling
    if os.path.exists(bin_path):
        os.unlink(bin_path)
```

`pause()` is a toggle, so it's only flipped when the loop wasn't already paused, and the prior state is restored on exit (including on error).

## Testing

- Full suite green — **339 tests pass** (`unittest discover`), including the `hid_fw_up` and `updater` modules.
- `host.py` compiles; the change is isolated to one method and mirrors the already-proven manual path.
- Hardware: the manual Flash + Apply path (same dialog, same `flash_firmware`) is confirmed working by the reporter; this makes the auto path take the identical, paused route.

---
_Generated by [Claude Code](https://claude.ai/code/session_017HHu9G18rzzMuHSCrJtGzE)_