### PR TITLE
tools: KLE-driven keycap demo renderer + emoji-layer GIF

### DIFF
--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,3 @@
+# Generated demo artifacts (regenerate with emoji_demo.py)
+out/
+assets/fonts/

--- a/tools/README.md
+++ b/tools/README.md
@@ -10,30 +10,32 @@ keycap should show.
 
 | File | Role |
 |------|------|
-| `kle_render.py` | Reusable renderer. Reuses `polyhost.kle.kle_praser.parse_kle`, lays out the keyboard (rotated thumb cluster included), and draws each key as a dark cap with a 72×40 monochrome "OLED". Per-frame API is `{matrix_pos: KeyContent}`; `save_gif()` writes the animation. |
+| `kle_render.py` | Reusable renderer. Reuses `polyhost.kle.kle_praser.parse_kle` (note: the module file really is spelled `kle_praser.py`), lays out the keyboard (rotated thumb cluster included), and draws each key as a dark cap with a 72×40 monochrome "OLED". Per-frame API is `{matrix_pos: KeyContent}`; `save_gif()` writes the animation. |
+| `gfx_font.py` | Pixel-exact glyph rendering from the firmware's generated Adafruit-GFX headers (`base/fonts/`), reproducing `kdisp_write_gfx_char`/`text`. Used by `--font-mode gfx` (the default). |
 | `emoji_demo.py` | Data-driven driver for the emoji layer. Pulls geometry + roles + glyphs straight from the firmware so the demo always matches the keyboard. |
-| `dl-demo-fonts.sh` | Downloads the mono Noto Emoji + Symbols2 fonts the renderer uses. |
+| `dl-demo-fonts.sh` | Downloads the mono Noto Emoji + Symbols2 fonts (only needed for `--font-mode ttf`). |
 
 ## Setup
 
 ```bash
 python -m venv .venv
-.venv/bin/pip install Pillow fonttools
-./tools/dl-demo-fonts.sh            # → ~/.cache/emojigif/fonts
+.venv/bin/pip install -r tools/requirements.txt   # Pillow + fontTools
+./tools/dl-demo-fonts.sh                           # only for --font-mode ttf
 ```
 
 ## Run
 
 ```bash
-.venv/bin/python tools/emoji_demo.py                   # → tools/out/emoji_layer.gif
-.venv/bin/python tools/emoji_demo.py --unit 96 --still # bigger, plus a still PNG
-.venv/bin/python tools/emoji_demo.py --no-bezel --scale 0.8 --out /tmp/e.gif
+.venv/bin/python tools/emoji_demo.py                   # → tools/out/emoji_layer.gif (gfx mode)
+.venv/bin/python tools/emoji_demo.py --still --max-pages 3   # quicker, plus a still PNG
+.venv/bin/python tools/emoji_demo.py --font-mode ttf --no-bezel --out /tmp/e.gif
 .venv/bin/python tools/emoji_demo.py --qmk /path/to/qmk_firmware
 ```
 
