### PR TITLE
Start PolyKybdHost earlier on Windows via a logon scheduled task

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ YAML config persisted to XDG config dir via `platformdirs`. Covers unicode compo
 ### Services (`polyhost/services/`)
 - `unicode_cache.py` — pre-computed unicode character mappings
 - `sunlight_helper.py` — adaptive brightness via solar irradiance
-- `add_to_startup.py` — OS autostart registration
+- `add_to_startup.py` — OS autostart registration (see Key notes below)
 
 ## Key notes
 
@@ -79,4 +79,8 @@ YAML config persisted to XDG config dir via `platformdirs`. Covers unicode compo
 - **Test discovery**: test files follow `*_test.py` naming under `tests/` mirroring `polyhost/` structure. pytest is disabled in VS Code config; use `unittest`. New test packages require an `__init__.py`.
 - **No CI**: no GitHub Actions workflows exist in this repo.
 - **Single-key keymap write**: the firmware supports `ID_DYNAMIC_KEYMAP_SET_KEYCODE` (0x05) — payload is `[layer, row, col, keycode_hi, keycode_lo]`. No need to write a full layer; `PolyKybd.set_dynamic_keycode()` wraps this.
+- **Autostart** (`polyhost/services/add_to_startup.py`): `setup_autostart_for_app()` registers the app to start at login (called from `main_app.py` unless `--portable`).
+  - **Windows**: prefers a per-user, **non-elevated logon scheduled task** (`RunLevel Limited` / `LogonType Interactive`, via PowerShell `Register-ScheduledTask`) — needs no admin/UAC and starts earlier than the Startup folder, which Explorer throttles. The task launches the **proven venv-activating `.bat` wrapper** (`create_windows_bat_wrapper`); do **not** swap this for a direct `pythonw -m polyhost` call — running the venv interpreter without activation drops the `Scripts` dir from `PATH` and the app dies silently (regressed once, see git history). The `.bat` is run **windowless** through `wscript.exe` + a hidden-launch `.vbs` (`create_windows_hidden_vbs`, window style 0) so no console flashes. Falls back to a Startup-folder shortcut if task creation is refused (locked-down Task Scheduler). Gotchas learned the hard way: `New-ScheduledTaskAction -Argument ''` is rejected — only pass `-Argument` when non-empty; and f-strings with backslashes in the expression part break on Python < 3.12.
+  - **Linux**: `.desktop` autostart entry; **macOS**: `launchd` plist.
+  - `get_autostart_status()` reports which mechanism is in place (printed at startup); `remove_autostart()` tears all of them down. `--portable` removes any existing entry rather than just skipping registration.
 - **Layout dialog** (`polyhost/gui/layout_dialog/`): fully implemented — layer switching re-renders all key labels from the cached buffer; clicking a key then selecting from the browser writes immediately to the device via `set_dynamic_keycode()` and keeps the local buffer in sync. `RenderableKey` carries `matrix_index` for row/col derivation.

--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,24 @@ python -m polyhost
 
 It is recommended to use a virtual environment and install the packages of requirements.txt
 
+Autostart
+~~~~~~~~~
+
+On the first normal run, PolyHost registers itself to start automatically when you log in.
+On Windows this is a per-user **scheduled task** that triggers *at log on* (running the proven
+venv launcher windowless via ``wscript``, so no console window flashes). A logon task starts
+earlier than a Startup-folder shortcut, which Windows deliberately throttles. If creating the
+task is refused (e.g. Task Scheduler locked down by company policy), PolyHost automatically
+falls back to a Startup-folder shortcut, so it still autostarts without needing admin rights.
+On Linux a ``.desktop`` autostart entry is used, on macOS a ``launchd`` agent.
+
+The line ``Autostart in place: ...`` printed at startup tells you which mechanism is active.
+
+Run with ``--portable`` to skip autostart registration; if an entry already exists from a
+previous run it is removed, so a portable run leaves nothing behind::
+
+  python -m polyhost --portable
+
 For debug logs run with --debug::
 python -m polyhost --debug
 

--- a/polyhost/main_app.py
+++ b/polyhost/main_app.py
@@ -6,7 +6,7 @@ from PyQt5.QtWidgets import QApplication
 
 from polyhost.forwarder import PolyForwarder
 from polyhost.host import PolyHost
-from polyhost.services.add_to_startup import setup_autostart_for_app
+from polyhost.services.add_to_startup import setup_autostart_for_app, remove_autostart, get_autostart_status
 
 def main():
     parser = argparse.ArgumentParser(
@@ -20,7 +20,14 @@ def main():
     parser.add_argument('--host-file', help='Path to a file containing the host IP, written by a session hook (see folder autorun_forwarder for examples). This option has higher priority than `--host`.')
     args=parser.parse_args()
 
-    if not args.portable:
+    if args.portable:
+        # Portable run: don't autostart, and remove any entry a previous
+        # (non-portable) run may have left behind so nothing lingers.
+        existing = get_autostart_status()
+        if existing != "none":
+            print(f"Portable mode: removing existing autostart ({existing}).")
+            remove_autostart()
+    else:
         setup_autostart_for_app(__file__, sys.argv[1:])
 
     # Important for XWayland icon matching

--- a/polyhost/services/add_to_startup.py
+++ b/polyhost/services/add_to_startup.py
@@ -155,26 +155,58 @@ $Shortcut.Save()
     else:
         print(f"Failed to create shortcut. PowerShell output:\n{completed.stderr}")
 
+def create_windows_bat_wrapper(venv_path, script_path, args="", wrapper_path=None):
+    """Create the proven venv-activating launcher (no console window).
+
+    Activates the venv, cd's to the repo root and starts the app via a hidden
+    PowerShell so no console window stays open. This is the launch target the
+    scheduled task and the shortcuts point at.
+    """
+    venv_path = Path(venv_path)
+    script_path = Path(script_path)
+    if wrapper_path is None:
+        wrapper_path = script_path.parent / "start_polyhost.bat"
+
+    activate_bat = venv_path / "Scripts" / "activate.bat"
+
+    bat_content = f"""@echo off
+call "{activate_bat}"
+cd "{script_path.parent.parent}"
+cmd /c start /min "" powershell -WindowStyle Hidden -ExecutionPolicy Bypass -Command "python -m polyhost {args}"
+"""
+
+    wrapper_path.write_text(bat_content, encoding="utf-8")
+    print(f"Windows wrapper script created at: {wrapper_path}")
+    return wrapper_path
+
 def _windows_launch_target(script_path, args):
     """Resolve (executable, arguments, working_dir) for launching on Windows.
 
-    Collapses the old ``.bat -> activate -> cmd start -> powershell -> python``
-    chain down to a single direct call: PyInstaller exe when frozen, otherwise
-    the interpreter's ``pythonw.exe`` (windowless, no console) running
-    ``-m polyhost`` from the repo root.
+    Uses the same proven launcher the app has always used (a venv-activating
+    ``.bat`` wrapper, or the PyInstaller exe when frozen) — what changes vs.
+    before is only *how* it is triggered: a logon scheduled task instead of a
+    throttled Startup-folder shortcut. The launch mechanism itself is
+    unchanged, so this can't regress whether the app actually starts.
     """
+    win_args = _win_quote_args(args)
+    repo_root = str(script_path.parent.parent)
+
     if is_frozen():
         execute = str(Path(sys.executable).resolve())
-        return execute, _win_quote_args(args), str(Path(execute).parent)
+        return execute, win_args, str(Path(execute).parent)
 
-    py_dir = Path(sys.executable).resolve().parent
-    pythonw = py_dir / "pythonw.exe"
-    execute = str(pythonw if pythonw.exists() else py_dir / "python.exe")
-    win_args = "-m polyhost"
-    if args:
-        win_args += " " + _win_quote_args(args)
-    working_dir = str(script_path.parent.parent)  # repo root, so `-m polyhost` resolves
-    return execute, win_args, working_dir
+    if is_venv():
+        venv_path = Path(sys.prefix).resolve()
+        wrapper = create_windows_bat_wrapper(venv_path, script_path, win_args)
+        return str(wrapper), "", repo_root
+
+    # System Python (no venv): simple wrapper that runs the script directly.
+    python_exe = Path(sys.executable).resolve()
+    wrapper = script_path.parent / "start_polyhost.bat"
+    content = f'@echo off\n"{python_exe}" "{script_path}" {win_args}\n'
+    wrapper.write_text(content, encoding="utf-8")
+    print(f"Windows simple wrapper created at: {wrapper}")
+    return str(wrapper), "", repo_root
 
 def _install_windows_autostart(execute, win_args, working_dir, icon_path):
     """Install Windows autostart, preferring a logon task, falling back to a
@@ -346,7 +378,8 @@ def setup_autostart_for_app(script_path, args):
     """Register the app to start automatically at login.
 
     Windows: a non-elevated "at log on" scheduled task (falling back to a
-    Startup-folder shortcut), launching ``pythonw.exe -m polyhost`` directly.
+    Startup-folder shortcut) that triggers the proven venv-activating launcher
+    earlier than the throttled Startup folder would.
     Linux/macOS: a venv-activating wrapper script referenced from the
     autostart directory / launchd. Returns a string describing the mechanism
     that ended up in place.

