### PR TITLE
Keymap editor: compose & display QMK layer / one-shot / tap-hold keycodes

### DIFF
--- a/polyhost/gui/layout_dialog/kb_layout_dialog.py
+++ b/polyhost/gui/layout_dialog/kb_layout_dialog.py
@@ -14,7 +14,7 @@ from polyhost.device.device_settings import DeviceSettings
 from polyhost.device.poly_kybd import PolyKybd
 from polyhost.gui.button_array import ButtonArray
 from polyhost.gui.get_icon import get_icon
-from polyhost.gui.layout_dialog.qmk_keycode_helper import create_nice_name, decompose_keycode, parse_layer_names
+from polyhost.gui.layout_dialog.qmk_keycode_helper import describe_keycode, parse_layer_names
 from polyhost.gui.layout_dialog.renderable_key import RenderableKey
 from polyhost.gui.layout_dialog.keycode_browser import KeycodeBrowser
 from polyhost.gui.zoomable_graphics_view import ZoomableGraphicsView
@@ -103,6 +103,7 @@ class KbLayoutDialog(QMainWindow):
         if not success:
             my_options = ["Could not read layers from device"]
         else:
+            self.keycode_browser.set_layer_count(self.num_layers)
             my_options = []
             for idx in range(self.keeb.num_layers):
                 hint = layer_names.get(idx)
@@ -148,12 +149,8 @@ class KbLayoutDialog(QMainWindow):
             while idx not in self.keys and idx < max_idx:
                 idx += 1
             keycode = self.key_buffer[idx + offset]
-            if keycode in mapping:
-                name = mapping[keycode]
-            else:
-                name = decompose_keycode(keycode, mapping)
-            nice_name = create_nice_name(name)
-            self.keys[idx].setKeycode(nice_name, name, keycode, 9 if len(nice_name) < 5 else 7)
+            main, badge, color = describe_keycode(keycode, mapping)
+            self.keys[idx].set_display(main, badge, color, 9 if len(main) < 5 else 7)
             idx += 1
 
     def layerChanged(self, button):
@@ -220,7 +217,9 @@ class KbLayoutDialog(QMainWindow):
     def keycodeSelected(self, nice_name, name, keycode, font_size_hint):
         if self.selected_key is None:
             return
-        self.selected_key.setKeycode(nice_name, name, keycode, font_size_hint)
+        mapping = self.keycode_browser.get_keycode_to_name_mapping()
+        main, badge, color = describe_keycode(keycode, mapping)
+        self.selected_key.set_display(main, badge, color, 9 if len(main) < 5 else 7)
         idx = self.selected_key.matrix_index
         if idx is None:
             return

--- a/polyhost/gui/layout_dialog/kb_layout_dialog.py
+++ b/polyhost/gui/layout_dialog/kb_layout_dialog.py
@@ -79,6 +79,7 @@ class KbLayoutDialog(QMainWindow):
         self.selected_key = None
         self.keys = {}
         self.current_layer = 0
+        self.key_buffer = None
 
         self.init_ui()
 
@@ -213,6 +214,12 @@ class KbLayoutDialog(QMainWindow):
 
     def mouseClickEvent(self, item):
         self.selected_key = item
+        # Reflect the clicked key's current keycode in the composer so its
+        # layer/modifier/tap setup is shown and ready to tweak.
+        idx = item.matrix_index
+        if idx is not None and self.key_buffer:
+            max_idx = self.settings.MATRIX_COLUMNS * self.settings.MATRIX_ROWS
+            self.keycode_browser.show_keycode(self.key_buffer[idx + self.current_layer * max_idx])
 
     def keycodeSelected(self, nice_name, name, keycode, font_size_hint):
         if self.selected_key is None:

--- a/polyhost/gui/layout_dialog/kb_layout_dialog.py
+++ b/polyhost/gui/layout_dialog/kb_layout_dialog.py
@@ -224,6 +224,9 @@ class KbLayoutDialog(QMainWindow):
     def keycodeSelected(self, nice_name, name, keycode, font_size_hint):
         if self.selected_key is None:
             return
+        if self.key_buffer is None:
+            self.log.warning("Cannot write keycode: key buffer not initialized")
+            return
         mapping = self.keycode_browser.get_keycode_to_name_mapping()
         main, badge, color = describe_keycode(keycode, mapping)
         self.selected_key.set_display(main, badge, color, 9 if len(main) < 5 else 7)

--- a/polyhost/gui/layout_dialog/kb_layout_dialog.py
+++ b/polyhost/gui/layout_dialog/kb_layout_dialog.py
@@ -105,7 +105,7 @@ class KbLayoutDialog(QMainWindow):
         else:
             self.keycode_browser.set_layer_count(self.num_layers)
             my_options = []
-            for idx in range(self.keeb.num_layers):
+            for idx in range(self.num_layers):
                 hint = layer_names.get(idx)
                 my_options.append(f"{idx} {hint}" if hint else str(idx))
 
@@ -131,7 +131,7 @@ class KbLayoutDialog(QMainWindow):
         if success:
             self.log.info("Received dynamic key buffer: %d", len(self.key_buffer))
             ok, default_layer = self.keeb.get_default_layer()
-            if ok and self.keeb.num_layers and 0 <= default_layer < self.keeb.num_layers:
+            if ok and self.num_layers and 0 <= default_layer < self.num_layers:
                 self.current_layer = default_layer
                 self.layers.set_active(default_layer)
             self.set_keycodes_for_layer(self.current_layer)

--- a/polyhost/gui/layout_dialog/keycode_browser.py
+++ b/polyhost/gui/layout_dialog/keycode_browser.py
@@ -22,6 +22,7 @@ class KeycodeBrowser(QWidget):
 
         tabs = QTabWidget()
         tabs.setTabPosition(QTabWidget.North)
+        self.tabs = tabs
         self.setMaximumHeight(400)
 
         CAT_ORDER = category_order()
@@ -59,6 +60,16 @@ class KeycodeBrowser(QWidget):
     def set_layer_count(self, num_layers: int):
         """Update the composer's layer range once the device layer count is known."""
         self.composer.set_layer_count(num_layers)
+
+    def show_keycode(self, keycode: int):
+        """Reflect a selected key's keycode in the composer.
+
+        For composable keycodes (layer switch / one-shot / mod-tap / layer-tap /
+        modified key) the composer is populated and brought to the front so the
+        user sees the key's current setup. Plain keys leave the view unchanged.
+        """
+        if self.composer.load_from_keycode(keycode):
+            self.tabs.setCurrentWidget(self.composer)
 
     def get_name_to_keycode_mapping(self):
         return self.keycodes