-The frame plan (linger → sweep every tab → page through the first category so the
-◀ / ▶ arrows light up) is a short list near the bottom of `emoji_demo.py:main()`
-— retime it or point it at a different "hero" category there.
+The frame plan (open on the first tab → sweep every tab, cycling through each
+tab's pages with a press-blink on the tabs and `‹ ›` arrows) is a short list near
+the bottom of `emoji_demo.py:main()` — retime (`--settle`, `--max-pages`) or
+re-point it there.
 
 ## How the emoji demo stays in sync with the firmware
 
@@ -63,11 +65,14 @@ r.save_gif([frame], "out.gif", durations=800)
 
 `KeyContent(glyph=…, label=…, frame='cap'|'bar', dim=…, selected=…, blank=…)`.
 
-## Fidelity note
+## Rendering modes (`--font-mode`)
 
-Glyphs are rendered from Noto Emoji (monochrome) and 1-bit dithered — a faithful
-*approximation* of the keycaps, not the exact pixel fonts the firmware ships. For
-pixel-exact output the same `KeyContent` path could blit the real generated GFX
-bitmaps instead.
+- **`gfx` (default)** — pixel-exact: glyphs are blitted from the firmware's
+  generated Adafruit-GFX pixel-font headers (`gfx_font.py`), at their native
+  size/baseline and via the same `ALL_FONTS` lookup the keyboard uses, so the
+  output matches the device exactly (real `ICON_LEFT`/`ICON_RIGHT` arrows
+  included). Needs only a `qmk_firmware` checkout — no font download.
+- **`ttf`** — live Noto Emoji (monochrome), 1-bit dithered and scaled to fit:
+  a faithful *approximation*, not pixel-identical. Needs `dl-demo-fonts.sh`.
 
 `out/` and `assets/fonts/` are generated and git-ignored.

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,73 @@
+# tools — keycap demo renderer
+
+Render promo images / animated GIFs of the PolyKybd per-keycap OLEDs, laid out
+from the **same KLE file the layout editor uses**
+(`polyhost/res/polykybd-split72.json`). The first consumer is an emoji-layer
+walk-through, but the renderer is generic — you tell it, per frame, what each
+keycap should show.
+
+## Files
+
+| File | Role |
+|------|------|
+| `kle_render.py` | Reusable renderer. Reuses `polyhost.kle.kle_praser.parse_kle`, lays out the keyboard (rotated thumb cluster included), and draws each key as a dark cap with a 72×40 monochrome "OLED". Per-frame API is `{matrix_pos: KeyContent}`; `save_gif()` writes the animation. |
+| `emoji_demo.py` | Data-driven driver for the emoji layer. Pulls geometry + roles + glyphs straight from the firmware so the demo always matches the keyboard. |
+| `dl-demo-fonts.sh` | Downloads the mono Noto Emoji + Symbols2 fonts the renderer uses. |
+
+## Setup
+
+```bash
+python -m venv .venv
+.venv/bin/pip install Pillow fonttools
+./tools/dl-demo-fonts.sh            # → ~/.cache/emojigif/fonts
+```
+
+## Run
+
+```bash
+.venv/bin/python tools/emoji_demo.py                   # → tools/out/emoji_layer.gif
+.venv/bin/python tools/emoji_demo.py --unit 96 --still # bigger, plus a still PNG
+.venv/bin/python tools/emoji_demo.py --no-bezel --scale 0.8 --out /tmp/e.gif
+.venv/bin/python tools/emoji_demo.py --qmk /path/to/qmk_firmware
+```
+
+The frame plan (linger → sweep every tab → page through the first category so the
+◀ / ▶ arrows light up) is a short list near the bottom of `emoji_demo.py:main()`
+— retime it or point it at a different "hero" category there.
+
+## How the emoji demo stays in sync with the firmware
+
+`emoji_demo.py` reads, from the `--qmk` checkout:
+
+- `split72/keyboard.json` — arg-index → matrix (`LAYOUT_left_right_stacked`)
+- `split72/keymaps/default/keymap.c` — the `[_EMJ]` layer → matrix → key role
+  (category tab / emoji slot / page arrow / unused)
+- `keyboards/handwired/polykybd/emoji/emoji_data.h` — codepoints per category
+- `.../emoji/emoji_layer.c` — `emj_tab_icons[]`
+
+So re-ordering categories, adding emojis, or remapping keys is picked up
+automatically — nothing in this tool is hand-maintained.
+
+## Reusing the renderer
+
+`kle_render.py` knows nothing about emojis. To animate any other layer or idea,
+build your own `{matrix_pos: KeyContent}` dicts:
+
+```python
+from kle_render import KleRenderer, KeyContent, GlyphRenderer
+r = KleRenderer(json.load(open("polyhost/res/polykybd-split72.json")),
+                glyphs=GlyphRenderer([("NotoEmoji.ttf", "mono")]))
+frame = {"0,1": KeyContent(glyph="A"), "0,2": KeyContent(glyph="😀", frame="cap")}
+r.save_gif([frame], "out.gif", durations=800)
+```
+
+`KeyContent(glyph=…, label=…, frame='cap'|'bar', dim=…, selected=…, blank=…)`.
+
+## Fidelity note
+
+Glyphs are rendered from Noto Emoji (monochrome) and 1-bit dithered — a faithful
+*approximation* of the keycaps, not the exact pixel fonts the firmware ships. For
+pixel-exact output the same `KeyContent` path could blit the real generated GFX
+bitmaps instead.
+
+`out/` and `assets/fonts/` are generated and git-ignored.

--- a/tools/dl-demo-fonts.sh
+++ b/tools/dl-demo-fonts.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Fetch the fonts the emoji-layer demo renders with.
+#
+#   * NotoEmoji        - monochrome (scalable) emoji, the primary glyph source
+#   * NotoSansSymbols2 - extra symbols / dingbats / arrows fallback
+#
+# DejaVu Sans and NotoColorEmoji are used as further fallbacks if present on the
+# system, so they are not downloaded here.
+#
+# Default target matches emoji_demo.py's --fontdir default (~/.cache/emojigif/fonts);
+# pass a directory as $1 to override.
+set -e
+
+DEST="${1:-$HOME/.cache/emojigif/fonts}"
+BASE="https://raw.githubusercontent.com/google/fonts/main/ofl"
+mkdir -p "$DEST"
+
+fetch() {
+    local url="$1" out="$2"
+    if [ -f "$out" ]; then echo "  skip  $out"; return; fi
+    echo "  fetch $out"
+    if command -v curl &>/dev/null; then curl -fsSL "$url" -o "$out"; else wget -q "$url" -O "$out"; fi
+}
+
+fetch "$BASE/notoemoji/NotoEmoji%5Bwght%5D.ttf"                 "$DEST/NotoEmoji.ttf"
+fetch "$BASE/notosanssymbols2/NotoSansSymbols2-Regular.ttf"     "$DEST/NotoSansSymbols2.ttf"
+
+echo "Fonts ready in $DEST"

--- a/tools/emoji_demo.py
+++ b/tools/emoji_demo.py
@@ -83,9 +83,12 @@ def _split_args(inner: str) -> list[str]:
 def parse_emj_layer_roles(keymap_c: str) -> list[tuple[str, int | None]]:
     """arg index -> (role, n) for the [_EMJ] layer."""
     text = strip_c_comments(open(keymap_c, encoding='utf-8').read())
-    i = text.index('[_EMJ]')
-    k = text.index('(', text.index(LAYOUT_NAME, i))
-    depth = 0
+    try:
+        i = text.index('[_EMJ]')
+        k = text.index('(', text.index(LAYOUT_NAME, i))
+    except ValueError as exc:
+        raise SystemExit(f"could not locate [_EMJ] / {LAYOUT_NAME} in {keymap_c}") from exc
+    depth, end = 0, None
     for m in range(k, len(text)):
         if text[m] == '(':
             depth += 1
@@ -94,6 +97,8 @@ def parse_emj_layer_roles(keymap_c: str) -> list[tuple[str, int | None]]:
             if depth == 0:
                 end = m
                 break
+    if end is None:
+        raise SystemExit(f"unbalanced {LAYOUT_NAME} parentheses in {keymap_c}")
     roles = []
     for tok in _split_args(text[k + 1:end]):
         if tok == 'KC_EMJ_PAGE_PREV':
@@ -189,6 +194,8 @@ def main():
     matrix_roles = dict(zip(matrices, roles))
     cats = parse_categories(emoji_data_h)
     icons = parse_tab_icons(emoji_layer_c)
+    if not cats:
+        raise SystemExit(f"no emoji categories parsed from {emoji_data_h}")
     print(f"  {len(cats)} categories, sizes={[len(c) for c in cats]}")
     print(f"  tabs={sum(1 for r in roles if r[0]=='tab')} slots={sum(1 for r in roles if r[0]=='slot')}")
 
@@ -215,8 +222,12 @@ def main():
 
     # Reverse lookups: which physical key is each tab / page arrow.
     tab_mx = {n: mp for mp, (role, n) in matrix_roles.items() if role == 'tab'}
-    prev_mx = next(mp for mp, (role, _) in matrix_roles.items() if role == 'prev')
-    next_mx = next(mp for mp, (role, _) in matrix_roles.items() if role == 'next')
+    prev_mx = next((mp for mp, (role, _) in matrix_roles.items() if role == 'prev'), None)
+    next_mx = next((mp for mp, (role, _) in matrix_roles.items() if role == 'next'), None)
+    missing = [i for i in range(len(cats)) if i not in tab_mx]
+    if missing or prev_mx is None or next_mx is None:
+        raise SystemExit(f"emoji role mapping incomplete: missing tabs={missing}, "
+                         f"prev={prev_mx is not None}, next={next_mx is not None}")
 
     FLASH, SETTLE, HOLD = 90, args.settle, args.settle + 500   # ms — flash is the quick press blink
 

--- a/tools/emoji_demo.py
+++ b/tools/emoji_demo.py
@@ -29,11 +29,12 @@ import re
 from dataclasses import replace
 
 from kle_render import GlyphRenderer, KeyContent, KleRenderer
+from gfx_font import GfxGlyphRenderer
 
-# Page-nav arrows. The firmware uses custom icon-font glyphs (ICON_LEFT/RIGHT);
-# here we use clean chevrons so they read as "prev / next page", not play buttons.
-ARROW_PREV, ARROW_NEXT = '‹', '›'   # ‹ ›
-ARROW_SCALE = 0.5                    # render the arrows small, not filling the cap
+# Page-nav arrows. 'gfx' mode draws the firmware's real ICON_LEFT/RIGHT
+# (codepoints 0x83/0x84 in IconsFont); 'ttf' mode falls back to chevrons.
+ARROW_PREV, ARROW_NEXT = '', ''
+ARROW_SCALE = 0.5                    # only used in ttf mode (gfx draws native size)
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 HOST_REPO = os.path.dirname(HERE)
@@ -165,7 +166,11 @@ def main():
     ap.add_argument('--settle', type=int, default=1500, help='ms each page is held')
     ap.add_argument('--max-pages', type=int, default=0,
                     help='cap pages shown per category (0 = all)')
-    ap.add_argument('--fontdir', default=os.path.join(HOME, '.cache', 'emojigif', 'fonts'))
+    ap.add_argument('--fontdir', default=os.path.join(HOME, '.cache', 'emojigif', 'fonts'),
+                    help='TTF fonts dir (ttf mode only)')
+    ap.add_argument('--font-mode', choices=['gfx', 'ttf'], default='gfx',
+                    help='gfx = pixel-exact from the generated GFX headers (default); '
+                         'ttf = live Noto render, scaled to fit')
     ap.add_argument('--still', action='store_true', help='also write a still PNG of frame 0')
     ap.add_argument('--no-bezel', action='store_true')
     args = ap.parse_args()
@@ -187,16 +192,24 @@ def main():
     print(f"  {len(cats)} categories, sizes={[len(c) for c in cats]}")
     print(f"  tabs={sum(1 for r in roles if r[0]=='tab')} slots={sum(1 for r in roles if r[0]=='slot')}")
 
-    font_chain = [
-        (os.path.join(args.fontdir, 'NotoEmoji.ttf'), 'mono'),
-        (os.path.join(args.fontdir, 'NotoSansSymbols2.ttf'), 'mono'),
-        ('/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf', 'mono'),
-        ('/usr/share/fonts/truetype/noto/NotoColorEmoji.ttf', 'color'),
-    ]
-    glyphs = GlyphRenderer(font_chain)
+    global ARROW_PREV, ARROW_NEXT
+    if args.font_mode == 'gfx':
+        glyphs = GfxGlyphRenderer(os.path.join(pk, 'base', 'fonts'))
+        ARROW_PREV, ARROW_NEXT = chr(0x83), chr(0x84)   # real ICON_LEFT / ICON_RIGHT
+        print(f"  gfx: {len(glyphs.fonts)} fonts in ALL_FONTS (pixel-exact)")
+    else:
+        font_chain = [
+            (os.path.join(args.fontdir, 'NotoEmoji.ttf'), 'mono'),
+            (os.path.join(args.fontdir, 'NotoSansSymbols2.ttf'), 'mono'),
+            ('/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf', 'mono'),
+            ('/usr/share/fonts/truetype/noto/NotoColorEmoji.ttf', 'color'),
+        ]
+        glyphs = GlyphRenderer(font_chain)
+        ARROW_PREV, ARROW_NEXT = '‹', '›'
     renderer = KleRenderer(json.load(open(args.kle, encoding='utf-8')),
                            unit=args.unit, glyphs=glyphs, bezel=not args.no_bezel,
-                           margin=args.margin, exclude=exclude)
+                           margin=args.margin, exclude=exclude,
+                           dither=(args.font_mode == 'ttf'))
     # Slide the halves together (left = matrix rows 0-4, right = 5-9).
     renderer.compact_halves(lambda mp: 'L' if int(mp.split(',')[0]) < 5 else 'R', gap_px=args.gap)
 

--- a/tools/emoji_demo.py
+++ b/tools/emoji_demo.py
@@ -33,6 +33,7 @@ from kle_render import GlyphRenderer, KeyContent, KleRenderer
 # Page-nav arrows. The firmware uses custom icon-font glyphs (ICON_LEFT/RIGHT);
 # here we use clean chevrons so they read as "prev / next page", not play buttons.
 ARROW_PREV, ARROW_NEXT = '‹', '›'   # ‹ ›