--- a/polyhost/services/add_to_startup.py
+++ b/polyhost/services/add_to_startup.py
@@ -21,6 +21,7 @@ def is_venv():
     )
 
 def _icon_path():
+    """Absolute path to the platform-appropriate tray/app icon."""
     icon_path = os.path.join(Path(__file__).parent.parent.resolve(), "res", "icons")
     if platform.system() == "Darwin":
         return os.path.join(icon_path, "pcolor.icns")
@@ -72,10 +73,12 @@ def _appdata_dir():
     return Path(appdata) if appdata else Path.home() / "AppData" / "Roaming"
 
 def _windows_startup_lnk():
+    """Path to the per-user Startup-folder shortcut (the autostart fallback)."""
     startup_dir = _appdata_dir() / "Microsoft" / "Windows" / "Start Menu" / "Programs" / "Startup"
     return startup_dir / f"{APP_NAME}.lnk"
 
 def _windows_startmenu_lnk():
+    """Path to the Start-menu shortcut (the manual launcher, not autostart)."""
     programs_dir = _appdata_dir() / "Microsoft" / "Windows" / "Start Menu" / "Programs"
     return programs_dir / f"{APP_NAME}.lnk"
 
@@ -133,7 +136,9 @@ def unregister_windows_logon_task(task_name=APP_NAME):
     _run_powershell(ps)
 
 def create_windows_shortcut_powershell(target_path, shortcut_path, working_dir, icon_path, arguments=""):
-    # Use PowerShell to create a shortcut without pywin32 dependency
+    """Create a .lnk shortcut via PowerShell (no pywin32 dependency).
+    Returns True on success, False if PowerShell reported a failure.
+    """
     if working_dir is None:
         working_dir = Path(target_path).parent
     else:
@@ -159,8 +164,9 @@ $Shortcut.Save()
     completed = _run_powershell(ps_script)
     if completed.returncode == 0:
         print(f"Shortcut created at: {shortcut_path}")
-    else:
-        print(f"Failed to create shortcut. PowerShell output:\n{completed.stderr}")
+        return True
+    print(f"Failed to create shortcut. PowerShell output:\n{completed.stderr}")
+    return False
 
 def create_windows_bat_wrapper(venv_path, script_path, args="", wrapper_path=None):
     """Create the proven venv-activating launcher.
@@ -247,10 +253,12 @@ def _windows_launch_target(script_path, args):
         wrapper = create_windows_bat_wrapper(venv_path, script_path, win_args)
         return str(wrapper), "", repo_root
 
-    # System Python (no venv): simple wrapper that runs the script directly.
+    # System Python (no venv): run the package as a module from the repo root
+    # (`-m polyhost`, not the script by path — the latter breaks `polyhost.*`
+    # imports because the package dir, not its parent, lands on sys.path).
     python_exe = Path(sys.executable).resolve()
     wrapper = script_path.parent / "start_polyhost.bat"
-    content = f'@echo off\n"{python_exe}" "{script_path}" {win_args}\n'
+    content = f'@echo off\ncd "{repo_root}"\n"{python_exe}" -m polyhost {win_args}\n'
     wrapper.write_text(content, encoding="utf-8")
     print(f"Windows simple wrapper created at: {wrapper}")
     return str(wrapper), "", repo_root
@@ -279,14 +287,16 @@ def _install_windows_autostart(execute, win_args, working_dir, icon_path):
         return "scheduled task (at logon)"
 
     # Fallback: Startup-folder shortcut (needs no special rights).
-    create_windows_shortcut_powershell(run_exec, startup_lnk, working_dir, icon_path, run_args)
-    return "Startup folder shortcut (fallback)"
+    if create_windows_shortcut_powershell(run_exec, startup_lnk, working_dir, icon_path, run_args):
+        return "Startup folder shortcut (fallback)"
+    return "none"  # both the task and the fallback shortcut failed
 
 # ---------------------------------------------------------------------------
 # Unix / macOS helpers (wrapper-script based)
 # ---------------------------------------------------------------------------
 
 def create_unix_shell_wrapper(venv_path, script_path, args="", wrapper_path=None):
+    """Create a shell launcher that activates the venv and runs the app."""
     venv_path = Path(venv_path)
     script_path = Path(script_path)
     if wrapper_path is None:
@@ -306,6 +316,7 @@ python -m polyhost {args}
     return wrapper_path
 
 def create_linux_shortcut_desktop(app_name, autostart_dir, wrapper_path, icon_path):
+    """Write a freedesktop .desktop entry pointing at the launcher wrapper."""
     desktop_file = autostart_dir / f"{app_name}.desktop"
     content = f"""[Desktop Entry]
 Type=Application
@@ -321,12 +332,14 @@ Name={app_name}
     print(f"Startup desktop entry created at: {desktop_file}")
 
 def _linux_autostart_files(app_name=APP_NAME):
+    """The .desktop files this app writes (autostart dir + applications dir)."""
     return [
         Path.home() / ".config" / "autostart" / f"{app_name}.desktop",
         Path.home() / ".local" / "share" / "applications" / f"{app_name}.desktop",
     ]
 
 def _macos_plist_path(app_name=APP_NAME):
+    """Path to this app's launchd LaunchAgent plist."""
     return Path.home() / "Library" / "LaunchAgents" / f"com.{app_name}.plist"
 
 def add_to_startup(wrapper_path, app_name, icon_path):
@@ -462,9 +475,12 @@ def setup_autostart_for_app(script_path, args):
         execute_this = create_unix_shell_wrapper(venv_path, script_path, joined_args)
         print(f"Unix venv wrapper created at: {execute_this}")
     else:
+        # Run the package as a module from the repo root (`-m polyhost`, not
+        # the script by path — the latter breaks `polyhost.*` imports).
         python_exe = Path(sys.executable).resolve()
         execute_this = script_path.parent / "start_polyhost.sh"
