### PR TITLE
device: replace assert with proper prefix check in enumerate_lang; add multi-packet test

### DIFF
--- a/polyhost/device/poly_kybd.py
+++ b/polyhost/device/poly_kybd.py
@@ -321,9 +321,12 @@ class PolyKybd:
             return False, "Could not receive language list."
         lang_str = ""
 
+        expected = expect(Cmd.GET_LANG_LIST).decode()
         reply = reply.decode().strip('\x00')
         while result and len(reply) > 3:
-            assert reply.startswith(expect(Cmd.GET_LANG_LIST).decode())
+            if not reply.startswith(expected):
+                self.log.warning("enumerate_lang: unexpected reply prefix, stopping early")
+                break
             lang_str = f"{lang_str}{reply[3:]}"
             result, reply, lock = self.hid.read_with_lock(15, lock)
             reply = reply.decode().strip('\x00')

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -514,6 +514,8 @@ class PolyHost(QApplication):
                             self.status.setText(f"Incompatible version: {msg}, expected {expected}, got {kb_version}'.")
                             self.connected = False
                     if compatible:
+                        if self.keeb_lang_menu is None:
+                            self.add_supported_lang(self.menu)
                         if connected_now and self.poly_settings.get("unicode_send_composition_mode"):
                             mode = get_input_method()
                             self.log.info("Setting unicode mode to str %s", mode)

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -514,8 +514,7 @@ class PolyHost(QApplication):
                             self.status.setText(f"Incompatible version: {msg}, expected {expected}, got {kb_version}'.")
                             self.connected = False
                     if compatible:
-                        if self.keeb_lang_menu is None:
-                            self.add_supported_lang(self.menu)
+                        self.add_supported_lang(self.menu)
                         if connected_now and self.poly_settings.get("unicode_send_composition_mode"):
                             mode = get_input_method()
                             self.log.info("Setting unicode mode to str %s", mode)
@@ -547,7 +546,12 @@ class PolyHost(QApplication):
         result, msg = self.keeb.enumerate_lang()
         if result:
             self.current_lang = self.keeb.get_current_lang()
-            self.keeb_lang_menu = menu.addMenu(get_icon("language.svg"), f"Selected Language: {self.current_lang[:2]} {self.langcode_to_flag(self.current_lang[2:])}")
+            title = f"Selected Language: {self.current_lang[:2]} {self.langcode_to_flag(self.current_lang[2:])}"
+            if self.keeb_lang_menu is None:
+                self.keeb_lang_menu = menu.addMenu(get_icon("language.svg"), title)
+            else:
+                self.keeb_lang_menu.setTitle(title)
+                self.keeb_lang_menu.clear()
 
             all_languages = sorted(self.keeb.get_lang_list(), key=sort_by_country_abc)
             self.log.debug("Adding %s to language menu", all_languages)

--- a/tests/device/poly_kybd_mock_test.py
+++ b/tests/device/poly_kybd_mock_test.py
@@ -172,6 +172,57 @@ class TestPolyKybdMockLanguage(unittest.TestCase):
         self.assertEqual(self.mock.get_current_lang(), "enUS")
 
 