+ARROW_SCALE = 0.5                    # render the arrows small, not filling the cap
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 HOST_REPO = os.path.dirname(HERE)
@@ -132,10 +133,12 @@ def build_state(matrix_roles, cats, icons, cat: int, page: int) -> dict[str, Key
             out[mp] = KeyContent(glyph=chr(cp) if cp else None,
                                  frame='cap' if n == cat else 'bar')
         elif role == 'prev':
-            out[mp] = KeyContent(glyph=ARROW_PREV if page > 0 else None, blank=(page == 0))
+            out[mp] = KeyContent(glyph=ARROW_PREV if page > 0 else None,
+                                 blank=(page == 0), scale=ARROW_SCALE)
         elif role == 'next':
             has = page + 1 < pages
-            out[mp] = KeyContent(glyph=ARROW_NEXT if has else None, blank=not has)
+            out[mp] = KeyContent(glyph=ARROW_NEXT if has else None,
+                                 blank=not has, scale=ARROW_SCALE)
         elif role == 'slot':
             idx = page * SLOTS_PER_PAGE + n
             cp = cats[cat][idx] if idx < len(cats[cat]) else None
@@ -156,8 +159,12 @@ def main():
     ap.add_argument('--scale', type=float, default=1.0, help='final GIF scale factor')
     ap.add_argument('--margin', type=int, default=5, help='outer margin in px')
     ap.add_argument('--gap', type=int, default=10, help='gap between the two halves in px')
-    ap.add_argument('--exclude', default='8,0',
-                    help='semicolon-separated matrix positions with no display, e.g. "8,0" (the encoder)')
+    ap.add_argument('--exclude', default='3,7;8,0',
+                    help='semicolon-separated matrix positions with no display '
+                         '(the left & right rotary encoders: "3,7" and "8,0")')
+    ap.add_argument('--settle', type=int, default=1500, help='ms each page is held')
+    ap.add_argument('--max-pages', type=int, default=0,
+                    help='cap pages shown per category (0 = all)')
     ap.add_argument('--fontdir', default=os.path.join(HOME, '.cache', 'emojigif', 'fonts'))
     ap.add_argument('--still', action='store_true', help='also write a still PNG of frame 0')
     ap.add_argument('--no-bezel', action='store_true')
@@ -198,7 +205,7 @@ def main():
     prev_mx = next(mp for mp, (role, _) in matrix_roles.items() if role == 'prev')
     next_mx = next(mp for mp, (role, _) in matrix_roles.items() if role == 'next')
 
-    FLASH, SETTLE, HOLD = 90, 720, 1100   # ms — flash is the quick key-press blink
+    FLASH, SETTLE, HOLD = 90, args.settle, args.settle + 500   # ms — flash is the quick press blink
 
     frames, durations = [], []
 
@@ -213,19 +220,21 @@ def main():
             s[flash] = replace(s[flash], invert=True, frame=None if is_tab else s[flash].frame)
         return s
 
-    # 1) open on Smileys
-    add(st(0, 0), HOLD)
-    # 2) sweep every tab — each press blinks the tab, then it settles with the ∩ cap
-    for c in range(1, len(cats)):
-        add(st(c, 0, flash=tab_mx[c], is_tab=True), FLASH)
-        add(st(c, 0), SETTLE)
-    # 3) back to Smileys, then page back and forth so the ‹ / › arrows blink on press
-    add(st(0, 0, flash=tab_mx[0], is_tab=True), FLASH)
-    add(st(0, 0), 600)
-    add(st(0, 0, flash=next_mx), FLASH); add(st(0, 1), SETTLE)   # press › on page 0 → page 1
-    add(st(0, 1, flash=next_mx), FLASH); add(st(0, 2), SETTLE)   # press › on page 1 → page 2
-    add(st(0, 2, flash=prev_mx), FLASH); add(st(0, 1), SETTLE)   # press ‹ on page 2 → page 1
-    add(st(0, 1, flash=prev_mx), FLASH); add(st(0, 0), SETTLE)   # press ‹ on page 1 → page 0
+    def page_count(cat):
+        n = max(1, math.ceil(len(cats[cat]) / SLOTS_PER_PAGE)) if cats[cat] else 1
+        return min(n, args.max_pages) if args.max_pages else n
+
+    # For each tab: press it, then cycle through every page (› blinks on each
+    # advance) before moving on to the next tab.
+    for ci in range(len(cats)):
+        if ci == 0:
+            add(st(0, 0), HOLD)                                    # open on Smileys
+        else:
+            add(st(ci, 0, flash=tab_mx[ci], is_tab=True), FLASH)   # press the tab
+            add(st(ci, 0), SETTLE)
+        for pg in range(1, page_count(ci)):
+            add(st(ci, pg - 1, flash=next_mx), FLASH)              # press › on the current page
+            add(st(ci, pg), SETTLE)                                # settle on the next page
 
     if args.still:
         png = os.path.splitext(args.out)[0] + '_still.png'

--- a/tools/emoji_demo.py
+++ b/tools/emoji_demo.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Render an animated GIF of the PolyKybd emoji layer for the website / Ko-fi.
+
+It is fully data-driven from the firmware sources, so the demo always matches
+what the keyboard actually does:
+
+  * KLE geometry          polyhost/res/polykybd-split72.json   (the editor's file)
+  * arg-index -> matrix    split72/keyboard.json  (LAYOUT_left_right_stacked)
+  * matrix  -> key role    split72/keymaps/default/keymap.c  ([_EMJ] layer)
+  * category codepoints    keyboards/.../emoji/emoji_data.h
+  * tab icons              keyboards/.../emoji/emoji_layer.c  (emj_tab_icons[])
+
+The frame sequence walks every category tab (active tab gets the ∩ border, the
+rest a bottom bar, exactly like emj_draw_tab_*), then demonstrates page paging
+on the first category so the ◀ / ▶ arrows light up.
+
+Usage:
+    python tools/emoji_demo.py                       # writes tools/out/emoji_layer.gif
+    python tools/emoji_demo.py --out /tmp/e.gif --unit 80 --still
+    python tools/emoji_demo.py --qmk /path/to/qmk_firmware
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+
+from kle_render import GlyphRenderer, KeyContent, KleRenderer
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+HOST_REPO = os.path.dirname(HERE)
+HOME = os.path.dirname(HOST_REPO)
+
+SLOTS_PER_PAGE = 50   # split72 (see emoji_layer.h EMJ_SLOTS_PER_PAGE)
+LAYOUT_NAME = "LAYOUT_left_right_stacked"
+
+CAT_NAMES = [
+    "Smileys & Faces", "Gestures & Body", "People & Jobs", "Love & Celebrations",
+    "Animals", "Nature, Plants & Food", "Weather & Sky", "Travel & Places",
+    "Sports & Entertainment", "Tools & Objects", "Symbols & Marks",
+    "Latin Extended-A & B",
+]
+
+
+def strip_c_comments(s: str) -> str:
+    s = re.sub(r'/\*.*?\*/', '', s, flags=re.S)
+    s = re.sub(r'//[^\n]*', '', s)
+    return s
+
+
+def parse_layout_matrix(keyboard_json: str) -> list[str]:
+    """arg index -> 'row,col' from keyboard.json."""
+    d = json.load(open(keyboard_json, encoding='utf-8'))
+    lay = d['layouts'][LAYOUT_NAME]['layout']
+    return [f"{k['matrix'][0]},{k['matrix'][1]}" for k in lay]
+
+
+def _split_args(inner: str) -> list[str]:
+    args, depth, cur = [], 0, ''
+    for ch in inner:
+        if ch == '(':
+            depth += 1; cur += ch
+        elif ch == ')':
+            depth -= 1; cur += ch
+        elif ch == ',' and depth == 0:
+            args.append(cur.strip()); cur = ''
+        else:
+            cur += ch
+    if cur.strip():
+        args.append(cur.strip())
+    return args
+
+
+def parse_emj_layer_roles(keymap_c: str) -> list[tuple[str, int | None]]:
+    """arg index -> (role, n) for the [_EMJ] layer."""
+    text = strip_c_comments(open(keymap_c, encoding='utf-8').read())
+    i = text.index('[_EMJ]')
+    k = text.index('(', text.index(LAYOUT_NAME, i))
+    depth = 0
+    for m in range(k, len(text)):
+        if text[m] == '(':
+            depth += 1
+        elif text[m] == ')':
+            depth -= 1
+            if depth == 0:
+                end = m
+                break
+    roles = []
+    for tok in _split_args(text[k + 1:end]):
+        if tok == 'KC_EMJ_PAGE_PREV':
+            roles.append(('prev', None))
+        elif tok == 'KC_EMJ_PAGE_NEXT':
+            roles.append(('next', None))
+        elif (mm := re.match(r'KC_EMJ_CAT\(\s*(\d+)\s*\)', tok)):
+            roles.append(('tab', int(mm.group(1))))
+        elif (mm := re.match(r'ESLOT\(\s*(\d+)\s*\)', tok)):
+            roles.append(('slot', int(mm.group(1))))
+        else:
+            roles.append(('none', None))
+    return roles
+
+
+def parse_categories(emoji_data_h: str) -> list[list[int]]:
+    text = strip_c_comments(open(emoji_data_h, encoding='utf-8').read())
+    cats: dict[int, list[int]] = {}
+    for m in re.finditer(r'emj_cat(\d+)\s*\[\]\s*=\s*\{(.*?)\}\s*;', text, re.S):
+        n = int(m.group(1))
+        cats[n] = [int(x, 16) for x in re.findall(r'0x[0-9A-Fa-f]+', m.group(2))]
+    return [cats[i] for i in sorted(cats)]
+
+
+def parse_tab_icons(emoji_layer_c: str) -> list[int]:
+    text = strip_c_comments(open(emoji_layer_c, encoding='utf-8').read())
+    m = re.search(r'emj_tab_icons\s*\[\]\s*=\s*\{(.*?)\}\s*;', text, re.S)
+    return [int(x, 16) for x in re.findall(r'0x[0-9A-Fa-f]+', m.group(1))] if m else []
+
+
+def build_state(matrix_roles, cats, icons, cat: int, page: int) -> dict[str, KeyContent]:
+    """One frame: {matrix_pos: KeyContent} for the given (category, page)."""
+    pages = max(1, math.ceil(len(cats[cat]) / SLOTS_PER_PAGE)) if cats[cat] else 1
+    out: dict[str, KeyContent] = {}
+    for mp, (role, n) in matrix_roles.items():
+        if role == 'tab':
+            cp = icons[n] if n < len(icons) and icons[n] else (cats[n][0] if n < len(cats) and cats[n] else 0)
+            out[mp] = KeyContent(glyph=chr(cp) if cp else None,
+                                 frame='cap' if n == cat else 'bar')
+        elif role == 'prev':
+            out[mp] = KeyContent(glyph='◀' if page > 0 else None, blank=(page == 0))
+        elif role == 'next':
+            has = page + 1 < pages
+            out[mp] = KeyContent(glyph='▶' if has else None, blank=not has)
+        elif role == 'slot':
+            idx = page * SLOTS_PER_PAGE + n
+            cp = cats[cat][idx] if idx < len(cats[cat]) else None
+            out[mp] = KeyContent(glyph=chr(cp) if cp else None, blank=(cp is None))
+        else:
+            out[mp] = KeyContent(dim=True)
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--qmk', default=os.path.join(HOME, 'qmk_firmware'),
+                    help='path to the qmk_firmware checkout')
+    ap.add_argument('--kle', default=os.path.join(HOST_REPO, 'polyhost', 'res', 'polykybd-split72.json'))
+    ap.add_argument('--out', default=os.path.join(HERE, 'out', 'emoji_layer.gif'))
+    ap.add_argument('--unit', type=int, default=72, help='pixels per key unit')
+    ap.add_argument('--scale', type=float, default=1.0, help='final GIF scale factor')
+    ap.add_argument('--fontdir', default=os.path.join(HOME, '.cache', 'emojigif', 'fonts'))
+    ap.add_argument('--still', action='store_true', help='also write a still PNG of frame 0')
+    ap.add_argument('--no-bezel', action='store_true')
+    args = ap.parse_args()
+
+    pk = os.path.join(args.qmk, 'keyboards', 'handwired', 'polykybd')
+    keyboard_json = os.path.join(pk, 'split72', 'keyboard.json')
+    keymap_c = os.path.join(pk, 'split72', 'keymaps', 'default', 'keymap.c')
+    emoji_data_h = os.path.join(pk, 'emoji', 'emoji_data.h')
+    emoji_layer_c = os.path.join(pk, 'emoji', 'emoji_layer.c')
+
+    matrices = parse_layout_matrix(keyboard_json)
+    roles = parse_emj_layer_roles(keymap_c)
+    if len(matrices) != len(roles):
+        raise SystemExit(f"layout/keymap length mismatch: {len(matrices)} vs {len(roles)}")
+    matrix_roles = dict(zip(matrices, roles))
+    cats = parse_categories(emoji_data_h)
+    icons = parse_tab_icons(emoji_layer_c)
+    print(f"  {len(cats)} categories, sizes={[len(c) for c in cats]}")
+    print(f"  tabs={sum(1 for r in roles if r[0]=='tab')} slots={sum(1 for r in roles if r[0]=='slot')}")
+
+    font_chain = [
+        (os.path.join(args.fontdir, 'NotoEmoji.ttf'), 'mono'),
+        (os.path.join(args.fontdir, 'NotoSansSymbols2.ttf'), 'mono'),
+        ('/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf', 'mono'),
+        ('/usr/share/fonts/truetype/noto/NotoColorEmoji.ttf', 'color'),
+    ]
+    glyphs = GlyphRenderer(font_chain)
+    renderer = KleRenderer(json.load(open(args.kle, encoding='utf-8')),
+                           unit=args.unit, glyphs=glyphs, bezel=not args.no_bezel)
+
+    # Frame plan: linger on the first tab, sweep every tab, then page through
+    # the first category so the ◀ / ▶ arrows appear.
+    plan = [(0, 0, 1300)]
+    plan += [(c, 0, 780) for c in range(1, len(cats))]
+    plan += [(0, 0, 700), (0, 1, 820), (0, 2, 820), (0, 1, 700)]
+
+    frames = [build_state(matrix_roles, cats, icons, c, p) for (c, p, _) in plan]
+    durations = [d for (_, _, d) in plan]
+
+    if args.still:
+        png = os.path.splitext(args.out)[0] + '_still.png'
+        os.makedirs(os.path.dirname(os.path.abspath(png)), exist_ok=True)
+        renderer.render_frame(frames[0]).save(png)
+        print(f"  wrote {png}")
+
+    out = renderer.save_gif(frames, args.out, durations, loop=0, scale=args.scale)
+    sz = os.path.getsize(out)
+    print(f"  wrote {out}  ({len(frames)} frames, {sz/1024:.0f} KB, {renderer.cw}x{renderer.ch})")
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/emoji_demo.py
+++ b/tools/emoji_demo.py
@@ -26,8 +26,13 @@ import json
 import math
 import os
 import re
+from dataclasses import replace
 
 from kle_render import GlyphRenderer, KeyContent, KleRenderer
+
+# Page-nav arrows. The firmware uses custom icon-font glyphs (ICON_LEFT/RIGHT);
+# here we use clean chevrons so they read as "prev / next page", not play buttons.
+ARROW_PREV, ARROW_NEXT = '‹', '›'   # ‹ ›
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 HOST_REPO = os.path.dirname(HERE)
@@ -127,10 +132,10 @@ def build_state(matrix_roles, cats, icons, cat: int, page: int) -> dict[str, Key
             out[mp] = KeyContent(glyph=chr(cp) if cp else None,
                                  frame='cap' if n == cat else 'bar')
         elif role == 'prev':
-            out[mp] = KeyContent(glyph='◀' if page > 0 else None, blank=(page == 0))
+            out[mp] = KeyContent(glyph=ARROW_PREV if page > 0 else None, blank=(page == 0))
         elif role == 'next':
             has = page + 1 < pages
-            out[mp] = KeyContent(glyph='▶' if has else None, blank=not has)
+            out[mp] = KeyContent(glyph=ARROW_NEXT if has else None, blank=not has)
         elif role == 'slot':
             idx = page * SLOTS_PER_PAGE + n
             cp = cats[cat][idx] if idx < len(cats[cat]) else None
@@ -149,10 +154,15 @@ def main():
     ap.add_argument('--out', default=os.path.join(HERE, 'out', 'emoji_layer.gif'))
     ap.add_argument('--unit', type=int, default=72, help='pixels per key unit')
     ap.add_argument('--scale', type=float, default=1.0, help='final GIF scale factor')
+    ap.add_argument('--margin', type=int, default=5, help='outer margin in px')
+    ap.add_argument('--gap', type=int, default=10, help='gap between the two halves in px')
+    ap.add_argument('--exclude', default='8,0',
+                    help='semicolon-separated matrix positions with no display, e.g. "8,0" (the encoder)')
     ap.add_argument('--fontdir', default=os.path.join(HOME, '.cache', 'emojigif', 'fonts'))
     ap.add_argument('--still', action='store_true', help='also write a still PNG of frame 0')
     ap.add_argument('--no-bezel', action='store_true')
     args = ap.parse_args()
+    exclude = {m.strip() for m in args.exclude.split(';') if m.strip()}
 
     pk = os.path.join(args.qmk, 'keyboards', 'handwired', 'polykybd')
     keyboard_json = os.path.join(pk, 'split72', 'keyboard.json')
@@ -178,16 +188,44 @@ def main():
     ]
     glyphs = GlyphRenderer(font_chain)
     renderer = KleRenderer(json.load(open(args.kle, encoding='utf-8')),
-                           unit=args.unit, glyphs=glyphs, bezel=not args.no_bezel)
+                           unit=args.unit, glyphs=glyphs, bezel=not args.no_bezel,
+                           margin=args.margin, exclude=exclude)
+    # Slide the halves together (left = matrix rows 0-4, right = 5-9).
+    renderer.compact_halves(lambda mp: 'L' if int(mp.split(',')[0]) < 5 else 'R', gap_px=args.gap)
 