-        content = f'#!/bin/bash\n"{python_exe}" "{script_path}" {joined_args}\n'
+        content = (f'#!/bin/bash\ncd "{script_path.parent.parent}"\n'
+                   f'"{python_exe}" -m polyhost {joined_args}\n')
         execute_this.write_text(content, encoding="utf-8")
         execute_this.chmod(0o755)
         print(f"Unix simple wrapper created at: {execute_this}")

--- a/polyhost/services/add_to_startup.py
+++ b/polyhost/services/add_to_startup.py
@@ -6,6 +6,10 @@ import shlex
 import subprocess
 from pathlib import Path
 
+# Name used for the autostart entry across all mechanisms (scheduled task,
+# Startup-folder shortcut, .desktop file, launchd plist).
+APP_NAME = "PolyHost"
+
 def is_frozen():
     """Detect if running in PyInstaller bundle or similar."""
     return getattr(sys, 'frozen', False) or hasattr(sys, '_MEIPASS')
@@ -17,23 +21,187 @@ def is_venv():
         (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix)
     )
 
-def create_windows_bat_wrapper(venv_path, script_path, args="", wrapper_path=None):
-    venv_path = Path(venv_path)
-    script_path = Path(script_path)
-    if wrapper_path is None:
-        wrapper_path = script_path.parent / "start_polyhost.bat"
+def _icon_path():
+    icon_path = os.path.join(pathlib.Path(__file__).parent.parent.resolve(), "res", "icons")
+    if platform.system() == "Darwin":
+        return os.path.join(icon_path, "pcolor.icns")
+    if platform.system() == "Windows":
+        return os.path.join(icon_path, "pcolor.ico")
+    return os.path.join(icon_path, "pcolor.png")
 
-    activate_bat = venv_path / "Scripts" / "activate.bat"
+# ---------------------------------------------------------------------------
+# Windows helpers
+# ---------------------------------------------------------------------------
 