+# All 58 languages from hid_com.c case 8 (cog-generated, 4 HID packets)
+_ALL_FIRMWARE_LANGS = (
+    "enUSdeDEfrFResESptPTitITtrTRkoKRjaJParSAelGRukUAruRUbeBYkkKZ"  # packet 1
+    "bgBGplPLroROzhCNnlNLheILsvSEfiFInnNOdaDKhuHUcsCZhrHRskSKltLT"  # packet 2
+    "lvLVetEEptBRsrRSmkMKfaIRhiINmrINneNPmnMNurPKenGBesMXdeCHfrBE"  # packet 3
+    "frCAthTHbnINteINtaINzhTWkaGEhyAMidIDazAZisISviVNzhHK"          # packet 4
+)
+
+_ALL_FIRMWARE_LANG_CODES = [
+    # packet 1
+    "enUS", "deDE", "frFR", "esES", "ptPT", "itIT", "trTR", "koKR",
+    "jaJP", "arSA", "elGR", "ukUA", "ruRU", "beBY", "kkKZ",
+    # packet 2
+    "bgBG", "plPL", "roRO", "zhCN", "nlNL", "heIL", "svSE", "fiFI",
+    "nnNO", "daDK", "huHU", "csCZ", "hrHR", "skSK", "ltLT",
+    # packet 3
+    "lvLV", "etEE", "ptBR", "srRS", "mkMK", "faIR", "hiIN", "mrIN",
+    "neNP", "mnMN", "urPK", "enGB", "esMX", "deCH", "frBE",
+    # packet 4
+    "frCA", "thTH", "bnIN", "teIN", "taIN", "zhTW", "kaGE", "hyAM",
+    "idID", "azAZ", "isIS", "viVN", "zhHK",
+]
+
+
+class TestPolyKybdMockAllFirmwareLanguages(unittest.TestCase):
+    """Mock initialised with the full 58-language set from the firmware."""
+
+    def setUp(self):
+        self.mock = make_mock(lang="enUS", langs=_ALL_FIRMWARE_LANGS)
+
+    def test_enumerate_lang_returns_full_string(self):
+        ok, langs = self.mock.enumerate_lang()
+        self.assertTrue(ok)
+        self.assertEqual(langs, _ALL_FIRMWARE_LANGS)
+
+    def test_lang_list_has_58_entries(self):
+        self.assertEqual(len(self.mock.get_lang_list()), 58)
+
+    def test_all_language_codes_present(self):
+        langs = self.mock.get_lang_list()
+        for code in _ALL_FIRMWARE_LANG_CODES:
+            with self.subTest(code=code):
+                self.assertIn(code, langs)
+
+    def test_change_to_every_language_succeeds(self):
+        for code in _ALL_FIRMWARE_LANG_CODES:
+            with self.subTest(code=code):
+                ok, _ = self.mock.change_language(code)
+                self.assertTrue(ok)
+
+
 class TestPolyKybdMockOverlayMapping(unittest.TestCase):
     def setUp(self):
         self.mock = make_mock()

--- a/tests/device/poly_kybd_test.py
+++ b/tests/device/poly_kybd_test.py
@@ -80,3 +80,16 @@ class TestEnumerateLangMultiPacket(unittest.TestCase):
         langs = keeb.get_lang_list()
         self.assertIn("enUS", langs)   # P1 was processed
         self.assertNotIn("bgBG", langs)  # loop stopped before P2
+
+    def test_unexpected_prefix_mid_stream_stops_loop(self):
+        """Bad prefix after a valid follow-up packet: earlier langs kept, later ones dropped."""
+        keeb = _make_keeb()
+        junk = _pad(b"X\x00.garbage")
+        keeb.hid.send_and_read_validate_with_lock.return_value = (True, _P1, None)
+        keeb.hid.read_with_lock.side_effect = [(True, _P2, None), (True, junk, None)]
+        ok, _ = keeb.enumerate_lang()
+        self.assertTrue(ok)
+        langs = keeb.get_lang_list()
+        self.assertIn("enUS", langs)   # P1 retained
+        self.assertIn("bgBG", langs)   # P2 retained (arrived before junk)
+        self.assertNotIn("lvLV", langs)  # P3 never reached