-    # Frame plan: linger on the first tab, sweep every tab, then page through
-    # the first category so the ◀ / ▶ arrows appear.
-    plan = [(0, 0, 1300)]
-    plan += [(c, 0, 780) for c in range(1, len(cats))]
-    plan += [(0, 0, 700), (0, 1, 820), (0, 2, 820), (0, 1, 700)]
+    # Reverse lookups: which physical key is each tab / page arrow.
+    tab_mx = {n: mp for mp, (role, n) in matrix_roles.items() if role == 'tab'}
+    prev_mx = next(mp for mp, (role, _) in matrix_roles.items() if role == 'prev')
+    next_mx = next(mp for mp, (role, _) in matrix_roles.items() if role == 'next')
 
-    frames = [build_state(matrix_roles, cats, icons, c, p) for (c, p, _) in plan]
-    durations = [d for (_, _, d) in plan]
+    FLASH, SETTLE, HOLD = 90, 720, 1100   # ms — flash is the quick key-press blink
+
+    frames, durations = [], []
+
+    def add(state, dur):
+        frames.append(state); durations.append(dur)
+
+    def st(cat, page, flash=None, is_tab=False):
+        """A (cat, page) frame, optionally with one key inverted to fake a key-press."""
+        s = build_state(matrix_roles, cats, icons, cat, page)
+        if flash is not None:
+            # During the press blink: invert the key; a tab drops its ∩ cap for that frame.
+            s[flash] = replace(s[flash], invert=True, frame=None if is_tab else s[flash].frame)
+        return s
+
+    # 1) open on Smileys
+    add(st(0, 0), HOLD)
+    # 2) sweep every tab — each press blinks the tab, then it settles with the ∩ cap
+    for c in range(1, len(cats)):
+        add(st(c, 0, flash=tab_mx[c], is_tab=True), FLASH)
+        add(st(c, 0), SETTLE)
+    # 3) back to Smileys, then page back and forth so the ‹ / › arrows blink on press
+    add(st(0, 0, flash=tab_mx[0], is_tab=True), FLASH)
+    add(st(0, 0), 600)
+    add(st(0, 0, flash=next_mx), FLASH); add(st(0, 1), SETTLE)   # press › on page 0 → page 1
+    add(st(0, 1, flash=next_mx), FLASH); add(st(0, 2), SETTLE)   # press › on page 1 → page 2
+    add(st(0, 2, flash=prev_mx), FLASH); add(st(0, 1), SETTLE)   # press ‹ on page 2 → page 1
+    add(st(0, 1, flash=prev_mx), FLASH); add(st(0, 0), SETTLE)   # press ‹ on page 1 → page 0
 
     if args.still:
         png = os.path.splitext(args.out)[0] + '_still.png'

