### PR TITLE
host(lang): keyboard-layout compatibility map

### DIFF
--- a/polyhost/lang/lang_compat.py
+++ b/polyhost/lang/lang_compat.py
@@ -26,9 +26,11 @@ class LangComp:
                         bucket.append(alt)
 
     def has_compatible_lang(self, lang):
-        return lang in self.mapping
+        # Keys are stored lowercased; normalise the lookup too so a match does
+        # not depend on the caller passing a lowercased country code.
+        return bool(lang) and lang.lower() in self.mapping
 
     def get_compatible_lang_list(self, lang):
-        if lang not in self.mapping:
+        if not lang:
             return None
-        return self.mapping[lang]
+        return self.mapping.get(lang.lower())

--- a/polyhost/lang/lang_compat.py
+++ b/polyhost/lang/lang_compat.py
@@ -8,11 +8,22 @@ class LangComp:
         path = os.path.join(pathlib.Path(__file__).parent.parent.resolve(), "res", "forced_country_match.txt")
         with open(path) as file:
             for line in file.readlines():
-                if "=" in line:
-                    key, value = line.split('=')
-                    key = key.strip(" \n\r")
-                    self.mapping[key] = []
-                    self.mapping[key].append(value.strip(" \n\r"))
+                line = line.strip()
+                # Skip blank lines and '#' comments; only "key=value" lines count.
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, value = line.split("=", 1)
+                key = key.strip(" \n\r").lower()
+                if not key:
+                    continue
+                # Values may be comma-separated and/or repeated across lines with
+                # the same key; accumulate (de-duplicated) instead of overwriting,
+                # so one layout can list several compatible OS layouts.
+                bucket = self.mapping.setdefault(key, [])
+                for alt in value.split(","):
+                    alt = alt.strip(" \n\r").lower()
+                    if alt and alt not in bucket:
+                        bucket.append(alt)
 
     def has_compatible_lang(self, lang):
         return lang in self.mapping

--- a/polyhost/res/forced_country_match.txt
+++ b/polyhost/res/forced_country_match.txt
@@ -1,2 +1,31 @@
+# PolyKybd - forced keyboard-layout compatibility map.
+#
+# Each line "a=b[,c,...]" declares that, for the PolyKybd layout whose country
+# code is "a", the OS keyboard layout(s) "b","c",... are acceptable equivalents.
+# linux_kde_helper.set_language() consults this when the keyboard's own country
+# code is not installed as an OS layout and switches the OS to the first listed
+# alternative that is present. Keys are normally PolyKybd layout countries;
+# values are xkb / ISO-3166 alpha-2 codes (Arabic's xkb code is "ara"). Values
+# may be comma-separated or repeated across lines with the same key. Lines
+# starting with '#' (or without '=') are ignored. Reverse entries are harmless.
+
+# German keyboard <-> Austrian OS layout (identical QWERTZ).
 de=at
 at=de
+
+# Croatian keyboard covers the shared ex-Yugoslav Latin QWERTZ - the Bosnian,
+# Montenegrin and Slovenian OS layouts are identical to it (Slovenian, Bosnian
+# and Montenegrin are folded onto hr instead of getting their own entries).
+hr=ba,me,si
+
+# Arabic: the PolyKybd entry is ar-SA, but every Arab state's OS layout uses the
+# single xkb code "ara" - map it so the Arabic layout matches everywhere.
+sa=ara
+
+# Finnish and Swedish share one Fennoscandian layout.
+fi=se
+se=fi
+
+# Norwegian and Danish share the same ae / o-slash / a-ring letter positions.
+no=dk
+dk=no


### PR DESCRIPTION
## Summary
Host-side complement to the 14 new firmware layouts (thpoll83/qmk_firmware PR): layouts that are mechanically identical to an existing PolyKybd layout reuse it via a compatibility map instead of getting their own firmware entry/flag.

- **`polyhost/res/forced_country_match.txt`** — compatibility folds, extending the existing Austria→German mechanism:
  - `hr=ba,me,si` — Bosnian / Montenegrin / Slovenian fold onto the identical Croatian QWERTZ
  - `sa=ara` — the Arabic entry maps to the xkb `ara` code every Arab state's OS layout uses
  - `fi=se` / `no=dk` — the Fennoscandian and Norwegian/Danish equivalences
- **`polyhost/lang/lang_compat.py`** — `LangComp` now accepts comma-separated and repeated-key values (the KDE helper already consumes a list of alternatives) and ignores `#` comments / blank lines, so one keyboard layout can fall back to several compatible OS layouts.

Rule of thumb: identical keymap → fold here; genuinely different keymap (e.g. pt-BR vs pt-PT) → its own firmware entry.

https://claude.ai/code/session_01U69j8s2Phaxg2troJeBT1K

---
_Generated by [Claude Code](https://claude.ai/code/session_01U69j8s2Phaxg2troJeBT1K)_

## Summary by Sourcery

Enhancements:
- Extend language compatibility parsing to ignore comments/blank lines, accept comma-separated values, and accumulate repeated keys into de-duplicated mappings for each layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded language and keyboard layout compatibility support for Croatian, Arabic, Finnish, Swedish, Norwegian, and Danish regions.

* **Bug Fixes**
  * Improved robustness of language and country compatibility matching to handle formatting variations and provide more consistent lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->