--- a/tests/device/poly_kybd_test.py
+++ b/tests/device/poly_kybd_test.py
@@ -1,0 +1,82 @@
+"""Unit tests for PolyKybd.enumerate_lang multi-packet reading.
+
+The firmware sends 4 HID reports in sequence for GET_LANG_LIST.
+These tests verify that all 4 are consumed and parsed, not just the first.
+"""
+import unittest
+from unittest.mock import MagicMock
+
+from polyhost.device.poly_kybd import PolyKybd
+from polyhost.device.device_settings import DeviceSettings
+from polyhost.settings import PolySettings
+
+
+def _pad(data: bytes, size: int = 64) -> bytes:
+    return data + b'\x00' * (size - len(data))
+
+
+# Exact firmware GET_LANG_LIST response packets (from hid_com.c case 8)
+_P1 = _pad(b"P\x08.enUSdeDEfrFResESptPTitITtrTRkoKRjaJParSAelGRukUAruRUbeBYkkKZ")
+_P2 = _pad(b"P\x08.bgBGplPLroROzhCNnlNLheILsvSEfiFInnNOdaDKhuHUcsCZhrHRskSKltLT")
+_P3 = _pad(b"P\x08.lvLVetEEptBRsrRSmkMKfaIRhiINmrINneNPmnMNurPKenGBesMXdeCHfrBE")
+_P4 = _pad(b"P\x08.frCAthTHbnINteINtaINzhTWkaGEhyAMidIDazAZisISviVNzhHK")
+_GET_LANG_ACK = _pad(b"P\x07.enUS")  # response to GET_LANG (query_current_lang)
+
+
+def _make_keeb() -> PolyKybd:
+    keeb = PolyKybd(DeviceSettings(), PolySettings())
+    hid = MagicMock()
+    hid.send_and_read_validate.return_value = (True, _GET_LANG_ACK)
+    keeb.hid = hid
+    return keeb
+
+
+class TestEnumerateLangMultiPacket(unittest.TestCase):
+
+    def _setup_reads(self, keeb: PolyKybd, extra_packets: list[bytes] = None):
+        packets = [_P2, _P3, _P4] + (extra_packets or []) + [b'']
+        keeb.hid.send_and_read_validate_with_lock.return_value = (True, _P1, None)
+        keeb.hid.read_with_lock.side_effect = [(True, p, None) for p in packets]
+
+    def test_all_four_packets_consumed(self):
+        keeb = _make_keeb()
+        self._setup_reads(keeb)
+        ok, _ = keeb.enumerate_lang()
+        self.assertTrue(ok)
+        # 3 follow-up reads (P2, P3, P4) + 1 empty sentinel = 4 total
+        self.assertEqual(keeb.hid.read_with_lock.call_count, 4)
+
+    def test_languages_from_all_packets_present(self):
+        keeb = _make_keeb()
+        self._setup_reads(keeb)
+        keeb.enumerate_lang()
+        langs = keeb.get_lang_list()
+        self.assertIn("enUS", langs)   # packet 1
+        self.assertIn("kkKZ", langs)   # last in packet 1
+        self.assertIn("bgBG", langs)   # packet 2
+        self.assertIn("ltLT", langs)   # last in packet 2
+        self.assertIn("lvLV", langs)   # packet 3
+        self.assertIn("frBE", langs)   # last in packet 3
+        self.assertIn("frCA", langs)   # packet 4
+        self.assertIn("zhHK", langs)   # last in packet 4
+
+    def test_only_first_packet_if_reads_time_out_early(self):
+        keeb = _make_keeb()
+        keeb.hid.send_and_read_validate_with_lock.return_value = (True, _P1, None)
+        keeb.hid.read_with_lock.side_effect = [(True, b'', None)]
+        ok, _ = keeb.enumerate_lang()
+        self.assertTrue(ok)
+        langs = keeb.get_lang_list()
+        self.assertIn("enUS", langs)
+        self.assertNotIn("bgBG", langs)  # P2 was never read
+
+    def test_unexpected_prefix_stops_loop(self):
+        keeb = _make_keeb()
+        junk = _pad(b"X\x00.garbage")
+        keeb.hid.send_and_read_validate_with_lock.return_value = (True, _P1, None)
+        keeb.hid.read_with_lock.side_effect = [(True, junk, None)]
+        ok, _ = keeb.enumerate_lang()
+        self.assertTrue(ok)
+        langs = keeb.get_lang_list()
+        self.assertIn("enUS", langs)   # P1 was processed
+        self.assertNotIn("bgBG", langs)  # loop stopped before P2


### PR DESCRIPTION
The while loop in enumerate_lang correctly reads all N response packets
from the firmware (GET_LANG_LIST, case 8, sends 4 back-to-back). Replace
the assert — which is silently disabled with python -O — with a logged
warning + break so a stale or mismatched reply stops the loop cleanly
rather than crashing in debug and passing corrupt data in optimised mode.

Add tests/device/poly_kybd_test.py to exercise the multi-packet reading
path with a mocked HID interface: verifies all 4 packets are consumed,
all expected language codes end up in all_languages, and that early
timeout or unexpected prefix stops the loop without crashing.

https://claude.ai/code/session_01GhZQeFcV4JFnxdr8K1YGx9

## Summary by Sourcery

Improve language enumeration robustness and test coverage for the Poly keyboard firmware integration.

New Features:
- Add support for dynamically creating or updating the language selection menu on reconnect based on the device’s reported languages.

Bug Fixes:
- Prevent enumerate_lang from crashing or silently accepting corrupt data by replacing an assertion with a guarded prefix check that stops the read loop on unexpected replies.

Enhancements:
- Ensure the language selection submenu is reused and refreshed instead of recreated, updating its title and entries to match the current language list.

Tests:
- Add unit tests for PolyKybd.enumerate_lang to verify correct handling of multi-packet language lists, early timeouts, and unexpected packet prefixes.
- Extend mock device tests to cover the full 58-language firmware set and validate language list contents and language switching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language enumeration error handling to prevent crashes and log warnings gracefully.

* **Improvements**
  * Language menu now automatically refreshes when the device reconnects.
  * Language menu items properly update and repopulate when languages change.

* **Tests**
  * Added comprehensive test coverage for language enumeration and full firmware language support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->