--- a/tools/gfx_font.py
+++ b/tools/gfx_font.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Render glyphs exactly like the PolyKybd firmware does — from the generated
+Adafruit-GFX pixel-font headers, not a live TTF.
+
+This reproduces ``kdisp_write_gfx_char`` / ``kdisp_write_gfx_text``
+(``base/disp_array.c``): pick the first ``ALL_FONTS`` entry whose 32-bit
+``[first,last]`` covers the codepoint, take the native 1-bit glyph bitmap, and
+blit it at ``(BUFFER_X + xOffset, baseline + yOffset)`` into the 72x40 visible
+window. Result: a keycap rendered with the same pixels, sizes and positions the
+hardware draws — including the real ICON_LEFT/RIGHT page arrows.
+"""
+from __future__ import annotations
+
+import glob
+import os
+import re
+from dataclasses import dataclass
+
+from PIL import Image
+
+# Visible OLED window and the firmware's text origin (base/disp_array.{h,c}).
+OLED_W, OLED_H = 72, 40
+BUFFER_X = 28          # (128-buffer − 72-visible) / 2  → buffer x 28 == visible x 0
+BASELINE = 23          # the y passed to kdisp_write_gfx_text for keycap glyphs
+EMOJI_PREFIX = "  "    # make_emoji_str(): two leading spaces before the glyph
+
+
+@dataclass
+class GfxFont:
+    name: str
+    bitmap: bytes
+    glyphs: list           # list of dict(bitmapOffset,width,height,xAdvance,xOffset,yOffset)
+    first: int
+    last: int
+    yAdvance: int
+
+
+def _parse_header(text: str, bitmaps: dict, glyph_arrays: dict, fonts: dict) -> None:
+    # Bitmap arrays — strip /* ... */ first (range comments contain 4-digit hex).
+    for m in re.finditer(r'const\s+uint8_t\s+(\w+)\s*\[\]\s*PROGMEM\s*=\s*\{(.*?)\};', text, re.S):
+        body = re.sub(r'/\*.*?\*/', '', m.group(2), flags=re.S)
+        bitmaps[m.group(1)] = bytes(int(b, 16) for b in re.findall(r'0x([0-9A-Fa-f]{2})', body))
+    # Glyph arrays — {bitmapOffset,width,height,xAdvance,xOffset,yOffset}, signed.
+    for m in re.finditer(r'const\s+GFXglyph\s+(\w+)\s*\[\]\s*(?:PROGMEM\s*)?=\s*\{(.*?)\};', text, re.S):
+        body = re.sub(r'//[^\n]*', '', m.group(2))
+        arr = []
+        for g in re.finditer(r'\{\s*(-?\d+)\s*,\s*(-?\d+)\s*,\s*(-?\d+)\s*,\s*(-?\d+)\s*,\s*(-?\d+)\s*,\s*(-?\d+)\s*\}', body):
+            v = list(map(int, g.groups()))
+            arr.append(dict(bitmapOffset=v[0], width=v[1], height=v[2],
+                            xAdvance=v[3], xOffset=v[4], yOffset=v[5]))
+        glyph_arrays[m.group(1)] = arr
+    # Font structs.
+    for m in re.finditer(r'const\s+GFXfont\s+(\w+)\s+PROGMEM\s*=\s*\{(.*?)\};', text, re.S):
+        parts = [p.strip() for p in re.sub(r'//[^\n]*', '', m.group(2)).split(',')]
+        bmp = re.findall(r'\w+', parts[0])[-1]
+        gly = re.findall(r'\w+', parts[1])[-1]
+        fonts[m.group(1)] = dict(name=m.group(1), bmp=bmp, gly=gly,
+                                 first=int(parts[2], 0), last=int(parts[3], 0),
+                                 yAdvance=int(parts[4], 0))
+
+
+def load_all_fonts(font_dir: str) -> list[GfxFont]:
+    """Parse every header under ``font_dir`` (+ generated/) and return the fonts
+    in ``ALL_FONTS[]`` priority order (the exact list the firmware links)."""
+    bitmaps: dict = {}
+    glyph_arrays: dict = {}
+    raw_fonts: dict = {}
+    paths = sorted(glob.glob(os.path.join(font_dir, '*.h')) +
+                   glob.glob(os.path.join(font_dir, 'generated', '*.h')))
+    for p in paths:
+        _parse_header(open(p, encoding='utf-8', errors='replace').read(),
+                      bitmaps, glyph_arrays, raw_fonts)
+
+    used = os.path.join(font_dir, 'gfx_used_fonts.h')
+    order = re.search(r'ALL_FONTS\s*\[\]\s*=\s*\{(.*?)\};',
+                      open(used, encoding='utf-8').read(), re.S)
+    names = re.findall(r'&\s*(\w+)', order.group(1)) if order else list(raw_fonts)
+
+    out = []
+    for n in names:
+        f = raw_fonts.get(n)
+        if not f or f['bmp'] not in bitmaps or f['gly'] not in glyph_arrays:
+            continue
+        out.append(GfxFont(n, bitmaps[f['bmp']], glyph_arrays[f['gly']],
+                           f['first'], f['last'], f['yAdvance']))
+    return out
+
+
+class GfxGlyphRenderer:
+    """Drop-in for kle_render.GlyphRenderer, but pixel-exact from the GFX headers.
+    ``render(ch)`` returns the 72x40 'L' OLED for make_emoji_str(ch) = "  "+ch."""
+
+    def __init__(self, font_dir: str):
+        self.fonts = load_all_fonts(font_dir)
+        if not self.fonts:
+            raise RuntimeError(f"no GFX fonts parsed from {font_dir}")
+        self.base_yadv = self.fonts[0].yAdvance     # fonts[0] == IconsFont
+        self._cache: dict[str, Image.Image] = {}
+
+    def _font_for(self, cp: int):
+        for f in self.fonts:
+            if f.first <= cp <= f.last:
+                return f
+        return None
+
+    def _blit(self, px, cp: int, x_cursor: int) -> int:
+        f = self._font_for(cp)
+        if f is None:                       # firmware falls back to fonts[0] '!'
+            f = self.fonts[0]
+            cp = ord('!')
+            if not (f.first <= cp <= f.last):
+                return x_cursor
+        g = f.glyphs[cp - f.first]
+        y = BASELINE + (f.yAdvance - self.base_yadv)
+        bo, bit, bits = g['bitmapOffset'], 0, 0
+        for yy in range(g['height']):
+            for xx in range(g['width']):
+                if (bit & 7) == 0:
+                    bits = f.bitmap[bo]; bo += 1
+                if bits & 0x80:
+                    vx = x_cursor + g['xOffset'] + xx - BUFFER_X
+                    vy = y + g['yOffset'] + yy
+                    if 0 <= vx < OLED_W and 0 <= vy < OLED_H:
+                        px[vx, vy] = 255
+                bits = (bits << 1) & 0xFF
+                bit += 1
+        return x_cursor + g['xAdvance']
+
+    def render(self, ch: str, scale: float = 1.0) -> Image.Image:
+        # `scale` is accepted for interface parity but ignored — the hardware
+        # draws every glyph at its native size; that's the whole point.
+        if ch in self._cache:
+            return self._cache[ch]
+        img = Image.new('L', (OLED_W, OLED_H), 0)
+        px = img.load()
+        x = BUFFER_X
+        for c in EMOJI_PREFIX + ch:
+            x = self._blit(px, ord(c), x)
+        self._cache[ch] = img
+        return img

--- a/tools/kle_render.py
+++ b/tools/kle_render.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Reusable KLE-driven keyboard renderer.
+
+Lays out a keyboard from a www.keyboard-layout-editor.com JSON (the same file
+``polyhost``'s layout editor uses) and renders frames where you decide, per
+physical key, what its little OLED keycap should display.  A list of frames can
+be written straight to an animated GIF.
+
+It is deliberately decoupled from any one keyboard or layer: feed it a KLE file
+plus, per frame, a ``{matrix_pos: KeyContent}`` mapping and it produces an image.
+See ``emoji_demo.py`` for a concrete driver (the emoji layer walk-through).
+
+Key geometry is taken from the KLE exactly like the editor does — including the
+rotated thumb cluster (``r``/``rx``/``ry``).  Glyphs are rendered the way the
+real hardware shows them: scaled into a 72x40 monochrome buffer and drawn white
+on a dark "OLED" rectangle, so the output reads like the actual keycaps.
+
+Dependencies: Pillow, fontTools.
+"""
+from __future__ import annotations
+
+import math
+import os
+from dataclasses import dataclass, field
+from typing import Iterable
+
+from PIL import Image, ImageDraw, ImageFont
+
+# Reuse the *exact* parser the PolyHost layout editor uses, so geometry never
+# drifts from the app.  Fall back to an inline copy if run outside the repo.
+try:  # pragma: no cover - import shim
+    import sys
+    _REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    if _REPO not in sys.path:
+        sys.path.insert(0, _REPO)
+    from polyhost.kle.kle_praser import parse_kle  # type: ignore
+except Exception:  # pragma: no cover
+    def parse_kle(json_data: list):
+        key_matrix = {}
+        y_cursor = 0.0
+        current_rotation = current_rx = current_ry = 0.0
+        cols = rows = 0
+        for row in json_data:
+            x_cursor = 0.0
+            row_defaults: dict = {}
+            if isinstance(row, dict) and 'name' in row:
+                continue
+            if isinstance(row, dict):
+                continue
+            for item in row:
+                if isinstance(item, dict):
+                    row_defaults.update(item)
+                    if 'r' in item:
+                        current_rotation = float(item['r'])
+                    if 'rx' in item:
+                        current_rx = float(item['rx']); x_cursor = current_rx
+                    if 'ry' in item:
+                        current_ry = float(item['ry']); y_cursor = current_ry
+                    if 'x' in item:
+                        x_cursor += float(item['x'])
+                    if 'y' in item:
+                        y_cursor += float(item['y'])
+                    continue
+                matrix_pos = str(item)
+                idx = matrix_pos.split(',')
+                col = int(idx[1]); row_i = int(idx[0])
+                cols = max(cols, col + 1); rows = max(rows, row_i + 1)
+                w = float(row_defaults.get('w', 1)); h = float(row_defaults.get('h', 1))
+                key_matrix[matrix_pos] = {
+                    'x': x_cursor, 'y': y_cursor, 'w': w, 'h': h,
+                    'r': current_rotation, 'rx': current_rx, 'ry': current_ry,
+                    'col': col, 'row': row_i,
+                }
+                x_cursor += w
+                row_defaults.clear()
+            if current_rotation == 0:
+                y_cursor += 1.0
+        return rows, cols, key_matrix
+
+
+# Logical resolution of one keycap OLED (matches the firmware: 72x40, monochrome).
+OLED_W, OLED_H = 72, 40
+
+
+@dataclass
+class KeyContent:
+    """What one physical key shows in a single frame."""
+    glyph: str | None = None      # a unicode character to draw on the OLED
+    label: str | None = None      # short text fallback when no glyph is given
+    dim: bool = False             # inactive key (KC_NO/unused): drawn darker, blank OLED
+    frame: str | None = None      # 'cap' = active-tab ∩ border, 'bar' = inactive-tab bottom bar
+    selected: bool = False        # highlight (e.g. the just-pressed key)
+    blank: bool = False           # a real key, but its OLED is intentionally empty
+
+
+@dataclass
+class Theme:
+    bg: tuple = (32, 33, 36)
+    key_bg: tuple = (53, 53, 53)
+    key_dim_bg: tuple = (42, 42, 42)
+    key_outline: tuple = (17, 17, 17)
+    oled_bg: tuple = (20, 21, 26)
+    oled_dim_bg: tuple = (14, 14, 16)
+    oled_on: tuple = (236, 240, 245)     # "lit" OLED pixel
+    bezel_light: tuple = (64, 64, 64)
+    bezel_dark: tuple = (80, 80, 80)
+    selected: tuple = (255, 225, 0)
+
+
+class GlyphRenderer:
+    """Renders a single unicode char into a 1-bit OLED-sized buffer, choosing a
+    font from a fallback chain by actual cmap coverage."""
+
+    def __init__(self, font_chain: list[tuple[str, str]], mono_px: int = 110):
+        from fontTools.ttLib import TTFont
+        self.fonts = []  # (coverage:set[int], PIL font, kind)
+        for path, kind in font_chain:
+            if not path or not os.path.exists(path):
+                continue
+            try:
+                tt = TTFont(path, fontNumber=0, lazy=True)
+                cov = set(tt.getBestCmap().keys())
+                tt.close()
+                size = 109 if kind == 'color' else mono_px
+                pil = ImageFont.truetype(path, size)
+                self.fonts.append((cov, pil, kind))
+            except Exception as exc:  # pragma: no cover
+                print(f"  [glyph] skipping {path}: {exc}")
+        self._cache: dict[str, Image.Image] = {}
+
+    def _font_for(self, cp: int):
+        for cov, pil, kind in self.fonts:
+            if cp in cov:
+                return pil, kind
+        return None
+
+    def render(self, ch: str) -> Image.Image:
+        """Return an OLED_W x OLED_H mode-'L' image (white glyph on black)."""
+        if ch in self._cache:
+            return self._cache[ch]
+        canvas = Image.new('L', (OLED_W, OLED_H), 0)
+        pick = self._font_for(ord(ch)) if ch else None
+        if pick is not None:
+            pil, kind = pick
+            glyph = self._raster(ch, pil, kind)
+            if glyph is not None:
+                # Fit within the OLED with a small margin, preserving aspect.
+                max_w, max_h = OLED_W - 4, OLED_H - 4
+                gw, gh = glyph.size
+                scale = min(max_w / gw, max_h / gh)
+                nw, nh = max(1, round(gw * scale)), max(1, round(gh * scale))
+                glyph = glyph.resize((nw, nh), Image.LANCZOS)
+                ox = (OLED_W - nw) // 2
+                oy = (OLED_H - nh) // 2
+                canvas.paste(glyph, (ox, oy))
+        self._cache[ch] = canvas
+        return canvas
+
+    @staticmethod
+    def _raster(ch: str, pil, kind: str) -> Image.Image | None:
+        if kind == 'color':
+            tmp = Image.new('RGBA', (160, 160), (0, 0, 0, 0))
+            d = ImageDraw.Draw(tmp)
+            try:
+                d.text((10, 10), ch, font=pil, embedded_color=True)
+            except Exception:
+                return None
+            bbox = tmp.getbbox()
+            if not bbox:
+                return None
+            glyph = tmp.crop(bbox)
+            bg = Image.new('RGBA', glyph.size, (0, 0, 0, 255))
+            bg.alpha_composite(glyph)
+            return bg.convert('L')
+        # monochrome / outline font: white on black
+        tmp = Image.new('L', (220, 220), 0)
+        d = ImageDraw.Draw(tmp)
+        d.text((20, 20), ch, font=pil, fill=255)
+        bbox = tmp.getbbox()
+        if not bbox:
+            return None
+        return tmp.crop(bbox)
+
+
+class KleRenderer:
+    def __init__(self, kle_json: list, unit: int = 72, key_pad: int = 3,
+                 theme: Theme | None = None, glyphs: GlyphRenderer | None = None,
+                 bezel: bool = True, dither: bool = True):
+        self.rows, self.cols, self.km = parse_kle(kle_json)
+        self.unit = unit
+        self.key_pad = key_pad
+        self.theme = theme or Theme()
+        self.glyphs = glyphs
+        self.bezel = bezel
+        self.dither = dither
+        self._geom()
+        self._bezel_tile = self._make_bezel_tile() if bezel else None
+
+    # -- geometry ------------------------------------------------------------
+    def _rot(self, px, py, rx, ry, deg):
+        a = math.radians(deg)
+        ca, sa = math.cos(a), math.sin(a)   # +deg == clockwise in screen (y-down)
+        dx, dy = px - rx, py - ry
+        return (rx + dx * ca - dy * sa, ry + dx * sa + dy * ca)
+
+    def _corners_px(self, p):
+        U = self.unit
+        X, Y, W, H = p['x'] * U, p['y'] * U, p['w'] * U, p['h'] * U
+        pts = [(X, Y), (X + W, Y), (X + W, Y + H), (X, Y + H)]
+        if p['r']:
+            rx, ry = p['rx'] * U, p['ry'] * U
+            pts = [self._rot(x, y, rx, ry, p['r']) for (x, y) in pts]
+        return pts
+
+    def _geom(self):
+        xs, ys = [], []
+        for p in self.km.values():
+            for (x, y) in self._corners_px(p):
+                xs.append(x); ys.append(y)
+        margin = self.unit // 2
+        self.ox = min(xs) - margin
+        self.oy = min(ys) - margin
+        self.cw = int(math.ceil(max(xs) - self.ox + margin))
+        self.ch = int(math.ceil(max(ys) - self.oy + margin))
+
+    def _make_bezel_tile(self) -> Image.Image:
+        # Diagonal hatch, echoing the editor's striped keycap "attachment".
+        t = 16
+        tile = Image.new('RGBA', (t, t), self.theme.bezel_light + (255,))
+        d = ImageDraw.Draw(tile)
+        for k in range(-t, t * 2, 8):
+            d.line([(k, t), (k + t, 0)], fill=self.theme.bezel_dark + (255,), width=4)
+        return tile
+
+    # -- per-key tile --------------------------------------------------------
+    def _oled_buffer(self, c: KeyContent) -> Image.Image | None:
+        """Build the 72x40 monochrome OLED image (RGB) for a key, or None."""
+        if c.dim or (c.glyph is None and c.label is None and not c.frame and not c.blank):
+            return None
+        buf = Image.new('L', (OLED_W, OLED_H), 0)
+        if c.glyph and self.glyphs is not None:
+            buf = self.glyphs.render(c.glyph).copy()
+        elif c.label:
+            d = ImageDraw.Draw(buf)
+            try:
+                f = ImageFont.truetype(
+                    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 18)
+            except Exception:
+                f = ImageFont.load_default()
+            tb = d.textbbox((0, 0), c.label, font=f)
+            d.text(((OLED_W - (tb[2] - tb[0])) / 2 - tb[0],
+                    (OLED_H - (tb[3] - tb[1])) / 2 - tb[1]), c.label, font=f, fill=255)
+        # tab decorations, drawn on top exactly like emj_draw_tab_* on the device
+        if c.frame == 'cap':
+            d = ImageDraw.Draw(buf)
+            d.rectangle([2, 0, OLED_W - 3, 0], fill=255)
+            d.rectangle([1, 1, OLED_W - 2, 1], fill=255)
+            d.rectangle([0, 2, 2, OLED_H - 1], fill=255)
+            d.rectangle([OLED_W - 3, 2, OLED_W - 1, OLED_H - 1], fill=255)
+        elif c.frame == 'bar':
+            ImageDraw.Draw(buf).rectangle([0, OLED_H - 3, OLED_W - 1, OLED_H - 1], fill=255)
+        # to 1-bit: dither (authentic OLED look) then colourise
+        one = buf.convert('1') if self.dither else buf.point(lambda v: 255 if v >= 110 else 0).convert('1')
+        on = self.theme.oled_on
+        bg = self.theme.oled_dim_bg if c.dim else self.theme.oled_bg
+        rgb = Image.new('RGB', (OLED_W, OLED_H), bg)
+        white = Image.new('RGB', (OLED_W, OLED_H), on)
+        rgb.paste(white, (0, 0), one)
+        return rgb
+
+    def _key_tile(self, p, c: KeyContent) -> Image.Image:
+        U = self.unit
+        tw, th = max(1, round(p['w'] * U)), max(1, round(p['h'] * U))
+        tile = Image.new('RGBA', (tw, th), (0, 0, 0, 0))
+        d = ImageDraw.Draw(tile)
+        pad = self.key_pad
+        rect = [pad, pad, tw - pad - 1, th - pad - 1]
+        radius = max(2, int(min(tw, th) * 0.10))
+        body = self.theme.key_dim_bg if c.dim else self.theme.key_bg
+        d.rounded_rectangle(rect, radius=radius, fill=body, outline=self.theme.key_outline, width=2)
+
+        # OLED display rect: width == key height minus margins, centred, anchored top
+        kx, ky, kw, kh = rect[0], rect[1], rect[2] - rect[0], rect[3] - rect[1]
+        m = max(3, U // 16)
+        disp_w = max(2, kh - 2 * m)
+        disp_h = int(disp_w * (OLED_H / OLED_W))
+        dx = int(kx + m + (kw - kh) / 2)
+        dy = int(ky + m)
+        d.rounded_rectangle([dx, dy, dx + disp_w, dy + disp_h],
+                            radius=2, fill=self.theme.oled_dim_bg if c.dim else self.theme.oled_bg)
+        # striped keycap "attachment" below the display (subtle)
+        if self.bezel and self._bezel_tile is not None and not c.dim:
+            band_h = max(1, disp_h // 2)
+            band = Image.new('RGBA', (disp_w, band_h))
+            for yy in range(0, band_h, self._bezel_tile.height):
+                for xx in range(0, disp_w, self._bezel_tile.width):
+                    band.paste(self._bezel_tile, (xx, yy))
+            mask = Image.new('L', (disp_w, band_h), 60)
+            tile.paste(band, (dx, dy + disp_h), mask)
+
+        oled = self._oled_buffer(c)
+        if oled is not None:
+            oled = oled.resize((disp_w, disp_h), Image.NEAREST)
+            tile.paste(oled, (dx, dy))
+
+        if c.selected:
+            d.rounded_rectangle(rect, radius=radius, outline=self.theme.selected, width=3)
+        return tile
+
+    # -- frames --------------------------------------------------------------
+    def render_frame(self, contents: dict[str, KeyContent]) -> Image.Image:
+        img = Image.new('RGB', (self.cw, self.ch), self.theme.bg)
+        for mp, p in self.km.items():
+            c = contents.get(mp, KeyContent(dim=True))
+            tile = self._key_tile(p, c)
+            if p['r']:
+                rot = tile.rotate(-p['r'], resample=Image.BICUBIC, expand=True)
+                cor = self._corners_px(p)
+                minx = min(x for x, _ in cor); miny = min(y for _, y in cor)
+                img.paste(rot, (int(round(minx - self.ox)), int(round(miny - self.oy))), rot)
+            else:
+                x = int(round(p['x'] * self.unit - self.ox))
+                y = int(round(p['y'] * self.unit - self.oy))
+                img.paste(tile, (x, y), tile)
+        return img
+
+    def save_gif(self, frames: Iterable[dict[str, KeyContent]], path: str,
+                 durations, loop: int = 0, scale: float = 1.0):
+        imgs = [self.render_frame(f) for f in frames]
+        if scale != 1.0:
+            size = (int(self.cw * scale), int(self.ch * scale))
+            imgs = [im.resize(size, Image.LANCZOS) for im in imgs]
+        # Quantise to a shared palette for a compact, clean GIF.
+        pal = imgs[0].quantize(colors=64, method=Image.MEDIANCUT)
+        pimgs = [im.quantize(palette=pal, dither=Image.NONE) for im in imgs]
+        if isinstance(durations, (int, float)):
+            durations = [durations] * len(pimgs)
+        os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+        pimgs[0].save(path, save_all=True, append_images=pimgs[1:],
+                      duration=list(durations), loop=loop, optimize=True, disposal=2)
+        return path

--- a/tools/kle_render.py
+++ b/tools/kle_render.py
@@ -34,7 +34,7 @@ try:  # pragma: no cover - import shim
     if _REPO not in sys.path:
         sys.path.insert(0, _REPO)
     from polyhost.kle.kle_praser import parse_kle  # type: ignore
-except Exception:  # pragma: no cover
+except ImportError:  # pragma: no cover — running outside the repo
     def parse_kle(json_data: list):
         key_matrix = {}
         y_cursor = 0.0
@@ -368,6 +368,8 @@ class KleRenderer:
     def save_gif(self, frames: Iterable[dict[str, KeyContent]], path: str,
                  durations, loop: int = 0, scale: float = 1.0):
         imgs = [self.render_frame(f) for f in frames]
+        if not imgs:
+            raise ValueError("save_gif() requires at least one frame")
         if scale != 1.0:
             size = (int(self.cw * scale), int(self.ch * scale))
             imgs = [im.resize(size, Image.LANCZOS) for im in imgs]
@@ -376,7 +378,11 @@ class KleRenderer:
         pimgs = [im.quantize(palette=pal, dither=Image.NONE) for im in imgs]
         if isinstance(durations, (int, float)):
             durations = [durations] * len(pimgs)
+        else:
+            durations = list(durations)
+            if len(durations) != len(pimgs):
+                raise ValueError(f"durations ({len(durations)}) != frames ({len(pimgs)})")
         os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
         pimgs[0].save(path, save_all=True, append_images=pimgs[1:],
-                      duration=list(durations), loop=loop, optimize=True, disposal=2)
+                      duration=durations, loop=loop, optimize=True, disposal=2)
         return path

--- a/tools/kle_render.py
+++ b/tools/kle_render.py
@@ -93,6 +93,7 @@ class KeyContent:
     blank: bool = False           # a real key, but its OLED is intentionally empty
     invert: bool = False          # invert the OLED (dark glyph on lit bg) — the kdisp_invert
                                   # press-feedback flash the firmware does on key-down
+    scale: float = 1.0            # glyph size within the OLED (e.g. 0.5 for small page arrows)
 
 
 @dataclass
@@ -136,10 +137,11 @@ class GlyphRenderer:
                 return pil, kind
         return None
 
-    def render(self, ch: str) -> Image.Image:
+    def render(self, ch: str, scale: float = 1.0) -> Image.Image:
         """Return an OLED_W x OLED_H mode-'L' image (white glyph on black)."""
-        if ch in self._cache:
-            return self._cache[ch]
+        key = (ch, round(scale, 3))
+        if key in self._cache:
+            return self._cache[key]
         canvas = Image.new('L', (OLED_W, OLED_H), 0)
         pick = self._font_for(ord(ch)) if ch else None
         if pick is not None:
@@ -147,7 +149,7 @@ class GlyphRenderer:
             glyph = self._raster(ch, pil, kind)
             if glyph is not None:
                 # Fit within the OLED with a small margin, preserving aspect.
-                max_w, max_h = OLED_W - 4, OLED_H - 4
+                max_w, max_h = (OLED_W - 4) * scale, (OLED_H - 4) * scale
                 gw, gh = glyph.size
                 scale = min(max_w / gw, max_h / gh)
                 nw, nh = max(1, round(gw * scale)), max(1, round(gh * scale))
@@ -155,7 +157,7 @@ class GlyphRenderer:
                 ox = (OLED_W - nw) // 2
                 oy = (OLED_H - nh) // 2
                 canvas.paste(glyph, (ox, oy))
-        self._cache[ch] = canvas
+        self._cache[key] = canvas
         return canvas
 
     @staticmethod
@@ -273,7 +275,7 @@ class KleRenderer:
             return None
         buf = Image.new('L', (OLED_W, OLED_H), 0)
         if c.glyph and self.glyphs is not None:
-            buf = self.glyphs.render(c.glyph).copy()
+            buf = self.glyphs.render(c.glyph, c.scale).copy()
         elif c.label:
             d = ImageDraw.Draw(buf)
             try:

--- a/tools/kle_render.py
+++ b/tools/kle_render.py
@@ -91,6 +91,8 @@ class KeyContent:
     frame: str | None = None      # 'cap' = active-tab ∩ border, 'bar' = inactive-tab bottom bar
     selected: bool = False        # highlight (e.g. the just-pressed key)
     blank: bool = False           # a real key, but its OLED is intentionally empty
+    invert: bool = False          # invert the OLED (dark glyph on lit bg) — the kdisp_invert
+                                  # press-feedback flash the firmware does on key-down
 
 
 @dataclass
@@ -185,7 +187,8 @@ class GlyphRenderer:
 class KleRenderer:
     def __init__(self, kle_json: list, unit: int = 72, key_pad: int = 3,
                  theme: Theme | None = None, glyphs: GlyphRenderer | None = None,
-                 bezel: bool = True, dither: bool = True):
+                 bezel: bool = True, dither: bool = True, margin: int = 24,
+                 exclude: set[str] | None = None):
         self.rows, self.cols, self.km = parse_kle(kle_json)
         self.unit = unit
         self.key_pad = key_pad