--- a/polyhost/gui/layout_dialog/keycode_browser.py
+++ b/polyhost/gui/layout_dialog/keycode_browser.py
@@ -6,6 +6,7 @@ from PyQt5.QtWidgets import (
 
 from polyhost.gui.flow_layout import FlowLayout
 from polyhost.gui.layout_dialog.keycode_browser_button import KeycodeBrowserButton
+from polyhost.gui.layout_dialog.keycode_composer import KeycodeComposer
 from polyhost.gui.layout_dialog.qmk_keycode_helper import HEADER_FILE, parse_qmk_keycodes, categorize, create_nice_name, \
     category_order, standard_category, last_key_in_standard_category
 
@@ -13,7 +14,7 @@ from polyhost.gui.layout_dialog.qmk_keycode_helper import HEADER_FILE, parse_qmk
 class KeycodeBrowser(QWidget):
     keycodeSelected = pyqtSignal(str, str, int, int)  # uint16
 
-    def __init__(self):
+    def __init__(self, num_layers: int = 9):
         super().__init__()
 
         self.keycodes = parse_qmk_keycodes(HEADER_FILE)
@@ -47,9 +48,18 @@ class KeycodeBrowser(QWidget):
             if category not in CAT_ORDER:
                 tabs.addTab(self._build_tab(categories[category]), category)
 
+        # Composer tab for building layer-switch / one-shot / tap-hold keycodes.
+        self.composer = KeycodeComposer(self.keycodes, num_layers=num_layers)
+        self.composer.keycodeSelected.connect(self.keycodeSelected)
+        tabs.addTab(self.composer, "Layers && Mods")
+
         layout = QVBoxLayout(self)
         layout.addWidget(tabs)
-        
+
+    def set_layer_count(self, num_layers: int):
+        """Update the composer's layer range once the device layer count is known."""
+        self.composer.set_layer_count(num_layers)
+
     def get_name_to_keycode_mapping(self):
         return self.keycodes
     

--- a/polyhost/gui/layout_dialog/keycode_composer.py
+++ b/polyhost/gui/layout_dialog/keycode_composer.py
@@ -18,6 +18,7 @@ from polyhost.gui.layout_dialog.qmk_keycode_helper import (
     decompose_keycode, create_nice_name,
     encode_mods, encode_layer_switch, encode_one_shot_mod,
     encode_mod_tap, encode_layer_tap, encode_modded, encode_layer_mod,
+    encode_persistent_def_layer, encode_swap_hands_tap,
     decode_for_composer, MOD_CTRL, MOD_SHIFT, MOD_ALT, MOD_GUI, MOD_RIGHT,
 )
 
@@ -27,6 +28,7 @@ BEHAVIORS = [
     ("TO", "TO — Switch to layer", True, False, False),
     ("TG", "TG — Toggle layer", True, False, False),
     ("DF", "DF — Set default layer", True, False, False),
+    ("PDF", "PDF — Persistent default layer", True, False, False),
     ("TT", "TT — Tap-toggle layer", True, False, False),
     ("OSL", "OSL — One-shot layer", True, False, False),
     ("OSM", "OSM — One-shot modifier", False, True, False),
@@ -34,6 +36,7 @@ BEHAVIORS = [
     ("LM", "LM — Layer + modifier (momentary)", True, True, False),
     ("MT", "MT — Mod-tap (hold mod / tap key)", False, True, True),
     ("MOD", "Modified key (Ctrl/Shift/… + key)", False, True, True),
+    ("SH_T", "SH_T — Swap-hands tap-hold (tap key / hold swap)", False, False, True),
 ]
 
 
@@ -196,12 +199,16 @@ class KeycodeComposer(QWidget):
 
         if key in ("MO", "TO", "TG", "DF", "TT", "OSL"):
             return encode_layer_switch(key, layer)
+        if key == "PDF":
+            return encode_persistent_def_layer(layer)
         if key == "OSM":
             return encode_one_shot_mod(mods)
         if key == "LM":
             return encode_layer_mod(layer, mods)
         if key == "LT":
             return encode_layer_tap(layer, inner)
+        if key == "SH_T":
+            return encode_swap_hands_tap(inner)
         if key == "MT":
             return encode_mod_tap(mods, inner)
         if key == "MOD":

--- a/polyhost/gui/layout_dialog/keycode_composer.py
+++ b/polyhost/gui/layout_dialog/keycode_composer.py
@@ -18,6 +18,7 @@ from polyhost.gui.layout_dialog.qmk_keycode_helper import (
     decompose_keycode, create_nice_name,
     encode_mods, encode_layer_switch, encode_one_shot_mod,
     encode_mod_tap, encode_layer_tap, encode_modded,
+    decode_for_composer, MOD_CTRL, MOD_SHIFT, MOD_ALT, MOD_GUI, MOD_RIGHT,
 )
 
 # Behaviour definitions: key -> (label, needs_layer, needs_mods, needs_inner_key)
@@ -115,6 +116,46 @@ class KeycodeComposer(QWidget):
         self._num_layers = max(1, num_layers)
         self.layer_spin.setRange(0, self._num_layers - 1)
         self._update_preview()
+
+    def load_from_keycode(self, value: int) -> bool:
+        """Populate the controls from an existing keycode.
+
+        Returns True if the keycode is one of the composable behaviours (and the
+        controls were updated), False otherwise (plain key / LM / unsupported).
+        """
+        decoded = decode_for_composer(value)
+        if decoded is None:
+            return False
+        behavior, layer, mods, inner = decoded
+        idx = self.behavior_combo.findData(behavior)
+        if idx < 0:
+            return False
+
+        # Suppress per-widget preview churn while we batch-set the controls.
+        widgets = (self.behavior_combo, self.layer_spin, self.inner_combo,
+                   self.cb_ctrl, self.cb_shift, self.cb_alt, self.cb_gui,
+                   self.rb_left, self.rb_right)
+        for w in widgets:
+            w.blockSignals(True)
+        try:
+            self.behavior_combo.setCurrentIndex(idx)
+            self.layer_spin.setValue(min(layer, self.layer_spin.maximum()))
+            self.cb_ctrl.setChecked(bool(mods & MOD_CTRL))
+            self.cb_shift.setChecked(bool(mods & MOD_SHIFT))
+            self.cb_alt.setChecked(bool(mods & MOD_ALT))
+            self.cb_gui.setChecked(bool(mods & MOD_GUI))
+            (self.rb_right if mods & MOD_RIGHT else self.rb_left).setChecked(True)
+            if inner:
+                inner_idx = self.inner_combo.findData(inner)
+                if inner_idx >= 0:
+                    self.inner_combo.setCurrentIndex(inner_idx)
+        finally:
+            for w in widgets:
+                w.blockSignals(False)
+
+        # Refresh enabled states + preview once, now that everything is set.
+        self._on_behavior_changed()
+        return True
 
     def _select_default_inner(self):
         """Default the inner-key combo to KC_A if present."""

--- a/polyhost/gui/layout_dialog/keycode_composer.py
+++ b/polyhost/gui/layout_dialog/keycode_composer.py
@@ -1,0 +1,195 @@
+"""Composer tab for building QMK "special" keycodes.
+
+The plain keycode tabs in KeycodeBrowser can only pick flat keycodes parsed
+from keycodes.h. This widget builds the parameterised quantum keycodes —
+layer switches (MO/TO/TG/DF/TT/OSL), one-shot mod (OSM), mod-tap (MT),
+layer-tap (LT) and modified keycodes (Ctrl+key …) — from a behaviour +
+layer/modifier/inner-key selection, with a live preview, and emits the same
+keycodeSelected signal the browser uses so the device-write path is unchanged.
+"""
+from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QFormLayout, QGroupBox,
+    QComboBox, QSpinBox, QCheckBox, QRadioButton, QButtonGroup,
+    QPushButton, QLabel,
+)
+
+from polyhost.gui.layout_dialog.qmk_keycode_helper import (
+    decompose_keycode, create_nice_name,
+    encode_mods, encode_layer_switch, encode_one_shot_mod,
+    encode_mod_tap, encode_layer_tap, encode_modded,
+)
+
+# Behaviour definitions: key -> (label, needs_layer, needs_mods, needs_inner_key)
+BEHAVIORS = [
+    ("MO", "MO — Momentary layer", True, False, False),
+    ("TO", "TO — Switch to layer", True, False, False),
+    ("TG", "TG — Toggle layer", True, False, False),
+    ("DF", "DF — Set default layer", True, False, False),
+    ("TT", "TT — Tap-toggle layer", True, False, False),
+    ("OSL", "OSL — One-shot layer", True, False, False),
+    ("OSM", "OSM — One-shot modifier", False, True, False),
+    ("LT", "LT — Layer-tap (hold layer / tap key)", True, False, True),
+    ("MT", "MT — Mod-tap (hold mod / tap key)", False, True, True),
+    ("MOD", "Modified key (Ctrl/Shift/… + key)", False, True, True),
+]
+
+
+class KeycodeComposer(QWidget):
+    keycodeSelected = pyqtSignal(str, str, int, int)  # nice_name, name, keycode, font_hint
+
+    def __init__(self, basic_keycodes: dict[str, int], num_layers: int = 9):
+        super().__init__()
+        # Inner-key choices: basic keycodes only (0x00–0xFF) — that is all MT/LT
+        # and modified keycodes can carry in their low byte.
+        self._basic = sorted(
+            ((name, kc) for name, kc in basic_keycodes.items() if 0x00 <= kc <= 0xFF),
+            key=lambda nk: nk[1],
+        )
+        # code -> name for verified previews of composed keycodes.
+        self._code_to_name = {kc: name for name, kc in self._basic}
+        self._num_layers = max(1, num_layers)
+
+        outer = QVBoxLayout(self)
+
+        form = QFormLayout()
+        self.behavior_combo = QComboBox()
+        for key, label, *_ in BEHAVIORS:
+            self.behavior_combo.addItem(label, key)
+        form.addRow("Behavior:", self.behavior_combo)
+
+        self.layer_spin = QSpinBox()
+        self.layer_spin.setRange(0, self._num_layers - 1)
+        form.addRow("Layer:", self.layer_spin)
+
+        # Modifier selection: Ctrl/Shift/Alt/GUI + a left/right side toggle.
+        mod_box = QGroupBox("Modifiers")
+        mod_layout = QHBoxLayout(mod_box)
+        self.cb_ctrl = QCheckBox("Ctrl")
+        self.cb_shift = QCheckBox("Shift")
+        self.cb_alt = QCheckBox("Alt")
+        self.cb_gui = QCheckBox("GUI")
+        for cb in (self.cb_ctrl, self.cb_shift, self.cb_alt, self.cb_gui):
+            mod_layout.addWidget(cb)
+        self.rb_left = QRadioButton("Left")
+        self.rb_right = QRadioButton("Right")
+        self.rb_left.setChecked(True)
+        self.side_group = QButtonGroup(self)
+        self.side_group.addButton(self.rb_left)
+        self.side_group.addButton(self.rb_right)
+        mod_layout.addSpacing(12)
+        mod_layout.addWidget(self.rb_left)
+        mod_layout.addWidget(self.rb_right)
+        form.addRow(mod_box)
+
+        self.inner_combo = QComboBox()
+        for name, kc in self._basic:
+            display = name[3:] if name.startswith("KC_") else name
+            self.inner_combo.addItem(display, kc)
+        self._select_default_inner()
+        form.addRow("Inner key:", self.inner_combo)
+
+        outer.addLayout(form)
+
+        self.preview = QLabel()
+        self.preview.setStyleSheet("font-weight: bold; padding: 4px;")
+        outer.addWidget(self.preview)
+
+        self.apply_btn = QPushButton("Apply to selected key")
+        outer.addWidget(self.apply_btn)
+        outer.addStretch(1)
+
+        # Wiring
+        self.behavior_combo.currentIndexChanged.connect(self._on_behavior_changed)
+        self.layer_spin.valueChanged.connect(self._update_preview)
+        self.inner_combo.currentIndexChanged.connect(self._update_preview)
+        for cb in (self.cb_ctrl, self.cb_shift, self.cb_alt, self.cb_gui):
+            cb.toggled.connect(self._update_preview)
+        self.rb_left.toggled.connect(self._update_preview)
+        self.apply_btn.clicked.connect(self._on_apply)
+
+        self._on_behavior_changed()
+
+    # -- helpers -----------------------------------------------------------
+    def set_layer_count(self, num_layers: int):
+        self._num_layers = max(1, num_layers)
+        self.layer_spin.setRange(0, self._num_layers - 1)
+        self._update_preview()
+
+    def _select_default_inner(self):
+        """Default the inner-key combo to KC_A if present."""
+        for i in range(self.inner_combo.count()):
+            if self.inner_combo.itemData(i) == 0x04:  # KC_A
+                self.inner_combo.setCurrentIndex(i)
+                return
+
+    def _current_behavior(self):
+        key = self.behavior_combo.currentData()
+        for entry in BEHAVIORS:
+            if entry[0] == key:
+                return entry
+        return BEHAVIORS[0]
+
+    def _current_mods(self) -> int:
+        return encode_mods(
+            ctrl=self.cb_ctrl.isChecked(), shift=self.cb_shift.isChecked(),
+            alt=self.cb_alt.isChecked(), gui=self.cb_gui.isChecked(),
+            right=self.rb_right.isChecked(),
+        )
+
+    def _current_inner_kc(self) -> int:
+        data = self.inner_combo.currentData()
+        return int(data) if data is not None else 0
+
+    def _encode(self):
+        """Return the composed 16-bit keycode, or None if the selection is invalid."""
+        key, _label, needs_layer, needs_mods, needs_inner = self._current_behavior()
+        mods = self._current_mods()
+        layer = self.layer_spin.value()
+        inner = self._current_inner_kc()
+
+        # MT/OSM/modified keycodes are meaningless with no modifier selected.
+        if needs_mods and mods == 0:
+            return None
+
+        if key in ("MO", "TO", "TG", "DF", "TT", "OSL"):
+            return encode_layer_switch(key, layer)
+        if key == "OSM":
+            return encode_one_shot_mod(mods)
+        if key == "LT":
+            return encode_layer_tap(layer, inner)
+        if key == "MT":
+            return encode_mod_tap(mods, inner)
+        if key == "MOD":
+            return encode_modded(mods, inner)
+        return None
+
+    # -- slots -------------------------------------------------------------
+    def _on_behavior_changed(self):
+        _key, _label, needs_layer, needs_mods, needs_inner = self._current_behavior()
+        self.layer_spin.setEnabled(needs_layer)
+        self.inner_combo.setEnabled(needs_inner)
+        for cb in (self.cb_ctrl, self.cb_shift, self.cb_alt, self.cb_gui):
+            cb.setEnabled(needs_mods)
+        self.rb_left.setEnabled(needs_mods)
+        self.rb_right.setEnabled(needs_mods)
+        self._update_preview()
+
+    def _update_preview(self):
+        keycode = self._encode()
+        if keycode is None:
+            self.preview.setText("Select at least one modifier")
+            self.apply_btn.setEnabled(False)
+            return
+        # Decode back for a verified human-readable preview.
+        name = decompose_keycode(keycode, self._code_to_name)
+        self.preview.setText(f"{name}   =   0x{keycode:04X}")
+        self.apply_btn.setEnabled(True)
+
+    def _on_apply(self):
+        keycode = self._encode()
+        if keycode is None:
+            return
+        name = decompose_keycode(keycode, self._code_to_name)
+        nice_name = create_nice_name(name)
+        self.keycodeSelected.emit(nice_name, name, keycode, 8)

--- a/polyhost/gui/layout_dialog/keycode_composer.py
+++ b/polyhost/gui/layout_dialog/keycode_composer.py
@@ -17,7 +17,7 @@ from PyQt5.QtWidgets import (
 from polyhost.gui.layout_dialog.qmk_keycode_helper import (
     decompose_keycode, create_nice_name,
     encode_mods, encode_layer_switch, encode_one_shot_mod,
-    encode_mod_tap, encode_layer_tap, encode_modded,
+    encode_mod_tap, encode_layer_tap, encode_modded, encode_layer_mod,
     decode_for_composer, MOD_CTRL, MOD_SHIFT, MOD_ALT, MOD_GUI, MOD_RIGHT,
 )
 
@@ -31,6 +31,7 @@ BEHAVIORS = [
     ("OSL", "OSL — One-shot layer", True, False, False),
     ("OSM", "OSM — One-shot modifier", False, True, False),
     ("LT", "LT — Layer-tap (hold layer / tap key)", True, False, True),
+    ("LM", "LM — Layer + modifier (momentary)", True, True, False),
     ("MT", "MT — Mod-tap (hold mod / tap key)", False, True, True),
     ("MOD", "Modified key (Ctrl/Shift/… + key)", False, True, True),
 ]
@@ -197,6 +198,8 @@ class KeycodeComposer(QWidget):
             return encode_layer_switch(key, layer)
         if key == "OSM":
             return encode_one_shot_mod(mods)
+        if key == "LM":
+            return encode_layer_mod(layer, mods)
         if key == "LT":
             return encode_layer_tap(layer, inner)
         if key == "MT":

--- a/polyhost/gui/layout_dialog/keycode_composer.py
+++ b/polyhost/gui/layout_dialog/keycode_composer.py
@@ -45,7 +45,7 @@ class KeycodeComposer(QWidget):
 
     def __init__(self, basic_keycodes: dict[str, int], num_layers: int = 9):
         super().__init__()
-        # Inner-key choices: basic keycodes only (0x00–0xFF) — that is all MT/LT
+        # Inner-key choices: basic keycodes only (0x00-0xFF) - that is all MT/LT
         # and modified keycodes can carry in their low byte.
         self._basic = sorted(
             ((name, kc) for name, kc in basic_keycodes.items() if 0x00 <= kc <= 0xFF),

--- a/polyhost/gui/layout_dialog/qmk_keycode_helper.py
+++ b/polyhost/gui/layout_dialog/qmk_keycode_helper.py
@@ -295,6 +295,37 @@ def encode_modded(mods: int, basic_kc: int) -> int:
     return QK_MODS | ((mods & 0x1F) << 8) | (basic_kc & 0xFF)
 
 
+def decode_for_composer(value: int):
+    """Decode a keycode into the composer's fields, or None if not composable.
+
+    Returns (behavior, layer, mods, inner_kc) where behavior is one of the
+    composer behaviour tags (MO/TO/TG/DF/TT/OSL/OSM/MT/LT/MOD). LM() and the
+    persistent-default-layer range are intentionally not composable and yield
+    None, as do plain basic keycodes.
+    """
+    # Modified keycode (Ctrl+C, RShift+A, …).
+    if 0x0100 <= value <= 0x1FFF:
+        return "MOD", 0, (value >> 8) & 0x1F, value & 0xFF
+    # Mod-tap MT().
+    if 0x2000 <= value <= 0x3FFF:
+        return "MT", 0, (value >> 8) & 0x1F, value & 0xFF
+    # Layer-tap LT().
+    if 0x4000 <= value <= 0x4FFF:
+        return "LT", (value >> 8) & 0x0F, 0, value & 0xFF
+    # Layer switches that take only a layer argument.
+    for lo, hi, tag in (
+        (0x5200, 0x521F, "TO"), (0x5220, 0x523F, "MO"),
+        (0x5240, 0x525F, "DF"), (0x5260, 0x527F, "TG"),
+        (0x5280, 0x529F, "OSL"), (0x52C0, 0x52DF, "TT"),
+    ):
+        if lo <= value <= hi:
+            return tag, value & 0x1F, 0, 0
+    # One-shot mod OSM().
+    if 0x52A0 <= value <= 0x52BF:
+        return "OSM", 0, value & 0x1F, 0
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Two-line display description — base label + behaviour badge.
 #

--- a/polyhost/gui/layout_dialog/qmk_keycode_helper.py
+++ b/polyhost/gui/layout_dialog/qmk_keycode_helper.py
@@ -328,17 +328,23 @@ def encode_persistent_def_layer(layer: int) -> int:
 
 
 def encode_swap_hands_tap(basic_kc: int) -> int:
-    """Encode SH_T(kc) — tap = kc, hold = swap hands. kc limited to 0..0xEF."""
-    return QK_SWAP_HANDS | (basic_kc & 0xFF)
+    """Encode SH_T(kc) — tap = kc, hold = swap hands. kc limited to 0..0xEF.
+
+    Values 0xF0..0xFF map onto the named swap-hands action block
+    (QK_SWAP_HANDS 0x56F0..0x56FF), not SH_T(kc), so they are rejected.
+    """
+    if not 0x00 <= basic_kc <= 0xEF:
+        raise ValueError("SH_T() tap key must be in range 0x00..0xEF")
+    return QK_SWAP_HANDS | basic_kc
 
 
 def decode_for_composer(value: int):
     """Decode a keycode into the composer's fields, or None if not composable.
 
     Returns (behavior, layer, mods, inner_kc) where behavior is one of the
-    composer behaviour tags (MO/TO/TG/DF/TT/OSL/OSM/MT/LT/MOD). LM() and the
-    persistent-default-layer range are intentionally not composable and yield
-    None, as do plain basic keycodes.
+    composer behaviour tags (MO/TO/TG/DF/TT/OSL/OSM/MT/LT/MOD/LM/PDF/SH_T).
+    Plain basic keycodes and non-composable firmware-defined ranges (TD, named
+    swap-hands actions, MACRO/PB/KB/USER) yield None.
     """
     # Modified keycode (Ctrl+C, RShift+A, …).
     if 0x0100 <= value <= 0x1FFF:

--- a/polyhost/gui/layout_dialog/qmk_keycode_helper.py
+++ b/polyhost/gui/layout_dialog/qmk_keycode_helper.py
@@ -211,3 +211,160 @@ def decompose_keycode(value: int, keycode_to_name: dict) -> str:
         return f"DF*({value & 0x1F})"
     # Fall through: look up in full mapping or show hex
     return keycode_to_name.get(value, f"0x{value:04X}")
+
+
+# ---------------------------------------------------------------------------
+# Keycode composition (encode) — the inverse of decompose_keycode().
+#
+# These build the 16-bit QMK keycode for the "special" behaviours from their
+# parameters (layer / modifier mask / inner basic keycode), matching the exact
+# encoding documented in quantum/keycodes.h. Keep these and decompose_keycode()
+# in sync — they are two halves of the same single source of truth.
+# ---------------------------------------------------------------------------
+
+# QK_* range bases (low edge of each range).
+QK_MODS = 0x0000          # modified keycode = (mods << 8) | basic_kc
+QK_MOD_TAP = 0x2000
+QK_LAYER_TAP = 0x4000
+QK_TO = 0x5200
+QK_MOMENTARY = 0x5220
+QK_DEF_LAYER = 0x5240
+QK_TOGGLE_LAYER = 0x5260
+QK_ONE_SHOT_LAYER = 0x5280
+QK_ONE_SHOT_MOD = 0x52A0
+QK_LAYER_TAP_TOGGLE = 0x52C0
+
+# 5-bit modifier mask bits (modifiers.h). Bit 4 selects right-hand mods.
+MOD_CTRL = 0x01
+MOD_SHIFT = 0x02
+MOD_ALT = 0x04
+MOD_GUI = 0x08
+MOD_RIGHT = 0x10
+
+# Layer-switch behaviours that take only a layer argument: name -> range base.
+LAYER_BEHAVIORS = {
+    "MO": QK_MOMENTARY,
+    "TO": QK_TO,
+    "TG": QK_TOGGLE_LAYER,
+    "DF": QK_DEF_LAYER,
+    "TT": QK_LAYER_TAP_TOGGLE,
+    "OSL": QK_ONE_SHOT_LAYER,
+}
+
+
+def encode_mods(ctrl: bool = False, shift: bool = False, alt: bool = False,
+                gui: bool = False, right: bool = False) -> int:
+    """Build a 5-bit QMK modifier mask from individual modifier flags."""
+    mods = 0
+    if ctrl:
+        mods |= MOD_CTRL
+    if shift:
+        mods |= MOD_SHIFT
+    if alt:
+        mods |= MOD_ALT
+    if gui:
+        mods |= MOD_GUI
+    if right and mods:
+        mods |= MOD_RIGHT
+    return mods
+
+
+def encode_layer_switch(behavior: str, layer: int) -> int:
+    """Encode MO/TO/TG/DF/TT/OSL(layer) — layer clamped to 0..31."""
+    base = LAYER_BEHAVIORS[behavior]
+    return base | (layer & 0x1F)
+
+
+def encode_one_shot_mod(mods: int) -> int:
+    """Encode OSM(mods)."""
+    return QK_ONE_SHOT_MOD | (mods & 0x1F)
+
+
+def encode_mod_tap(mods: int, basic_kc: int) -> int:
+    """Encode MT(mods, kc) — tap = kc, hold = mods. kc limited to 0..255."""
+    return QK_MOD_TAP | ((mods & 0x1F) << 8) | (basic_kc & 0xFF)
+
+
+def encode_layer_tap(layer: int, basic_kc: int) -> int:
+    """Encode LT(layer, kc) — tap = kc, hold = layer. layer limited to 0..15."""
+    return QK_LAYER_TAP | ((layer & 0x0F) << 8) | (basic_kc & 0xFF)
+
+
+def encode_modded(mods: int, basic_kc: int) -> int:
+    """Encode a modified keycode like LCTL(kc)/RSFT(kc) — sends mods+kc together."""
+    return QK_MODS | ((mods & 0x1F) << 8) | (basic_kc & 0xFF)
+
+
+# ---------------------------------------------------------------------------
+# Two-line display description — base label + behaviour badge.
+#
+# describe_keycode() turns a 16-bit keycode into (main_text, badge_text,
+# badge_color) so a key tile can show the tap/base key prominently with a small
+# coloured badge for the behaviour (held mod, target layer, one-shot, …).
+# ---------------------------------------------------------------------------
+
+# Badge colours by behaviour family.
+BADGE_COLOR_LAYER = "#FFCC44"   # amber  — layer switches (MO/TO/TG/DF/TT/OSL) & OSM
+BADGE_COLOR_TAP = "#66C2FF"     # cyan   — tap/hold duals (LT/MT)
+BADGE_COLOR_MOD = "#FF9955"     # orange — modified keycodes sent together (LCTL(kc)…)
+
+# Compact modifier glyphs for badges.
+_MOD_GLYPHS = [(MOD_CTRL, "⌃"), (MOD_SHIFT, "⇧"),
+               (MOD_ALT, "⌥"), (MOD_GUI, "⌘")]
+
+
+def _mod_symbols(mods: int) -> str:
+    """Compact modifier glyph string, e.g. 0x12 -> 'R⇧' (right shift)."""
+    glyphs = "".join(g for bit, g in _MOD_GLYPHS if mods & bit)
+    if not glyphs:
+        return "∅"
+    return ("R" + glyphs) if (mods & MOD_RIGHT) else glyphs
+
+
+def describe_keycode(value: int, keycode_to_name: dict):
+    """Return (main_text, badge_text, badge_color) for a two-line key tile.
+
+    badge_text is "" (and badge_color None) for plain keys.
+    """
+    def basic_display(kc: int) -> str:
+        name = keycode_to_name.get(kc)
+        if name is None:
+            name = decompose_keycode(kc, keycode_to_name)
+        return create_nice_name(name)
+
+    # Modified keycode (Ctrl+C, RShift+A, …) — main = key, badge = held mods.
+    if 0x0100 <= value <= 0x1FFF:
+        mods = (value >> 8) & 0x1F
+        return basic_display(value & 0xFF), _mod_symbols(mods), BADGE_COLOR_MOD
+    # Mod-tap MT() — main = tap key, badge = held mods (cyan = tap/hold dual).
+    if 0x2000 <= value <= 0x3FFF:
+        mods = (value >> 8) & 0x1F
+        return basic_display(value & 0xFF), _mod_symbols(mods), BADGE_COLOR_TAP
+    # Layer-tap LT() — main = tap key, badge = hold target layer.
+    if 0x4000 <= value <= 0x4FFF:
+        layer = (value >> 8) & 0x0F
+        return basic_display(value & 0xFF), f"L{layer}", BADGE_COLOR_TAP
+    # Layer-mod LM() — main = target layer, badge = mods.
+    if 0x5000 <= value <= 0x51FF:
+        layer = (value >> 4) & 0x0F
+        return f"L{layer}", "LM" + _mod_symbols(value & 0x0F), BADGE_COLOR_LAYER
+    # Layer switches MO/TO/DF/TG/OSL/TT — main = target layer, badge = behaviour.
+    for lo, hi, tag in (
+        (0x5200, 0x521F, "TO"), (0x5220, 0x523F, "MO"),
+        (0x5240, 0x525F, "DF"), (0x5260, 0x527F, "TG"),
+        (0x5280, 0x529F, "OSL"), (0x52C0, 0x52DF, "TT"),
+    ):
+        if lo <= value <= hi:
+            return f"L{value & 0x1F}", tag, BADGE_COLOR_LAYER
+    # One-shot mod OSM() — main = mods, badge = OSM.
+    if 0x52A0 <= value <= 0x52BF:
+        return _mod_symbols(value & 0x1F), "OSM", BADGE_COLOR_LAYER
+    # Persistent default layer.
+    if 0x52E0 <= value <= 0x52FF:
+        return f"L{value & 0x1F}", "DF*", BADGE_COLOR_LAYER
+
+    # Plain key (or anything else) — single line, no badge.
+    name = keycode_to_name.get(value)
+    if name is None:
+        name = decompose_keycode(value, keycode_to_name)
+    return create_nice_name(name), "", None

--- a/polyhost/gui/layout_dialog/qmk_keycode_helper.py
+++ b/polyhost/gui/layout_dialog/qmk_keycode_helper.py
@@ -253,6 +253,8 @@ QK_TOGGLE_LAYER = 0x5260
 QK_ONE_SHOT_LAYER = 0x5280
 QK_ONE_SHOT_MOD = 0x52A0
 QK_LAYER_TAP_TOGGLE = 0x52C0
+QK_PERSISTENT_DEF_LAYER = 0x52E0
+QK_SWAP_HANDS = 0x5600
 
 # 5-bit modifier mask bits (modifiers.h). Bit 4 selects right-hand mods.
 MOD_CTRL = 0x01
@@ -320,6 +322,16 @@ def encode_layer_mod(layer: int, mods: int) -> int:
     return QK_LAYER_MOD | ((layer & 0x0F) << 5) | (mods & 0x1F)
 
 
+def encode_persistent_def_layer(layer: int) -> int:
+    """Encode PDF(layer) — set the default layer and persist it to EEPROM."""
+    return QK_PERSISTENT_DEF_LAYER | (layer & 0x1F)
+
+
+def encode_swap_hands_tap(basic_kc: int) -> int:
+    """Encode SH_T(kc) — tap = kc, hold = swap hands. kc limited to 0..0xEF."""
+    return QK_SWAP_HANDS | (basic_kc & 0xFF)
+
+
 def decode_for_composer(value: int):
     """Decode a keycode into the composer's fields, or None if not composable.
 
@@ -351,6 +363,12 @@ def decode_for_composer(value: int):
     # One-shot mod OSM().
     if 0x52A0 <= value <= 0x52BF:
         return "OSM", 0, value & 0x1F, 0
+    # Persistent default layer PDF().
+    if 0x52E0 <= value <= 0x52FF:
+        return "PDF", value & 0x1F, 0, 0
+    # Swap-hands tap-hold SH_T().
+    if 0x5600 <= value <= 0x56EF:
+        return "SH_T", 0, 0, value & 0xFF
     return None
 
 

--- a/polyhost/gui/layout_dialog/qmk_keycode_helper.py
+++ b/polyhost/gui/layout_dialog/qmk_keycode_helper.py
@@ -206,11 +206,30 @@ def decompose_keycode(value: int, keycode_to_name: dict) -> str:
     # QK_LAYER_TAP_TOGGLE: TT() — 0x52C0–0x52DF
     if 0x52C0 <= value <= 0x52DF:
         return f"TT({value & 0x1F})"
-    # QK_PERSISTENT_DEF_LAYER — 0x52E0–0x52FF
+    # QK_PERSISTENT_DEF_LAYER: PDF() — 0x52E0–0x52FF
     if 0x52E0 <= value <= 0x52FF:
-        return f"DF*({value & 0x1F})"
-    # Fall through: look up in full mapping or show hex
-    return keycode_to_name.get(value, f"0x{value:04X}")
+        return f"PDF({value & 0x1F})"
+    # QK_SWAP_HANDS: SH_T(kc) tap-hold — 0x5600–0x56EF (0x56F0+ are named actions)
+    if 0x5600 <= value <= 0x56EF:
+        return f"SH_T({basic_name(value & 0xFF)})"
+    # QK_TAP_DANCE: TD(n) — 0x5700–0x57FF (firmware-defined dance index)
+    if 0x5700 <= value <= 0x57FF:
+        return f"TD({value & 0xFF})"
+
+    # A named constant (parsed from keycodes.h) wins for everything else.
+    name = keycode_to_name.get(value)
+    if name is not None:
+        return name
+    # Firmware-defined parametric keycodes — index encoded in the low bits.
+    if 0x7440 <= value <= 0x747F:
+        return f"PB({value - 0x7440})"          # programmable button
+    if 0x7700 <= value <= 0x777F:
+        return f"MACRO({value - 0x7700})"
+    if 0x7E00 <= value <= 0x7E3F:
+        return f"KB({value - 0x7E00})"           # keyboard-specific custom
+    if 0x7E40 <= value <= 0x7FFF:
+        return f"USER({value - 0x7E40})"         # user custom (QK_USER)
+    return f"0x{value:04X}"
 
 
 # ---------------------------------------------------------------------------
@@ -345,8 +364,9 @@ def decode_for_composer(value: int):
 
 # Badge colours by behaviour family.
 BADGE_COLOR_LAYER = "#FFCC44"   # amber  — layer switches (MO/TO/TG/DF/TT/OSL) & OSM
-BADGE_COLOR_TAP = "#66C2FF"     # cyan   — tap/hold duals (LT/MT)
+BADGE_COLOR_TAP = "#66C2FF"     # cyan   — tap/hold duals (LT/MT/SH_T)
 BADGE_COLOR_MOD = "#FF9955"     # orange — modified keycodes sent together (LCTL(kc)…)
+BADGE_COLOR_FW = "#C792EA"      # violet — firmware-defined (TD/MACRO/PB/KB/USER)
 
 # Compact modifier glyphs for badges.
 _MOD_GLYPHS = [(MOD_CTRL, "⌃"), (MOD_SHIFT, "⇧"),
@@ -399,9 +419,15 @@ def describe_keycode(value: int, keycode_to_name: dict):
     # One-shot mod OSM() — main = mods, badge = OSM.
     if 0x52A0 <= value <= 0x52BF:
         return _mod_symbols(value & 0x1F), "OSM", BADGE_COLOR_LAYER
-    # Persistent default layer.
+    # Persistent default layer PDF().
     if 0x52E0 <= value <= 0x52FF:
-        return f"L{value & 0x1F}", "DF*", BADGE_COLOR_LAYER
+        return f"L{value & 0x1F}", "PDF", BADGE_COLOR_LAYER
+    # Swap-hands tap-hold SH_T() — tap key / hold swap.
+    if 0x5600 <= value <= 0x56EF:
+        return basic_display(value & 0xFF), "SH", BADGE_COLOR_TAP
+    # Tap dance TD() — firmware-defined dance index.
+    if 0x5700 <= value <= 0x57FF:
+        return "TD", str(value & 0xFF), BADGE_COLOR_FW
 
     # Plain key (or anything else) — single line, no badge.
     name = keycode_to_name.get(value)

--- a/polyhost/gui/layout_dialog/qmk_keycode_helper.py
+++ b/polyhost/gui/layout_dialog/qmk_keycode_helper.py
@@ -180,10 +180,10 @@ def decompose_keycode(value: int, keycode_to_name: dict) -> str:
         layer = (value >> 8) & 0x0F
         key = value & 0xFF
         return f"LT({layer},{basic_name(key)})"
-    # QK_LAYER_MOD: LM() — 0x5000–0x51FF
+    # QK_LAYER_MOD: LM() — 0x5000–0x51FF (layer<<5 | 5-bit mod)
     if 0x5000 <= value <= 0x51FF:
-        layer = (value >> 4) & 0x0F
-        mods = value & 0x0F
+        layer = (value >> 5) & 0x0F
+        mods = value & 0x1F
         return f"LM({layer},{_mod_str(mods)})"
     # QK_TO: TO() — 0x5200–0x521F
     if 0x5200 <= value <= 0x521F:
@@ -226,6 +226,7 @@ def decompose_keycode(value: int, keycode_to_name: dict) -> str:
 QK_MODS = 0x0000          # modified keycode = (mods << 8) | basic_kc
 QK_MOD_TAP = 0x2000
 QK_LAYER_TAP = 0x4000
+QK_LAYER_MOD = 0x5000
 QK_TO = 0x5200
 QK_MOMENTARY = 0x5220
 QK_DEF_LAYER = 0x5240
@@ -295,6 +296,11 @@ def encode_modded(mods: int, basic_kc: int) -> int:
     return QK_MODS | ((mods & 0x1F) << 8) | (basic_kc & 0xFF)
 
 
+def encode_layer_mod(layer: int, mods: int) -> int:
+    """Encode LM(layer, mods) — momentary layer while holding the given mods."""
+    return QK_LAYER_MOD | ((layer & 0x0F) << 5) | (mods & 0x1F)
+
+
 def decode_for_composer(value: int):
     """Decode a keycode into the composer's fields, or None if not composable.
 
@@ -312,6 +318,9 @@ def decode_for_composer(value: int):
     # Layer-tap LT().
     if 0x4000 <= value <= 0x4FFF:
         return "LT", (value >> 8) & 0x0F, 0, value & 0xFF
+    # Layer-mod LM().
+    if 0x5000 <= value <= 0x51FF:
+        return "LM", (value >> 5) & 0x0F, value & 0x1F, 0
     # Layer switches that take only a layer argument.
     for lo, hi, tag in (
         (0x5200, 0x521F, "TO"), (0x5220, 0x523F, "MO"),
@@ -377,8 +386,8 @@ def describe_keycode(value: int, keycode_to_name: dict):
         return basic_display(value & 0xFF), f"L{layer}", BADGE_COLOR_TAP
     # Layer-mod LM() — main = target layer, badge = mods.
     if 0x5000 <= value <= 0x51FF:
-        layer = (value >> 4) & 0x0F
-        return f"L{layer}", "LM" + _mod_symbols(value & 0x0F), BADGE_COLOR_LAYER
+        layer = (value >> 5) & 0x0F
+        return f"L{layer}", "LM" + _mod_symbols(value & 0x1F), BADGE_COLOR_LAYER
     # Layer switches MO/TO/DF/TG/OSL/TT — main = target layer, badge = behaviour.
     for lo, hi, tag in (
         (0x5200, 0x521F, "TO"), (0x5220, 0x523F, "MO"),

--- a/polyhost/gui/layout_dialog/renderable_key.py
+++ b/polyhost/gui/layout_dialog/renderable_key.py
@@ -194,5 +194,5 @@ class RenderableKey(QGraphicsObject):
 
         badge_bounds = self.badge.boundingRect()
         self.badge.setPos(rect.x() + (rect.width() - badge_bounds.width())/2,
-                          rect.y() + rect.height() - badge_bounds.height() - 4)
+                          rect.y() + rect.height() - badge_bounds.height() + 1)
         self.badge.setTextWidth(badge_bounds.width())

--- a/polyhost/gui/layout_dialog/renderable_key.py
+++ b/polyhost/gui/layout_dialog/renderable_key.py
@@ -8,6 +8,7 @@ from PyQt5.QtWidgets import (
 KEY_MARGIN_X = 2
 KEY_MARGIN_Y = 2
 KEY_RADIUS = 0.1
+BADGE_BOTTOM_GAP = 20  # px from tile bottom to the badge's top edge
 
 
 class RenderableKey(QGraphicsObject):
@@ -193,6 +194,9 @@ class RenderableKey(QGraphicsObject):
         self.text.setTextWidth(bounding.width())
 
         badge_bounds = self.badge.boundingRect()
+        # Anchor the badge a fixed distance from the tile bottom (not by its own
+        # height) so ASCII tags ("MO", "L2") and the taller Unicode modifier
+        # glyphs (⇧⌃⌥⌘) all sit on exactly the same line regardless of colour.
         self.badge.setPos(rect.x() + (rect.width() - badge_bounds.width())/2,
-                          rect.y() + rect.height() - badge_bounds.height() + 1)
+                          rect.y() + rect.height() - BADGE_BOTTOM_GAP)
         self.badge.setTextWidth(badge_bounds.width())

--- a/polyhost/gui/layout_dialog/renderable_key.py
+++ b/polyhost/gui/layout_dialog/renderable_key.py
@@ -38,13 +38,24 @@ class RenderableKey(QGraphicsObject):
         self.setFlag(self.ItemIsFocusable, True)
         self.setAcceptHoverEvents(True)
 
-        # text label
+        # text label (base / tap keycode, drawn prominently in the centre)
         self.text = QGraphicsTextItem(nice_name, self)
         self.text.setFont(QFont("Arial", 10))
         self.text.setDefaultTextColor(Qt.white)
         opt = QTextOption()
         opt.setAlignment(Qt.AlignCenter)
         self.text.document().setDefaultTextOption(opt)
+
+        # behaviour badge (held mod / target layer / one-shot …), drawn small
+        # near the bottom. Empty + hidden for plain keys.
+        self.badge = QGraphicsTextItem("", self)
+        self.badge.setFont(QFont("Arial", 8, QFont.Bold))
+        self.badge.setDefaultTextColor(QColor("#FFCC44"))
+        badge_opt = QTextOption()
+        badge_opt.setAlignment(Qt.AlignCenter)
+        self.badge.document().setDefaultTextOption(badge_opt)
+        self.badge.setVisible(False)
+
         self.update_text_position()
 
         # hover state
@@ -152,16 +163,36 @@ class RenderableKey(QGraphicsObject):
         super().mousePressEvent(ev)
 
     def setKeycode(self, nice_name, name, keycode, font_size_hint=None):
-        self.nice_name = nice_name
-        self.text.document().setPlainText(nice_name)
+        # Legacy single-line setter (kept for compatibility). Prefer set_display.
+        self.set_display(nice_name, "", None, font_size_hint)
+
+    def set_display(self, main_text, badge_text="", badge_color=None, font_size_hint=None):
+        """Update the tile to show a base/tap label plus an optional behaviour badge."""
+        self.nice_name = main_text
+        self.text.document().setPlainText(main_text or "")
         if font_size_hint is not None and isinstance(font_size_hint, (int, float)):
             self.text.setFont(QFont("Arial", int(font_size_hint)))
+
+        has_badge = bool(badge_text)
+        self.badge.document().setPlainText(badge_text or "")
+        self.badge.setVisible(has_badge)
+        if has_badge and badge_color:
+            self.badge.setDefaultTextColor(QColor(badge_color))
+
         self.update_text_position()
         self.update()
 
     def update_text_position(self):
         rect = self.boundingRect()
         bounding = self.text.boundingRect()
+        # Nudge the main label up a little when a badge is shown so the two
+        # lines sit either side of the tile's display area.
+        y_nudge = 18 if self.badge.isVisible() else 14
         self.text.setPos(rect.x() + (rect.width() - bounding.width())/2,
-                         rect.y() + (rect.height() - bounding.height())/2 - 14)
+                         rect.y() + (rect.height() - bounding.height())/2 - y_nudge)
         self.text.setTextWidth(bounding.width())
+
+        badge_bounds = self.badge.boundingRect()
+        self.badge.setPos(rect.x() + (rect.width() - badge_bounds.width())/2,
+                          rect.y() + rect.height() - badge_bounds.height() - 4)
+        self.badge.setTextWidth(badge_bounds.width())

--- a/tests/gui/qmk_keycode_helper_test.py
+++ b/tests/gui/qmk_keycode_helper_test.py
@@ -1,0 +1,120 @@
+import unittest
+
+from polyhost.gui.layout_dialog.qmk_keycode_helper import (
+    MOD_CTRL, MOD_SHIFT, MOD_ALT, MOD_GUI, MOD_RIGHT,
+    encode_mods, encode_layer_switch, encode_one_shot_mod,
+    encode_mod_tap, encode_layer_tap, encode_modded,
+    decompose_keycode, describe_keycode,
+    BADGE_COLOR_LAYER, BADGE_COLOR_TAP, BADGE_COLOR_MOD,
+)
+
+# Minimal code->name mapping for the inner keys used in the tests.
+KC = {0x0000: "KC_NO", 0x0001: "KC_TRANSPARENT", 0x0004: "KC_A", 0x002C: "KC_SPACE"}
+
+
+class TestEncodeMods(unittest.TestCase):
+    def test_individual_bits(self):
+        self.assertEqual(encode_mods(ctrl=True), MOD_CTRL)
+        self.assertEqual(encode_mods(shift=True), MOD_SHIFT)
+        self.assertEqual(encode_mods(alt=True), MOD_ALT)
+        self.assertEqual(encode_mods(gui=True), MOD_GUI)
+
+    def test_combo_and_right(self):
+        self.assertEqual(encode_mods(ctrl=True, shift=True), MOD_CTRL | MOD_SHIFT)
+        self.assertEqual(encode_mods(shift=True, right=True), MOD_SHIFT | MOD_RIGHT)
+
+    def test_right_ignored_without_mods(self):
+        # right-hand flag is meaningless with no modifier selected
+        self.assertEqual(encode_mods(right=True), 0)
+
+
+class TestEncoders(unittest.TestCase):
+    def test_layer_switches(self):
+        self.assertEqual(encode_layer_switch("TO", 1), 0x5201)
+        self.assertEqual(encode_layer_switch("MO", 2), 0x5222)
+        self.assertEqual(encode_layer_switch("DF", 1), 0x5241)
+        self.assertEqual(encode_layer_switch("TG", 3), 0x5263)
+        self.assertEqual(encode_layer_switch("OSL", 1), 0x5281)
+        self.assertEqual(encode_layer_switch("TT", 0), 0x52C0)
+
+    def test_one_shot_mod(self):
+        self.assertEqual(encode_one_shot_mod(MOD_SHIFT), 0x52A2)
+
+    def test_mod_tap(self):
+        self.assertEqual(encode_mod_tap(MOD_SHIFT, 0x04), 0x2204)
+
+    def test_layer_tap(self):
+        self.assertEqual(encode_layer_tap(1, 0x04), 0x4104)
+
+    def test_modded(self):
+        self.assertEqual(encode_modded(MOD_CTRL, 0x04), 0x0104)
+        self.assertEqual(encode_modded(MOD_CTRL | MOD_RIGHT, 0x04), 0x1104)
+
+
+class TestRoundTrip(unittest.TestCase):
+    """encode_* must produce keycodes that decompose_keycode reads back correctly."""
+
+    def test_layer_switch_roundtrip(self):
+        for tag in ("MO", "TO", "TG", "DF", "TT", "OSL"):
+            kc = encode_layer_switch(tag, 3)
+            self.assertEqual(decompose_keycode(kc, KC), f"{tag}(3)")
+
+    def test_mod_tap_roundtrip(self):
+        kc = encode_mod_tap(MOD_SHIFT, 0x04)
+        self.assertEqual(decompose_keycode(kc, KC), "MT(LSFT,A)")
+
+    def test_layer_tap_roundtrip(self):
+        kc = encode_layer_tap(2, 0x2C)
+        self.assertEqual(decompose_keycode(kc, KC), "LT(2,SPACE)")
+
+    def test_modded_roundtrip(self):
+        kc = encode_modded(MOD_CTRL, 0x04)
+        self.assertEqual(decompose_keycode(kc, KC), "LCTL(A)")
+        kc_r = encode_modded(MOD_CTRL | MOD_RIGHT, 0x04)
+        self.assertEqual(decompose_keycode(kc_r, KC), "RCTL(A)")
+
+    def test_one_shot_mod_roundtrip(self):
+        kc = encode_one_shot_mod(MOD_SHIFT)
+        self.assertEqual(decompose_keycode(kc, KC), "OSM(LSFT)")
+
+
+class TestDescribeKeycode(unittest.TestCase):
+    def test_plain_key_no_badge(self):
+        main, badge, color = describe_keycode(0x0004, KC)
+        self.assertEqual(main, "A")
+        self.assertEqual(badge, "")
+        self.assertIsNone(color)
+
+    def test_layer_switch_badge(self):
+        main, badge, color = describe_keycode(encode_layer_switch("MO", 2), KC)
+        self.assertEqual(main, "L2")
+        self.assertEqual(badge, "MO")
+        self.assertEqual(color, BADGE_COLOR_LAYER)
+
+    def test_mod_tap_badge(self):
+        main, badge, color = describe_keycode(encode_mod_tap(MOD_SHIFT, 0x04), KC)
+        self.assertEqual(main, "A")
+        self.assertIn("⇧", badge)
+        self.assertEqual(color, BADGE_COLOR_TAP)
+
+    def test_layer_tap_badge(self):
+        main, badge, color = describe_keycode(encode_layer_tap(1, 0x2C), KC)
+        self.assertEqual(main, "SPACE")
+        self.assertEqual(badge, "L1")
+        self.assertEqual(color, BADGE_COLOR_TAP)
+
+    def test_modded_badge(self):
+        main, badge, color = describe_keycode(encode_modded(MOD_CTRL, 0x04), KC)
+        self.assertEqual(main, "A")
+        self.assertIn("⌃", badge)
+        self.assertEqual(color, BADGE_COLOR_MOD)
+
+    def test_osm_badge(self):
+        main, badge, color = describe_keycode(encode_one_shot_mod(MOD_SHIFT), KC)
+        self.assertIn("⇧", main)
+        self.assertEqual(badge, "OSM")
+        self.assertEqual(color, BADGE_COLOR_LAYER)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/gui/qmk_keycode_helper_test.py
+++ b/tests/gui/qmk_keycode_helper_test.py
@@ -4,6 +4,7 @@ from polyhost.gui.layout_dialog.qmk_keycode_helper import (
     MOD_CTRL, MOD_SHIFT, MOD_ALT, MOD_GUI, MOD_RIGHT,
     encode_mods, encode_layer_switch, encode_one_shot_mod,
     encode_mod_tap, encode_layer_tap, encode_modded, encode_layer_mod,
+    encode_persistent_def_layer, encode_swap_hands_tap,
     decompose_keycode, describe_keycode, decode_for_composer,
     BADGE_COLOR_LAYER, BADGE_COLOR_TAP, BADGE_COLOR_MOD, BADGE_COLOR_FW,
 )
@@ -55,6 +56,12 @@ class TestEncoders(unittest.TestCase):
         self.assertEqual(encode_layer_mod(1, MOD_CTRL), 0x5021)
         self.assertEqual(encode_layer_mod(2, MOD_SHIFT), 0x5042)
 
+    def test_persistent_def_layer(self):
+        self.assertEqual(encode_persistent_def_layer(2), 0x52E2)
+
+    def test_swap_hands_tap(self):
+        self.assertEqual(encode_swap_hands_tap(0x04), 0x5604)
+
 
 class TestRoundTrip(unittest.TestCase):
     """encode_* must produce keycodes that decompose_keycode reads back correctly."""
@@ -86,6 +93,16 @@ class TestRoundTrip(unittest.TestCase):
         kc = encode_layer_mod(2, MOD_CTRL | MOD_SHIFT)
         self.assertEqual(decompose_keycode(kc, KC), "LM(2,LCTL+LSFT)")
         self.assertEqual(decode_for_composer(kc), ("LM", 2, MOD_CTRL | MOD_SHIFT, 0))
+
+    def test_persistent_def_layer_roundtrip(self):
+        kc = encode_persistent_def_layer(3)
+        self.assertEqual(decompose_keycode(kc, KC), "PDF(3)")
+        self.assertEqual(decode_for_composer(kc), ("PDF", 3, 0, 0))
+
+    def test_swap_hands_tap_roundtrip(self):
+        kc = encode_swap_hands_tap(0x04)
+        self.assertEqual(decompose_keycode(kc, KC), "SH_T(A)")
+        self.assertEqual(decode_for_composer(kc), ("SH_T", 0, 0, 0x04))
 
 
 class TestDescribeKeycode(unittest.TestCase):
@@ -165,7 +182,9 @@ class TestDecodeForComposer(unittest.TestCase):
     def test_plain_and_unsupported_return_none(self):
         self.assertIsNone(decode_for_composer(0x0004))   # KC_A
         self.assertIsNone(decode_for_composer(0x0000))   # KC_NO
-        self.assertIsNone(decode_for_composer(0x52E1))   # persistent DF* — not composable
+        self.assertIsNone(decode_for_composer(0x5703))   # TD() — firmware-defined
+        self.assertIsNone(decode_for_composer(0x56F0))   # SH_TOGG — named action, not SH_T
+        self.assertIsNone(decode_for_composer(0x7702))   # MACRO() — firmware-defined
 
 
 class TestFirmwareKeycodeDisplay(unittest.TestCase):

--- a/tests/gui/qmk_keycode_helper_test.py
+++ b/tests/gui/qmk_keycode_helper_test.py
@@ -61,6 +61,13 @@ class TestEncoders(unittest.TestCase):
 
     def test_swap_hands_tap(self):
         self.assertEqual(encode_swap_hands_tap(0x04), 0x5604)
+        self.assertEqual(encode_swap_hands_tap(0xEF), 0x56EF)
+
+    def test_swap_hands_tap_rejects_named_action_range(self):
+        # 0xF0..0xFF would collide with the named swap-hands action block.
+        for bad in (0xF0, 0xFF, -1, 0x100):
+            with self.assertRaises(ValueError):
+                encode_swap_hands_tap(bad)
 
 
 class TestRoundTrip(unittest.TestCase):

--- a/tests/gui/qmk_keycode_helper_test.py
+++ b/tests/gui/qmk_keycode_helper_test.py
@@ -5,7 +5,7 @@ from polyhost.gui.layout_dialog.qmk_keycode_helper import (
     encode_mods, encode_layer_switch, encode_one_shot_mod,
     encode_mod_tap, encode_layer_tap, encode_modded, encode_layer_mod,
     decompose_keycode, describe_keycode, decode_for_composer,
-    BADGE_COLOR_LAYER, BADGE_COLOR_TAP, BADGE_COLOR_MOD,
+    BADGE_COLOR_LAYER, BADGE_COLOR_TAP, BADGE_COLOR_MOD, BADGE_COLOR_FW,
 )
 
 # Minimal code->name mapping for the inner keys used in the tests.
@@ -166,6 +166,44 @@ class TestDecodeForComposer(unittest.TestCase):
         self.assertIsNone(decode_for_composer(0x0004))   # KC_A
         self.assertIsNone(decode_for_composer(0x0000))   # KC_NO
         self.assertIsNone(decode_for_composer(0x52E1))   # persistent DF* — not composable
+
+
+class TestFirmwareKeycodeDisplay(unittest.TestCase):
+    """Parametric / firmware-defined keycodes that used to fall through to hex."""
+
+    def test_decompose_labels(self):
+        cases = {
+            0x52E2: "PDF(2)",          # persistent default layer
+            0x5604: "SH_T(A)",         # swap-hands tap-hold
+            0x5703: "TD(3)",           # tap dance
+            0x7702: "MACRO(2)",
+            0x7441: "PB(1)",           # programmable button
+            0x7E05: "KB(5)",           # keyboard custom
+            0x7E43: "USER(3)",         # user custom
+        }
+        for kc, expected in cases.items():
+            self.assertEqual(decompose_keycode(kc, KC), expected, hex(kc))
+
+    def test_no_raw_hex_for_these(self):
+        for kc in (0x52E2, 0x5604, 0x5703, 0x7702, 0x7441, 0x7E05, 0x7E43):
+            self.assertNotIn("0x", decompose_keycode(kc, KC), hex(kc))
+
+    def test_named_constant_still_wins(self):
+        # A named entry in the mapping must take priority over parametric decode.
+        mapping = dict(KC)
+        mapping[0x7702] = "MC_MYMACRO"
+        self.assertEqual(decompose_keycode(0x7702, mapping), "MC_MYMACRO")
+
+    def test_describe_badges(self):
+        self.assertEqual(describe_keycode(0x52E2, KC), ("L2", "PDF", BADGE_COLOR_LAYER))
+        self.assertEqual(describe_keycode(0x5604, KC), ("A", "SH", BADGE_COLOR_TAP))
+        self.assertEqual(describe_keycode(0x5703, KC), ("TD", "3", BADGE_COLOR_FW))
+
+    def test_describe_firmware_fallthrough_single_line(self):
+        main, badge, color = describe_keycode(0x7702, KC)   # MACRO(2)
+        self.assertEqual(main, "MACRO(2)")
+        self.assertEqual(badge, "")
+        self.assertIsNone(color)
 
 
 if __name__ == "__main__":

--- a/tests/gui/qmk_keycode_helper_test.py
+++ b/tests/gui/qmk_keycode_helper_test.py
@@ -4,7 +4,7 @@ from polyhost.gui.layout_dialog.qmk_keycode_helper import (
     MOD_CTRL, MOD_SHIFT, MOD_ALT, MOD_GUI, MOD_RIGHT,
     encode_mods, encode_layer_switch, encode_one_shot_mod,
     encode_mod_tap, encode_layer_tap, encode_modded,
-    decompose_keycode, describe_keycode,
+    decompose_keycode, describe_keycode, decode_for_composer,
     BADGE_COLOR_LAYER, BADGE_COLOR_TAP, BADGE_COLOR_MOD,
 )
 
@@ -114,6 +114,49 @@ class TestDescribeKeycode(unittest.TestCase):
         self.assertIn("⇧", main)
         self.assertEqual(badge, "OSM")
         self.assertEqual(color, BADGE_COLOR_LAYER)
+
+
+class TestDecodeForComposer(unittest.TestCase):
+    def test_layer_switches(self):
+        for tag in ("MO", "TO", "TG", "DF", "TT", "OSL"):
+            self.assertEqual(
+                decode_for_composer(encode_layer_switch(tag, 3)),
+                (tag, 3, 0, 0),
+            )
+
+    def test_one_shot_mod(self):
+        self.assertEqual(
+            decode_for_composer(encode_one_shot_mod(MOD_SHIFT)),
+            ("OSM", 0, MOD_SHIFT, 0),
+        )
+
+    def test_mod_tap(self):
+        self.assertEqual(
+            decode_for_composer(encode_mod_tap(MOD_SHIFT, 0x04)),
+            ("MT", 0, MOD_SHIFT, 0x04),
+        )
+
+    def test_layer_tap(self):
+        self.assertEqual(
+            decode_for_composer(encode_layer_tap(2, 0x2C)),
+            ("LT", 2, 0, 0x2C),
+        )
+
+    def test_modded_left_and_right(self):
+        self.assertEqual(
+            decode_for_composer(encode_modded(MOD_CTRL, 0x04)),
+            ("MOD", 0, MOD_CTRL, 0x04),
+        )
+        self.assertEqual(
+            decode_for_composer(encode_modded(MOD_CTRL | MOD_RIGHT, 0x04)),
+            ("MOD", 0, MOD_CTRL | MOD_RIGHT, 0x04),
+        )
+
+    def test_plain_and_unsupported_return_none(self):
+        self.assertIsNone(decode_for_composer(0x0004))   # KC_A
+        self.assertIsNone(decode_for_composer(0x0000))   # KC_NO
+        self.assertIsNone(decode_for_composer(0x5020))   # LM() — not composable
+        self.assertIsNone(decode_for_composer(0x52E1))   # persistent DF*
 
 
 if __name__ == "__main__":

--- a/tests/gui/qmk_keycode_helper_test.py
+++ b/tests/gui/qmk_keycode_helper_test.py
@@ -3,7 +3,7 @@ import unittest
 from polyhost.gui.layout_dialog.qmk_keycode_helper import (
     MOD_CTRL, MOD_SHIFT, MOD_ALT, MOD_GUI, MOD_RIGHT,
     encode_mods, encode_layer_switch, encode_one_shot_mod,
-    encode_mod_tap, encode_layer_tap, encode_modded,
+    encode_mod_tap, encode_layer_tap, encode_modded, encode_layer_mod,
     decompose_keycode, describe_keycode, decode_for_composer,
     BADGE_COLOR_LAYER, BADGE_COLOR_TAP, BADGE_COLOR_MOD,
 )
@@ -50,6 +50,11 @@ class TestEncoders(unittest.TestCase):
         self.assertEqual(encode_modded(MOD_CTRL, 0x04), 0x0104)
         self.assertEqual(encode_modded(MOD_CTRL | MOD_RIGHT, 0x04), 0x1104)
 
+    def test_layer_mod(self):
+        # LM(layer, mod) = QK_LAYER_MOD | (layer << 5) | mod
+        self.assertEqual(encode_layer_mod(1, MOD_CTRL), 0x5021)
+        self.assertEqual(encode_layer_mod(2, MOD_SHIFT), 0x5042)
+
 
 class TestRoundTrip(unittest.TestCase):
     """encode_* must produce keycodes that decompose_keycode reads back correctly."""
@@ -76,6 +81,11 @@ class TestRoundTrip(unittest.TestCase):
     def test_one_shot_mod_roundtrip(self):
         kc = encode_one_shot_mod(MOD_SHIFT)
         self.assertEqual(decompose_keycode(kc, KC), "OSM(LSFT)")
+
+    def test_layer_mod_roundtrip(self):
+        kc = encode_layer_mod(2, MOD_CTRL | MOD_SHIFT)
+        self.assertEqual(decompose_keycode(kc, KC), "LM(2,LCTL+LSFT)")
+        self.assertEqual(decode_for_composer(kc), ("LM", 2, MOD_CTRL | MOD_SHIFT, 0))
 
 
 class TestDescribeKeycode(unittest.TestCase):
@@ -155,8 +165,7 @@ class TestDecodeForComposer(unittest.TestCase):
     def test_plain_and_unsupported_return_none(self):
         self.assertIsNone(decode_for_composer(0x0004))   # KC_A
         self.assertIsNone(decode_for_composer(0x0000))   # KC_NO
-        self.assertIsNone(decode_for_composer(0x5020))   # LM() — not composable
-        self.assertIsNone(decode_for_composer(0x52E1))   # persistent DF*
+        self.assertIsNone(decode_for_composer(0x52E1))   # persistent DF* — not composable
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The dynamic keymap dialog could only assign flat keycodes from the browser — there was no way to **build** QMK quantum keycodes (layer switches, one-shot keys, mod-tap, layer-tap), and several parametric keycodes rendered as raw `0xXXXX` on read-back. This PR adds an end-to-end **composer** (the encode counterpart to the existing decoder), a clearer two-line on-key display, and correct decoding for the remaining parametric/firmware-defined ranges.

## What's new

**New "Layers & Mods" composer tab** (`keycode_composer.py`) — pick a behaviour + parameters, see a live verified preview, and Apply. It emits the same `keycodeSelected` signal, so the device-write path is unchanged. Supported behaviours:

| Group | Behaviours |
|---|---|
| Layer switch | `MO` `TO` `TG` `DF` `PDF` `TT` `OSL` |
| One-shot | `OSM` (mod) |
| Tap/hold dual | `LT` (layer-tap) · `MT` (mod-tap) · `SH_T` (swap-hands tap) |
| Combined | `LM` (layer+mod) · modified key (`Ctrl/Shift/Alt/GUI + key`, L/R) |

- Apply is blocked when a mod-requiring behaviour has no modifier selected.
- The layer spinner is clamped to the device's actual layer count.

**Two-line key tiles** (`renderable_key.py`) — base/tap key shown large, with a small colour-coded behaviour badge underneath:
- amber = layer switches & OSM/PDF · cyan = tap/hold duals (LT/MT/SH_T) · orange = modified keys · violet = firmware-defined (TD/MACRO/…)
- All badge colours are anchored to the same baseline (Unicode mod glyphs `⇧⌃⌥⌘` reported a taller box and previously sat 1px higher).

**Click-to-edit** — clicking a key loads its current setup into the composer and brings the tab to the front (for composable keycodes); plain keys leave the view untouched. Round-trips exactly (re-encoding reproduces the original keycode).

**Correct display for parametric / firmware-defined keycodes** that used to show as hex: `SH_T(kc)`, `TD(n)`, `PDF(n)` (was `DF*`), and `MACRO/PB/KB/USER(n)`. A named constant from `keycodes.h` still wins where one exists.

## Bug fixes along the way
- `LM()` was mis-decoded (`>>4 & 0x0F` instead of `>>5 & 0x1F` per `quantum_keycodes.h`) — fixed in both decode paths.
- Layout dialog now reads the layer count consistently from the value returned by `get_dynamic_layer_count()` rather than a device-internal attribute (also lets the dialog build against `PolyKybdMock`).

## Scope notes
- Tap dance, combos, key overrides, and custom `MACRO/KB/USER` keycodes are **display-only** by design — they're compiled into the firmware (C arrays/callbacks); the dynamic keymap can only store the trigger value, not the behaviour.
- The L/R side toggle applies to the whole modifier set — a faithful limitation of QMK's single side-bit encoding.

## Testing
- 36 new unit tests (encode/decode round-trips, `describe_keycode` badges, named-constant precedence) in `tests/gui/qmk_keycode_helper_test.py`.
- Full suite: **375 passing.**
- Headless (offscreen Qt) smoke tests of the real widgets + full dialog against `PolyKybdMock`: every behaviour encodes to the correct QMK value, two-line tiles render with aligned badges, and click-to-edit round-trips.

https://claude.ai/code/session_013p55VgGmjHHGz7oXumLe1B

---
_Generated by [Claude Code](https://claude.ai/code/session_013p55VgGmjHHGz7oXumLe1B)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a keycode composer tool in the browser for constructing special keycodes (layer switches, one-shot modifiers, mod-tap, layer-tap, and modified keycodes).
  * Key displays now show informational badges indicating held modifiers, target layers, and one-shot states.
  * Improved keycode preview and rendering in the layout dialog.

* **Tests**
  * Added comprehensive tests for keycode encoding and decoding functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->