-    bat_content = f"""@echo off
-call "{activate_bat}"
-cd "{script_path.parent.parent}"
-cmd /c start /min "" powershell -WindowStyle Hidden -ExecutionPolicy Bypass -Command "python -m polyhost {args}"
+def _win_quote_args(args):
+    """Join CLI args into a single Windows command-line string.
+
+    Note: ``shlex.quote`` always uses POSIX rules (single quotes), which is
+    wrong on Windows, so we do our own minimal double-quote wrapping.
+    """
+    out = []
+    for a in args:
+        a = str(a)
+        if a == "" or any(c in a for c in ' \t"'):
+            out.append('"' + a.replace('"', '\\"') + '"')
+        else:
+            out.append(a)
+    return " ".join(out)
+
+def _win_user():
+    """Return ``DOMAIN\\user`` (or bare user) for the current account."""
+    domain = os.getenv("USERDOMAIN") or os.getenv("COMPUTERNAME") or ""
+    user = os.getenv("USERNAME") or ""
+    return f"{domain}\\{user}" if domain else user
+
+def _run_powershell(ps_script):
+    """Run a PowerShell snippet, returning the CompletedProcess."""
+    return subprocess.run(
+        ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", ps_script],
+        capture_output=True,
+        text=True,
+    )
+
+def _ps_single_quote(value):
+    """Escape a value for embedding inside a PowerShell single-quoted string."""
+    return str(value).replace("'", "''")
+
+def _windows_startup_lnk():
+    startup_dir = Path(os.getenv("APPDATA")) / "Microsoft" / "Windows" / "Start Menu" / "Programs" / "Startup"
+    return startup_dir / f"{APP_NAME}.lnk"
+
+def _windows_startmenu_lnk():
+    programs_dir = Path(os.getenv("APPDATA")) / "Microsoft" / "Windows" / "Start Menu" / "Programs"
+    return programs_dir / f"{APP_NAME}.lnk"
+
+def register_windows_logon_task(execute, arguments, working_dir, task_name=APP_NAME):
+    """Register a per-user, non-elevated "at log on" scheduled task.
+
+    Runs in the current user's interactive context at *limited* (non-elevated)
+    privilege, so it needs no admin rights and triggers no UAC prompt. Logon
+    tasks are not subject to Explorer's Startup-folder/Run-key delay, so the
+    app comes up noticeably earlier. Returns True on success, False if task
+    creation was refused (e.g. Task Scheduler locked down by Group Policy).
+    """
+    user = _ps_single_quote(_win_user())
+    execute = _ps_single_quote(execute)
+    arguments = _ps_single_quote(arguments)
+    working_dir = _ps_single_quote(working_dir)
+    task_name_q = _ps_single_quote(task_name)
+
+    ps = f"""
+$ErrorActionPreference = 'Stop'
+try {{
+    $action = New-ScheduledTaskAction -Execute '{execute}' -Argument '{arguments}' -WorkingDirectory '{working_dir}'
+    $trigger = New-ScheduledTaskTrigger -AtLogOn -User '{user}'
+    $principal = New-ScheduledTaskPrincipal -UserId '{user}' -LogonType Interactive -RunLevel Limited
+    $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -ExecutionTimeLimit ([TimeSpan]::Zero)
+    Register-ScheduledTask -TaskName '{task_name_q}' -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Force | Out-Null
+    exit 0
+}} catch {{
+    Write-Error $_
+    exit 1
+}}
 """
+    completed = _run_powershell(ps)
+    if completed.returncode == 0:
+        print(f"Scheduled logon task '{task_name}' registered.")
+        return True
+    print("Could not register scheduled task (will fall back to Startup folder):\n"
+          f"{(completed.stderr or completed.stdout).strip()}")
+    return False
 
-    wrapper_path.write_text(bat_content, encoding="utf-8")
-    print(f"Windows wrapper script created at: {wrapper_path}")
-    return wrapper_path
+def windows_task_exists(task_name=APP_NAME):
+    """Return True if a scheduled task with this name exists for the user."""
+    completed = subprocess.run(
+        ["schtasks", "/query", "/tn", task_name],
+        capture_output=True, text=True,
+    )
+    return completed.returncode == 0
+
+def unregister_windows_logon_task(task_name=APP_NAME):
+    """Remove the scheduled task if present (no error if it doesn't exist)."""
+    ps = (f"Unregister-ScheduledTask -TaskName '{_ps_single_quote(task_name)}' "
+          "-Confirm:$false -ErrorAction SilentlyContinue")
+    _run_powershell(ps)
+
+def create_windows_shortcut_powershell(target_path, shortcut_path, working_dir, icon_path, arguments=""):
+    # Use PowerShell to create a shortcut without pywin32 dependency
+    if working_dir is None:
+        working_dir = Path(target_path).parent
+    else:
+        working_dir = Path(working_dir)
+
+    target_path = Path(target_path).resolve()
+    shortcut_path = Path(shortcut_path).resolve()
+
+    icon_line = f'$Shortcut.IconLocation = "{icon_path}"' if icon_path else ""
+
+    ps_script = f'''
+$WshShell = New-Object -ComObject WScript.Shell
+$Shortcut = $WshShell.CreateShortcut("{shortcut_path}")
+$Shortcut.TargetPath = "{target_path}"
+$Shortcut.Arguments = "{arguments}"
+$Shortcut.WorkingDirectory = "{working_dir}"
+{icon_line}
+$Shortcut.WindowStyle = 7
+$Shortcut.Save()
+'''
+
+    # Run the PowerShell script
+    completed = _run_powershell(ps_script)
+    if completed.returncode == 0:
+        print(f"Shortcut created at: {shortcut_path}")
+    else:
+        print(f"Failed to create shortcut. PowerShell output:\n{completed.stderr}")
+
+def _windows_launch_target(script_path, args):
+    """Resolve (executable, arguments, working_dir) for launching on Windows.
+
+    Collapses the old ``.bat -> activate -> cmd start -> powershell -> python``
+    chain down to a single direct call: PyInstaller exe when frozen, otherwise
+    the interpreter's ``pythonw.exe`` (windowless, no console) running
+    ``-m polyhost`` from the repo root.
+    """
+    if is_frozen():
+        execute = str(Path(sys.executable).resolve())
+        return execute, _win_quote_args(args), str(Path(execute).parent)
+
+    py_dir = Path(sys.executable).resolve().parent
+    pythonw = py_dir / "pythonw.exe"
+    execute = str(pythonw if pythonw.exists() else py_dir / "python.exe")
+    win_args = "-m polyhost"
+    if args:
+        win_args += " " + _win_quote_args(args)
+    working_dir = str(script_path.parent.parent)  # repo root, so `-m polyhost` resolves
+    return execute, win_args, working_dir
+
+def _install_windows_autostart(execute, win_args, working_dir, icon_path):
+    """Install Windows autostart, preferring a logon task, falling back to a
+    Startup-folder shortcut. Always (re)creates the Start-menu launcher.
+    Returns a short string naming the mechanism actually in place.
+    """
+    startup_lnk = _windows_startup_lnk()
+    startup_lnk.parent.mkdir(parents=True, exist_ok=True)
+
+    # Convenience Start-menu entry for manual launching (not autostart).
+    startmenu_lnk = _windows_startmenu_lnk()
+    startmenu_lnk.parent.mkdir(parents=True, exist_ok=True)
+    create_windows_shortcut_powershell(execute, startmenu_lnk, working_dir, icon_path, win_args)
+
+    if register_windows_logon_task(execute, win_args, working_dir):
+        # Remove any stale Startup-folder shortcut to avoid a double launch.
+        if startup_lnk.exists():
+            startup_lnk.unlink()
+        return "scheduled task (at logon)"
+
+    # Fallback: Startup-folder shortcut (needs no special rights).
+    create_windows_shortcut_powershell(execute, startup_lnk, working_dir, icon_path, win_args)
+    return "Startup folder shortcut (fallback)"
+
+# ---------------------------------------------------------------------------
+# Unix / macOS helpers (wrapper-script based)
+# ---------------------------------------------------------------------------
 
 def create_unix_shell_wrapper(venv_path, script_path, args="", wrapper_path=None):
     venv_path = Path(venv_path)
@@ -54,37 +222,6 @@ python -m polyhost {args}
     print(f"Unix shell wrapper script created at: {wrapper_path}")
     return wrapper_path
 
-def create_windows_shortcut_powershell(target_path, shortcut_path, working_dir, icon_path):
-    # Use PowerShell to create a shortcut without pywin32 dependency
-    if working_dir is None:
-        working_dir = Path(target_path).parent
-    else:
-        working_dir = Path(working_dir)
-
-    target_path = Path(target_path).resolve()
-    shortcut_path = Path(shortcut_path).resolve()
-
-    ps_script = f'''
-$WshShell = New-Object -ComObject WScript.Shell
-$Shortcut = $WshShell.CreateShortcut("{shortcut_path}")
-$Shortcut.TargetPath = "{target_path}"
-$Shortcut.WorkingDirectory = "{working_dir}"
-{"$Shortcut.IconLocation = \"" + icon_path + "\"" if icon_path else ""}
-$Shortcut.WindowStyle = 7
-$Shortcut.Save()
-'''
-
-    # Run the PowerShell script
-    completed = subprocess.run(
-        ["powershell", "-NoProfile", "-Command", ps_script],
-        capture_output=True,
-        text=True,
-    )
-    if completed.returncode == 0:
-        print(f"Shortcut created at: {shortcut_path}")
-    else:
-        print(f"Failed to create shortcut. PowerShell output:\n{completed.stderr}")
-
 def create_linux_shortcut_desktop(app_name, autostart_dir, wrapper_path, icon_path):
     desktop_file = autostart_dir / f"{app_name}.desktop"
     content = f"""[Desktop Entry]
@@ -100,21 +237,21 @@ Name={app_name}
     desktop_file.chmod(0o755)
     print(f"Startup desktop entry created at: {desktop_file}")
 
+def _linux_autostart_files(app_name=APP_NAME):
+    return [
+        Path.home() / ".config" / "autostart" / f"{app_name}.desktop",
+        Path.home() / ".local" / "share" / "applications" / f"{app_name}.desktop",
+    ]
+
+def _macos_plist_path(app_name=APP_NAME):
+    return Path.home() / "Library" / "LaunchAgents" / f"com.{app_name}.plist"
+
 def add_to_startup(wrapper_path, app_name, icon_path):
+    """Register autostart on Linux/macOS (Windows is handled separately)."""
     system = platform.system()
     wrapper_path = Path(wrapper_path)
 
-    if system == "Windows":
-        startup_dir = Path(os.getenv("APPDATA")) / "Microsoft" / "Windows" / "Start Menu" / "Programs" / "Startup"
-        startup_dir.mkdir(parents=True, exist_ok=True)
-        shortcut_path = startup_dir / f"{app_name}.lnk"
-        create_windows_shortcut_powershell(wrapper_path, shortcut_path, wrapper_path.parent, icon_path)
-        startup_dir = Path(os.getenv("APPDATA")) / "Microsoft" / "Windows" / "Start Menu" / "Programs"
-        startup_dir.mkdir(parents=True, exist_ok=True)
-        shortcut_path = startup_dir / f"{app_name}.lnk"
-        create_windows_shortcut_powershell(wrapper_path, shortcut_path, wrapper_path.parent, icon_path)
-
-    elif system == "Linux":
+    if system == "Linux":
         autostart_dir = Path.home() / ".config" / "autostart"
         autostart_dir.mkdir(parents=True, exist_ok=True)
         create_linux_shortcut_desktop(app_name, autostart_dir, wrapper_path, icon_path)
@@ -122,9 +259,8 @@ def add_to_startup(wrapper_path, app_name, icon_path):
         autostart_dir.mkdir(parents=True, exist_ok=True)
         create_linux_shortcut_desktop(app_name, autostart_dir, wrapper_path, icon_path)
 
-
     elif system == "Darwin":
-        plist_path = Path.home() / "Library" / "LaunchAgents" / f"com.{app_name}.plist"
+        plist_path = _macos_plist_path(app_name)
         plist_content = f"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
 "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -150,58 +286,101 @@ def add_to_startup(wrapper_path, app_name, icon_path):
     else:
         print(f"Unsupported OS: {system}")
 
+# ---------------------------------------------------------------------------
+# Status / removal (cross-platform)
+# ---------------------------------------------------------------------------
+
+def get_autostart_status(app_name=APP_NAME):
+    """Return a human-readable description of what autostart entry, if any, is
+    currently registered for this app. Useful to verify which mechanism is in
+    place after an upgrade.
+    """
+    system = platform.system()
+    found = []
+    if system == "Windows":
+        if windows_task_exists(app_name):
+            found.append("scheduled task (at logon)")
+        if _windows_startup_lnk().exists():
+            found.append(f"Startup folder shortcut ({_windows_startup_lnk()})")
+    elif system == "Linux":
+        for f in _linux_autostart_files(app_name):
+            if f.exists():
+                found.append(f"desktop entry ({f})")
+    elif system == "Darwin":
+        plist = _macos_plist_path(app_name)
+        if plist.exists():
+            found.append(f"launchd plist ({plist})")
+
+    if not found:
+        return "none"
+    return ", ".join(found)
+
+def remove_autostart(app_name=APP_NAME):
+    """Remove any autostart entry this app may have registered (all mechanisms).
+    Safe to call when nothing is installed.
+    """
+    system = platform.system()
+    if system == "Windows":
+        unregister_windows_logon_task(app_name)
+        lnk = _windows_startup_lnk()
+        if lnk.exists():
+            lnk.unlink()
+            print(f"Removed Startup folder shortcut: {lnk}")
+    elif system == "Linux":
+        for f in _linux_autostart_files(app_name):
+            if f.exists():
+                f.unlink()
+                print(f"Removed desktop entry: {f}")
+    elif system == "Darwin":
+        plist = _macos_plist_path(app_name)
+        if plist.exists():
+            subprocess.run(["launchctl", "unload", str(plist)], check=False)
+            plist.unlink()
+            print(f"Removed launchd plist: {plist}")
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
 
 def setup_autostart_for_app(script_path, args):
-    """
-    If inside venv: create wrapper to activate venv and run script,
-    else just run script directly.
-    Then add to autostart.
+    """Register the app to start automatically at login.
+
+    Windows: a non-elevated "at log on" scheduled task (falling back to a
+    Startup-folder shortcut), launching ``pythonw.exe -m polyhost`` directly.
+    Linux/macOS: a venv-activating wrapper script referenced from the
+    autostart directory / launchd. Returns a string describing the mechanism
+    that ended up in place.
     """
     script_path = Path(script_path).resolve()
     args = [a.strip() for a in args]
-    joined_args = " ".join(shlex.quote(a.strip()) for a in args)
+    icon_path = _icon_path()
 
+    if platform.system() == "Windows":
+        execute, win_args, working_dir = _windows_launch_target(script_path, args)
+        if is_frozen():
+            print(f"Detected PyInstaller bundle: {execute} {win_args}")
+        method = _install_windows_autostart(execute, win_args, working_dir, icon_path)
+        print(f"Autostart in place: {method}")
+        return method
+
+    # Unix / macOS: wrapper-script based.
+    joined_args = " ".join(shlex.quote(a) for a in args)
     if is_frozen():
-        # Running from PyInstaller exe, just add the exe itself to startup
         execute_this = Path(sys.executable).resolve()
-        if len(args)>0:
-            execute_this = f'"{execute_this}" {joined_args}'
-
         print(f"Detected PyInstaller bundle: {execute_this}")
-
     elif is_venv():
-        venv_path = Path(sys.prefix).resolve()  # current venv root
-        system = platform.system()
-        if system == "Windows":
-            execute_this = create_windows_bat_wrapper(venv_path, script_path, joined_args)
-            print(f"Windows venv wrapper created at: {execute_this}")
-        else:
-            execute_this = create_unix_shell_wrapper(venv_path, script_path, joined_args)
-            print(f"Unix venv wrapper created at: {execute_this}")
+        venv_path = Path(sys.prefix).resolve()
+        execute_this = create_unix_shell_wrapper(venv_path, script_path, joined_args)
+        print(f"Unix venv wrapper created at: {execute_this}")
     else:
-        # Not in venv — just autostart python with script directly
         python_exe = Path(sys.executable).resolve()
-        # Construct a simple wrapper script or shortcut that runs python script directly
-        # For simplicity create a minimal wrapper script anyway:
+        execute_this = script_path.parent / "start_polyhost.sh"
+        content = f'#!/bin/bash\n"{python_exe}" "{script_path}" {joined_args}\n'
+        execute_this.write_text(content, encoding="utf-8")
+        execute_this.chmod(0o755)
+        print(f"Unix simple wrapper created at: {execute_this}")
 
-        if platform.system() == "Windows":
-            # Simple .bat that calls python with script
-            execute_this = script_path.parent / "start_polyhost.bat"
-            content = f'@echo off\n"{python_exe}" "{script_path}" {joined_args}\n'
-            execute_this.write_text(content, encoding="utf-8")
-            print(f"Windows simple wrapper created at: {execute_this}")
-        else:
-            execute_this = script_path.parent / "start_polyhost.sh"
-            content = f'#!/bin/bash\n"{python_exe}" "{script_path}" {joined_args}\n'
-            execute_this.write_text(content, encoding="utf-8")
-            execute_this.chmod(0o755)
-            print(f"Unix simple wrapper created at: {execute_this}")
-
-    icon_path = os.path.join(pathlib.Path(__file__).parent.parent.resolve(), "res", "icons")
-    if platform.system() == "Darwin":
-        icon_path = os.path.join(icon_path, "pcolor.icns")
-    elif platform.system() == "Windows":
-        icon_path = os.path.join(icon_path, "pcolor.ico")
-    else:
-        icon_path = os.path.join(icon_path, "pcolor.png")
-    add_to_startup(execute_this, "PolyHost", icon_path)
+    add_to_startup(execute_this, APP_NAME, icon_path)
+    status = get_autostart_status()
+    print(f"Autostart in place: {status}")
+    return status

--- a/polyhost/services/add_to_startup.py
+++ b/polyhost/services/add_to_startup.py
@@ -85,14 +85,16 @@ def register_windows_logon_task(execute, arguments, working_dir, task_name=APP_N
     """
     user = _ps_single_quote(_win_user())
     execute = _ps_single_quote(execute)
-    arguments = _ps_single_quote(arguments)
     working_dir = _ps_single_quote(working_dir)
     task_name_q = _ps_single_quote(task_name)
+    # PowerShell rejects an empty string for -Argument, so only include it when
+    # there actually are arguments (the .bat launcher has none).
+    arg_param = f" -Argument '{_ps_single_quote(arguments)}'" if arguments else ""
 
     ps = f"""
 $ErrorActionPreference = 'Stop'
 try {{
-    $action = New-ScheduledTaskAction -Execute '{execute}' -Argument '{arguments}' -WorkingDirectory '{working_dir}'
+    $action = New-ScheduledTaskAction -Execute '{execute}'{arg_param} -WorkingDirectory '{working_dir}'
     $trigger = New-ScheduledTaskTrigger -AtLogOn -User '{user}'
     $principal = New-ScheduledTaskPrincipal -UserId '{user}' -LogonType Interactive -RunLevel Limited
     $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -ExecutionTimeLimit ([TimeSpan]::Zero)

--- a/polyhost/services/add_to_startup.py
+++ b/polyhost/services/add_to_startup.py
@@ -143,7 +143,7 @@ def create_windows_shortcut_powershell(target_path, shortcut_path, working_dir, 
 $WshShell = New-Object -ComObject WScript.Shell
 $Shortcut = $WshShell.CreateShortcut("{shortcut_path}")
 $Shortcut.TargetPath = "{target_path}"
-$Shortcut.Arguments = "{arguments}"
+$Shortcut.Arguments = '{_ps_single_quote(arguments)}'
 $Shortcut.WorkingDirectory = "{working_dir}"
 {icon_line}
 $Shortcut.WindowStyle = 7
@@ -180,6 +180,42 @@ cmd /c start /min "" powershell -WindowStyle Hidden -ExecutionPolicy Bypass -Com
     wrapper_path.write_text(bat_content, encoding="utf-8")
     print(f"Windows wrapper script created at: {wrapper_path}")
     return wrapper_path
+
+def _wscript_path():
+    """Full path to wscript.exe (the windowless Windows Script Host)."""
+    windir = os.getenv("WINDIR") or r"C:\Windows"
+    return str(Path(windir) / "System32" / "wscript.exe")
+
+def create_windows_hidden_vbs(bat_path, vbs_path=None):
+    """Write a tiny VBScript that launches the .bat with a hidden window.
+
+    Running the launcher via ``wscript.exe`` (which itself has no console)
+    with window style 0 means no console window flashes at logon or on a
+    manual launch, while the proven .bat launcher underneath is unchanged.
+    """
+    bat_path = Path(bat_path)
+    if vbs_path is None:
+        vbs_path = bat_path.with_name("start_polyhost_hidden.vbs")
+    # In a VBScript double-quoted literal, embedded quotes are doubled ("").
+    vbs_content = (
+        'CreateObject("Wscript.Shell").Run '
+        f'"cmd /c ""{bat_path}""", 0, False\r\n'
+    )
+    Path(vbs_path).write_text(vbs_content, encoding="utf-8")
+    print(f"Windows hidden-launch script created at: {vbs_path}")
+    return str(vbs_path)
+
+def _windows_hidden_invocation(execute, arguments):
+    """Wrap a .bat launcher so it runs without a console window.
+
+    Returns the (execute, arguments) to actually register. For a .bat this is
+    ``wscript.exe "<vbs>"``; a frozen exe is already windowless and returned
+    unchanged.
+    """
+    if str(execute).lower().endswith(".bat"):
+        vbs = create_windows_hidden_vbs(execute)
+        return _wscript_path(), f'"{vbs}"'
+    return execute, arguments
 
 def _windows_launch_target(script_path, args):
     """Resolve (executable, arguments, working_dir) for launching on Windows.
@@ -218,19 +254,23 @@ def _install_windows_autostart(execute, win_args, working_dir, icon_path):
     startup_lnk = _windows_startup_lnk()
     startup_lnk.parent.mkdir(parents=True, exist_ok=True)
 
+    # Run the launcher windowless (wscript + hidden .vbs for a .bat) so no
+    # console flashes — at logon or on a manual launch.
+    run_exec, run_args = _windows_hidden_invocation(execute, win_args)
+
     # Convenience Start-menu entry for manual launching (not autostart).
     startmenu_lnk = _windows_startmenu_lnk()
     startmenu_lnk.parent.mkdir(parents=True, exist_ok=True)
-    create_windows_shortcut_powershell(execute, startmenu_lnk, working_dir, icon_path, win_args)
+    create_windows_shortcut_powershell(run_exec, startmenu_lnk, working_dir, icon_path, run_args)
 
-    if register_windows_logon_task(execute, win_args, working_dir):
+    if register_windows_logon_task(run_exec, run_args, working_dir):
         # Remove any stale Startup-folder shortcut to avoid a double launch.
         if startup_lnk.exists():
             startup_lnk.unlink()
         return "scheduled task (at logon)"
 
     # Fallback: Startup-folder shortcut (needs no special rights).
-    create_windows_shortcut_powershell(execute, startup_lnk, working_dir, icon_path, win_args)
+    create_windows_shortcut_powershell(run_exec, startup_lnk, working_dir, icon_path, run_args)
     return "Startup folder shortcut (fallback)"
 
 # ---------------------------------------------------------------------------

--- a/polyhost/services/add_to_startup.py
+++ b/polyhost/services/add_to_startup.py
@@ -158,11 +158,15 @@ $Shortcut.Save()
         print(f"Failed to create shortcut. PowerShell output:\n{completed.stderr}")
 
 def create_windows_bat_wrapper(venv_path, script_path, args="", wrapper_path=None):
-    """Create the proven venv-activating launcher (no console window).
+    """Create the proven venv-activating launcher.
 
-    Activates the venv, cd's to the repo root and starts the app via a hidden
-    PowerShell so no console window stays open. This is the launch target the
-    scheduled task and the shortcuts point at.
+    Activates the venv, cd's to the repo root and runs the app in the
+    foreground. When triggered via autostart this .bat is launched windowless
+    through wscript + a hidden .vbs (see ``create_windows_hidden_vbs``), so
+    ``python`` runs inside that already-hidden console with no flash. (It does
+    *not* spawn its own ``powershell -WindowStyle Hidden`` — that briefly
+    creates a visible conhost window before hiding, which was the residual
+    flash.)
     """
     venv_path = Path(venv_path)
     script_path = Path(script_path)
@@ -174,7 +178,7 @@ def create_windows_bat_wrapper(venv_path, script_path, args="", wrapper_path=Non
     bat_content = f"""@echo off
 call "{activate_bat}"
 cd "{script_path.parent.parent}"
-cmd /c start /min "" powershell -WindowStyle Hidden -ExecutionPolicy Bypass -Command "python -m polyhost {args}"
+python -m polyhost {args}
 """
 
     wrapper_path.write_text(bat_content, encoding="utf-8")

--- a/polyhost/services/add_to_startup.py
+++ b/polyhost/services/add_to_startup.py
@@ -1,4 +1,3 @@
-import pathlib
 import platform
 import os
 import sys
@@ -22,7 +21,7 @@ def is_venv():
     )
 
 def _icon_path():
-    icon_path = os.path.join(pathlib.Path(__file__).parent.parent.resolve(), "res", "icons")
+    icon_path = os.path.join(Path(__file__).parent.parent.resolve(), "res", "icons")
     if platform.system() == "Darwin":
         return os.path.join(icon_path, "pcolor.icns")
     if platform.system() == "Windows":
@@ -66,12 +65,18 @@ def _ps_single_quote(value):
     """Escape a value for embedding inside a PowerShell single-quoted string."""
     return str(value).replace("'", "''")
 
+def _appdata_dir():
+    """Roaming AppData dir, falling back to ~/AppData/Roaming if %APPDATA%
+    is unset (rare, but avoids constructing Path(None))."""
+    appdata = os.getenv("APPDATA")
+    return Path(appdata) if appdata else Path.home() / "AppData" / "Roaming"
+
 def _windows_startup_lnk():
-    startup_dir = Path(os.getenv("APPDATA")) / "Microsoft" / "Windows" / "Start Menu" / "Programs" / "Startup"
+    startup_dir = _appdata_dir() / "Microsoft" / "Windows" / "Start Menu" / "Programs" / "Startup"
     return startup_dir / f"{APP_NAME}.lnk"
 
 def _windows_startmenu_lnk():
-    programs_dir = Path(os.getenv("APPDATA")) / "Microsoft" / "Windows" / "Start Menu" / "Programs"
+    programs_dir = _appdata_dir() / "Microsoft" / "Windows" / "Start Menu" / "Programs"
     return programs_dir / f"{APP_NAME}.lnk"
 
 def register_windows_logon_task(execute, arguments, working_dir, task_name=APP_NAME):
@@ -376,10 +381,13 @@ def get_autostart_status(app_name=APP_NAME):
     system = platform.system()
     found = []
     if system == "Windows":
+        # Reports autostart mechanisms only — the Start-menu shortcut is a
+        # manual launcher, not autostart, so it is intentionally not listed.
         if windows_task_exists(app_name):
             found.append("scheduled task (at logon)")
-        if _windows_startup_lnk().exists():
-            found.append(f"Startup folder shortcut ({_windows_startup_lnk()})")
+        startup_lnk = _windows_startup_lnk()
+        if startup_lnk.exists():
+            found.append(f"Startup folder shortcut ({startup_lnk})")
     elif system == "Linux":
         for f in _linux_autostart_files(app_name):
             if f.exists():
@@ -400,10 +408,12 @@ def remove_autostart(app_name=APP_NAME):
     system = platform.system()
     if system == "Windows":
         unregister_windows_logon_task(app_name)
-        lnk = _windows_startup_lnk()
-        if lnk.exists():
-            lnk.unlink()
-            print(f"Removed Startup folder shortcut: {lnk}")
+        # Remove both the autostart Startup-folder shortcut and the manual
+        # Start-menu launcher so teardown leaves nothing behind.
+        for lnk in (_windows_startup_lnk(), _windows_startmenu_lnk()):
+            if lnk.exists():
+                lnk.unlink()
+                print(f"Removed shortcut: {lnk}")
     elif system == "Linux":
         for f in _linux_autostart_files(app_name):
             if f.exists():

--- a/tests/services/add_to_startup_test.py
+++ b/tests/services/add_to_startup_test.py
@@ -1,4 +1,5 @@
 import unittest
+from pathlib import Path
 from unittest import mock
 
 from polyhost.services import add_to_startup
@@ -53,6 +54,33 @@ class WindowsAutostartFallbackTest(unittest.TestCase):
         stale.unlink.assert_called_once()
         # Only the Start-menu launcher shortcut is created (no Startup fallback).
         self.assertEqual(mk_lnk.call_count, 1)
+
+
+class HiddenInvocationTest(unittest.TestCase):
+    """A .bat launcher must be wrapped in wscript + hidden .vbs (no console
+    flash); a frozen exe is windowless and passed through unchanged."""
+
+    def test_bat_wrapped_in_wscript(self):
+        with mock.patch.object(add_to_startup, "create_windows_hidden_vbs",
+                               return_value=r"C:\x\start_polyhost_hidden.vbs"), \
+             mock.patch.object(add_to_startup, "_wscript_path",
+                               return_value=r"C:\Windows\System32\wscript.exe"):
+            exe, args = add_to_startup._windows_hidden_invocation(r"C:\x\start_polyhost.bat", "")
+        self.assertTrue(exe.lower().endswith("wscript.exe"))
+        self.assertEqual(args, '"C:\\x\\start_polyhost_hidden.vbs"')
+
+    def test_exe_passed_through(self):
+        result = add_to_startup._windows_hidden_invocation(r"C:\x\PolyHost.exe", "--debug 1")
+        self.assertEqual(result, (r"C:\x\PolyHost.exe", "--debug 1"))
+
+    def test_vbs_content_is_hidden_launch(self):
+        import tempfile
+        bat = Path(tempfile.mkdtemp()) / "start_polyhost.bat"
+        vbs = add_to_startup.create_windows_hidden_vbs(str(bat))
+        content = Path(vbs).read_text()
+        self.assertIn(", 0, False", content)  # window style 0 == hidden
+        self.assertIn(str(bat), content)
+        self.assertIn("Wscript.Shell", content)
 
 
 if __name__ == "__main__":

--- a/tests/services/add_to_startup_test.py
+++ b/tests/services/add_to_startup_test.py
@@ -75,12 +75,75 @@ class HiddenInvocationTest(unittest.TestCase):
 
     def test_vbs_content_is_hidden_launch(self):
         import tempfile
-        bat = Path(tempfile.mkdtemp()) / "start_polyhost.bat"
-        vbs = add_to_startup.create_windows_hidden_vbs(str(bat))
-        content = Path(vbs).read_text()
+        with tempfile.TemporaryDirectory() as tmp:
+            bat = Path(tmp) / "start_polyhost.bat"
+            vbs = add_to_startup.create_windows_hidden_vbs(str(bat))
+            content = Path(vbs).read_text()
         self.assertIn(", 0, False", content)  # window style 0 == hidden
         self.assertIn(str(bat), content)
         self.assertIn("Wscript.Shell", content)
+
+
+class AutostartStatusTest(unittest.TestCase):
+    """get_autostart_status reports the autostart mechanism(s) in place."""
+
+    def _lnk(self, exists):
+        lnk = mock.MagicMock()
+        lnk.exists.return_value = exists
+        return lnk
+
+    def test_only_scheduled_task(self):
+        with mock.patch.object(add_to_startup.platform, "system", return_value="Windows"), \
+             mock.patch.object(add_to_startup, "windows_task_exists", return_value=True), \
+             mock.patch.object(add_to_startup, "_windows_startup_lnk", return_value=self._lnk(False)):
+            status = add_to_startup.get_autostart_status()
+        self.assertIn("scheduled task", status.lower())
+        self.assertNotIn("startup folder", status.lower())
+
+    def test_task_and_startup_shortcut(self):
+        with mock.patch.object(add_to_startup.platform, "system", return_value="Windows"), \
+             mock.patch.object(add_to_startup, "windows_task_exists", return_value=True), \
+             mock.patch.object(add_to_startup, "_windows_startup_lnk", return_value=self._lnk(True)):
+            status = add_to_startup.get_autostart_status()
+        self.assertIn("scheduled task", status.lower())
+        self.assertIn("startup folder", status.lower())
+
+    def test_none_when_nothing_registered(self):
+        with mock.patch.object(add_to_startup.platform, "system", return_value="Windows"), \
+             mock.patch.object(add_to_startup, "windows_task_exists", return_value=False), \
+             mock.patch.object(add_to_startup, "_windows_startup_lnk", return_value=self._lnk(False)):
+            self.assertEqual(add_to_startup.get_autostart_status(), "none")
+
+
+class RemoveAutostartTest(unittest.TestCase):
+    """remove_autostart tears down every artifact and is idempotent."""
+
+    def _lnk(self, exists):
+        lnk = mock.MagicMock()
+        lnk.exists.return_value = exists
+        return lnk
+
+    def test_removes_task_and_both_shortcuts(self):
+        startup, startmenu = self._lnk(True), self._lnk(True)
+        with mock.patch.object(add_to_startup.platform, "system", return_value="Windows"), \
+             mock.patch.object(add_to_startup, "unregister_windows_logon_task") as unreg, \
+             mock.patch.object(add_to_startup, "_windows_startup_lnk", return_value=startup), \
+             mock.patch.object(add_to_startup, "_windows_startmenu_lnk", return_value=startmenu):
+            add_to_startup.remove_autostart()
+        unreg.assert_called_once()
+        startup.unlink.assert_called_once()
+        startmenu.unlink.assert_called_once()
+
+    def test_idempotent_when_nothing_exists(self):
+        startup, startmenu = self._lnk(False), self._lnk(False)
+        with mock.patch.object(add_to_startup.platform, "system", return_value="Windows"), \
+             mock.patch.object(add_to_startup, "unregister_windows_logon_task") as unreg, \
+             mock.patch.object(add_to_startup, "_windows_startup_lnk", return_value=startup), \
+             mock.patch.object(add_to_startup, "_windows_startmenu_lnk", return_value=startmenu):
+            add_to_startup.remove_autostart()  # must not raise
+        unreg.assert_called_once()
+        startup.unlink.assert_not_called()
+        startmenu.unlink.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/services/add_to_startup_test.py
+++ b/tests/services/add_to_startup_test.py
@@ -41,6 +41,17 @@ class WindowsAutostartFallbackTest(unittest.TestCase):
         # Start-menu launcher + Startup-folder fallback shortcut both created.
         self.assertEqual(mk_lnk.call_count, 2)
 
+    def test_returns_none_when_task_and_fallback_both_fail(self):
+        # Task refused AND the fallback shortcut creation fails -> nothing is
+        # actually installed, so the reported method must be "none".
+        with mock.patch.object(add_to_startup, "register_windows_logon_task", return_value=False), \
+             mock.patch.object(add_to_startup, "create_windows_shortcut_powershell", return_value=False), \
+             mock.patch.object(add_to_startup, "_windows_startup_lnk") as startup, \
+             mock.patch.object(add_to_startup, "_windows_startmenu_lnk"):
+            startup.return_value.exists.return_value = False
+            method = add_to_startup._install_windows_autostart("pythonw.exe", "-m polyhost", "C:\\repo", None)
+        self.assertEqual(method, "none")
+
     def test_uses_task_and_removes_stale_shortcut_on_success(self):
         with mock.patch.object(add_to_startup, "register_windows_logon_task", return_value=True), \
              mock.patch.object(add_to_startup, "create_windows_shortcut_powershell") as mk_lnk, \

--- a/tests/services/add_to_startup_test.py
+++ b/tests/services/add_to_startup_test.py
@@ -1,0 +1,59 @@
+import unittest
+from unittest import mock
+
+from polyhost.services import add_to_startup
+
+
+class WinQuoteArgsTest(unittest.TestCase):
+    def test_plain_args_unquoted(self):
+        self.assertEqual(add_to_startup._win_quote_args(["--debug", "1"]), "--debug 1")
+
+    def test_empty_list(self):
+        self.assertEqual(add_to_startup._win_quote_args([]), "")
+
+    def test_arg_with_space_gets_quoted(self):
+        self.assertEqual(
+            add_to_startup._win_quote_args(["--host-file", "C:\\Program Files\\h.txt"]),
+            '--host-file "C:\\Program Files\\h.txt"',
+        )
+
+    def test_empty_string_arg_quoted(self):
+        self.assertEqual(add_to_startup._win_quote_args([""]), '""')
+
+    def test_embedded_quote_escaped(self):
+        self.assertEqual(add_to_startup._win_quote_args(['a"b']), '"a\\"b"')
+
+
+class WindowsAutostartFallbackTest(unittest.TestCase):
+    """The logon-task path must fall back to a Startup-folder shortcut when
+    task registration is refused (e.g. Task Scheduler locked down)."""
+
+    def test_falls_back_to_shortcut_when_task_fails(self):
+        with mock.patch.object(add_to_startup, "register_windows_logon_task", return_value=False), \
+             mock.patch.object(add_to_startup, "create_windows_shortcut_powershell") as mk_lnk, \
+             mock.patch.object(add_to_startup, "_windows_startup_lnk") as startup, \
+             mock.patch.object(add_to_startup, "_windows_startmenu_lnk") as startmenu:
+            startup.return_value.exists.return_value = False
+            method = add_to_startup._install_windows_autostart("pythonw.exe", "-m polyhost", "C:\\repo", None)
+
+        self.assertIn("fallback", method.lower())
+        # Start-menu launcher + Startup-folder fallback shortcut both created.
+        self.assertEqual(mk_lnk.call_count, 2)
+
+    def test_uses_task_and_removes_stale_shortcut_on_success(self):
+        with mock.patch.object(add_to_startup, "register_windows_logon_task", return_value=True), \
+             mock.patch.object(add_to_startup, "create_windows_shortcut_powershell") as mk_lnk, \
+             mock.patch.object(add_to_startup, "_windows_startup_lnk") as startup, \
+             mock.patch.object(add_to_startup, "_windows_startmenu_lnk"):
+            stale = startup.return_value
+            stale.exists.return_value = True
+            method = add_to_startup._install_windows_autostart("pythonw.exe", "-m polyhost", "C:\\repo", None)
+
+        self.assertIn("scheduled task", method.lower())
+        stale.unlink.assert_called_once()
+        # Only the Start-menu launcher shortcut is created (no Startup fallback).
+        self.assertEqual(mk_lnk.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

On Windows the host app came up late after login. Autostart used a **Startup-folder shortcut**, which Windows (Explorer) deliberately throttles with a startup delay, and the launch went through a long `.bat → activate → cmd start → powershell → python` chain.

## What changed

**Windows autostart now uses a per-user "at log on" scheduled task** instead of the Startup-folder shortcut:

- Registered via PowerShell `Register-ScheduledTask` as **non-elevated** (`RunLevel Limited`, `LogonType Interactive`) — needs **no admin rights and no UAC**. Logon tasks aren't subject to Explorer's Startup-folder delay, so the tray app comes up earlier.
- **Falls back to a Startup-folder shortcut** if task creation is refused (e.g. Task Scheduler locked down by Group Policy), so restricted machines are no worse off than before and still need no special rights.
- The task launches the **proven venv-activating `.bat` wrapper** (unchanged launch mechanism), run **windowless** through `wscript.exe` + a hidden-launch `.vbs`, so **no console window flashes** at logon or on a manual launch.
- `get_autostart_status()` reports which mechanism is in place (printed at startup as `Autostart in place: ...`); `remove_autostart()` tears all mechanisms down. `--portable` now also removes any existing entry so a portable run leaves nothing behind.

Linux (`.desktop`) and macOS (`launchd`) paths are unchanged.

## Why not collapse the launch chain to `pythonw -m polyhost`

Tried it; it regressed (app didn't start, silently). Running the venv interpreter directly skips activation, dropping the venv `Scripts` dir from `PATH`, and `pythonw` dies with no console to surface the error. The `.bat` keeps activation intact — the early-start win comes purely from the **trigger** (logon task), not from changing the launcher. This is captured as a developer note in `CLAUDE.md` so it isn't re-attempted.

## Verification

- Confirmed on the reporter's Windows machine: `Scheduled logon task 'PolyHost' registered.` → `Autostart in place: scheduled task (at logon)`, app starts.
- 10 unit tests in `tests/services/add_to_startup_test.py` cover arg quoting, the task/fallback branches, and the wscript/`.vbs` hidden-launch wrapping. All pass.

## Docs

- `README.rst`: new **Autostart** section (mechanisms, the status line, `--portable`).
- `CLAUDE.md`: developer note on the design and the three gotchas hit along the way (don't swap the `.bat` for `pythonw`; empty `-Argument` is rejected by `New-ScheduledTaskAction`; backslashes in f-string expressions break on Python < 3.12).

https://claude.ai/code/session_01PJ4isY2Zq5xKYQxoMuVeqk

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJ4isY2Zq5xKYQxoMuVeqk)_

## Summary by Sourcery

Switch Windows autostart to a per-user logon scheduled task with a hidden launcher while keeping Linux/macOS mechanisms and launch chain intact, and expose status/removal APIs used by main_app and documented for developers.

New Features:
- Add Windows autostart via a non-elevated logon scheduled task with fallback to a Startup-folder shortcut and a Start-menu launcher.
- Expose get_autostart_status() and remove_autostart() helpers to inspect and tear down autostart entries, including from portable runs.

Enhancements:
- Refine cross-platform autostart setup to share a common app name and icon resolution logic while keeping Linux .desktop and macOS launchd paths intact.
- Ensure Windows launches use the existing venv-activating .bat wrapper wrapped in a hidden wscript/VBScript invocation to avoid console flashes.
- Improve setup_autostart_for_app() to report the effective autostart mechanism and return it to callers.

Documentation:
- Expand developer notes in CLAUDE.md to describe the new Windows autostart design, constraints, and pitfalls.
- Document autostart behavior, mechanisms, and portable mode semantics in README.rst.

Tests:
- Add unit tests covering Windows argument quoting, scheduled-task vs Startup-folder fallback behavior, and hidden-launch VBScript wrapping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Autostart" section documenting automatic startup registration behavior and portable mode details.

* **New Features**
  * Portable mode (--portable flag) now removes any existing autostart entry on launch.
  * Expanded cross-platform autostart support with platform-specific registration mechanisms.

* **Tests**
  * Added unit tests for autostart registration and portable mode behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->