@@ -193,8 +196,36 @@ class KleRenderer:
         self.glyphs = glyphs
         self.bezel = bezel
         self.dither = dither
+        self.margin = margin
+        self.exclude = set(exclude or ())   # matrix positions with no display (e.g. encoder)
         self._geom()
         self._bezel_tile = self._make_bezel_tile() if bezel else None
+
+    def compact_halves(self, side_of, gap_px: int = 10):
+        """Slide the two halves together to a fixed pixel gap. ``side_of`` maps a
+        matrix position to 'L' / 'R' / None; right-half keys (origin included) are
+        translated left so the inner gap becomes ``gap_px``."""
+        U = self.unit
+        left_max, right_min = [], []
+        for mp, p in self.km.items():
+            if mp in self.exclude:
+                continue
+            xs = [x for x, _ in self._corners_px(p)]
+            side = side_of(mp)
+            if side == 'L':
+                left_max.append(max(xs))
+            elif side == 'R':
+                right_min.append(min(xs))
+        if not left_max or not right_min:
+            return
+        delta_units = ((min(right_min) - max(left_max)) - gap_px) / U
+        if abs(delta_units) < 1e-9:
+            return
+        for mp, p in self.km.items():
+            if side_of(mp) == 'R':
+                p['x'] -= delta_units
+                p['rx'] -= delta_units   # shift rotation pivot too, so rotated keys translate cleanly
+        self._geom()
 
     # -- geometry ------------------------------------------------------------
     def _rot(self, px, py, rx, ry, deg):
@@ -214,14 +245,16 @@ class KleRenderer:
 
     def _geom(self):
         xs, ys = [], []
-        for p in self.km.values():
+        for mp, p in self.km.items():
+            if mp in self.exclude:
+                continue
             for (x, y) in self._corners_px(p):
                 xs.append(x); ys.append(y)
-        margin = self.unit // 2
-        self.ox = min(xs) - margin
-        self.oy = min(ys) - margin
-        self.cw = int(math.ceil(max(xs) - self.ox + margin))
-        self.ch = int(math.ceil(max(ys) - self.oy + margin))
+        m = self.margin
+        self.ox = min(xs) - m
+        self.oy = min(ys) - m
+        self.cw = int(math.ceil(max(xs) - self.ox + m))
+        self.ch = int(math.ceil(max(ys) - self.oy + m))
 
     def _make_bezel_tile(self) -> Image.Image:
         # Diagonal hatch, echoing the editor's striped keycap "attachment".
@@ -235,7 +268,8 @@ class KleRenderer:
     # -- per-key tile --------------------------------------------------------
     def _oled_buffer(self, c: KeyContent) -> Image.Image | None:
         """Build the 72x40 monochrome OLED image (RGB) for a key, or None."""
-        if c.dim or (c.glyph is None and c.label is None and not c.frame and not c.blank):
+        if c.dim or (c.glyph is None and c.label is None and not c.frame
+                     and not c.blank and not c.invert):
             return None
         buf = Image.new('L', (OLED_W, OLED_H), 0)
         if c.glyph and self.glyphs is not None:
@@ -263,9 +297,12 @@ class KleRenderer:
         one = buf.convert('1') if self.dither else buf.point(lambda v: 255 if v >= 110 else 0).convert('1')
         on = self.theme.oled_on
         bg = self.theme.oled_dim_bg if c.dim else self.theme.oled_bg
-        rgb = Image.new('RGB', (OLED_W, OLED_H), bg)
-        white = Image.new('RGB', (OLED_W, OLED_H), on)
-        rgb.paste(white, (0, 0), one)
+        if c.invert:   # kdisp_invert: lit background, dark glyph
+            rgb = Image.new('RGB', (OLED_W, OLED_H), on)
+            rgb.paste(Image.new('RGB', (OLED_W, OLED_H), bg), (0, 0), one)
+        else:
+            rgb = Image.new('RGB', (OLED_W, OLED_H), bg)
+            rgb.paste(Image.new('RGB', (OLED_W, OLED_H), on), (0, 0), one)
         return rgb
 
     def _key_tile(self, p, c: KeyContent) -> Image.Image:
@@ -311,6 +348,8 @@ class KleRenderer:
     def render_frame(self, contents: dict[str, KeyContent]) -> Image.Image:
         img = Image.new('RGB', (self.cw, self.ch), self.theme.bg)
         for mp, p in self.km.items():
+            if mp in self.exclude:
+                continue
             c = contents.get(mp, KeyContent(dim=True))
             tile = self._key_tile(p, c)
             if p['r']:

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,0 +1,5 @@
+# Dependencies for the tools/ keycap demo renderer only.
+# These are NOT runtime deps of the polyhost app — install them separately
+# (e.g. into a venv) when generating demo GIFs.
+Pillow>=10
+fonttools>=4


### PR DESCRIPTION
## What

A small, reusable tool under `tools/` that lays out the PolyKybd keycaps from the **same KLE file the layout editor uses** (`polyhost/res/polykybd-split72.json`) and renders an animated GIF — you decide, per frame, what each keycap OLED shows. First use: a walk-through of the emoji layer for the website / Ko-fi.

Glyphs are drawn **pixel-exact** from the firmware's generated Adafruit-GFX pixel-font headers (`base/fonts/`), reproducing `kdisp_write_gfx_char`/`kdisp_write_gfx_text`: the `ALL_FONTS` first-match priority lookup, the `ch − first` glyph index, the `yAdvance` baseline adjust, and a native 1-bit blit at `(BUFFER_X + xOffset, baseline + yOffset)` in the 72×40 window — including the real `ICON_LEFT`/`ICON_RIGHT` page arrows. So the output matches what the hardware actually draws (true glyph sizes/positions, not scale-to-fit).

## Files

| File | Role |
|------|------|
| `tools/kle_render.py` | Reusable renderer. Reuses `polyhost.kle.kle_praser.parse_kle`, lays out the board (rotated thumb cluster included), draws each key as a dark cap with a monochrome 72×40 "OLED". Per-frame API is `{matrix_pos: KeyContent}`; `save_gif()` writes the animation. |
| `tools/gfx_font.py` | Parses the generated GFX headers and renders glyphs exactly like the firmware. |
| `tools/emoji_demo.py` | Data-driven emoji-layer driver — reads geometry, key roles and glyphs straight from a `qmk_firmware` checkout (`split72/keyboard.json`, the `[_EMJ]` keymap, `emoji/emoji_data.h`, `emj_tab_icons[]`). |
| `tools/dl-demo-fonts.sh` | Fetches the Noto fonts for `--font-mode ttf`. |
| `tools/README.md`, `tools/.gitignore` | Docs + ignore generated output. |

## Usage

```bash
python -m venv .venv
.venv/bin/pip install Pillow fonttools
# expects a qmk_firmware checkout next to this repo (or pass --qmk PATH)
.venv/bin/python tools/emoji_demo.py            # → tools/out/emoji_layer.gif
.venv/bin/python tools/emoji_demo.py --still --max-pages 3   # quicker, also dumps a still PNG
```

Handy flags (`emoji_demo.py`):

- `--qmk PATH` — path to the `qmk_firmware` checkout (default: `../qmk_firmware`)
- `--font-mode gfx|ttf` — `gfx` = pixel-exact from the GFX headers (default); `ttf` = live Noto, scaled to fit (run `tools/dl-demo-fonts.sh` first)
- `--settle MS` — ms each page is held (default `1500`); `--max-pages N` — cap pages shown per category
- `--unit PX`, `--margin PX`, `--gap PX` — geometry; `--exclude "3,7;8,0"` — matrix positions with no display (the rotary encoders); `--no-bezel`, `--scale`, `--still`

The frame plan (sweep every tab, cycle each tab's pages with a press-blink on the tabs/arrows) is a short list near the bottom of `emoji_demo.py:main()` — retime or re-point it there. The renderer itself knows nothing about emojis: feed it any `{matrix: KeyContent}` frames to animate other layers/ideas (see `tools/README.md`).

## Notes

- No changes outside `tools/`. Generated output (`tools/out/`) is git-ignored — regenerate with `emoji_demo.py`.
- Rendering is faithful to the device: same KLE geometry as the editor, same `ALL_FONTS` lookup and pixel fonts as the firmware.

https://claude.ai/code/session_013MUXM6UVNCrQLq48nv6njP

---
_Generated by [Claude Code](https://claude.ai/code/session_013MUXM6UVNCrQLq48nv6njP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for the demo renderer toolchain covering setup, usage, and architecture.

* **New Features**
  * Toolchain to generate animated GIFs and promotional images from keyboard layouts.
  * Emoji layer visualization with firmware-accurate OLED rendering.
  * Automated font retrieval for demo generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->