### PR TITLE
Persist keyboard MRU recents on system suspend / shutdown

### DIFF
--- a/polyhost/device/command_ids.py
+++ b/polyhost/device/command_ids.py
@@ -47,3 +47,4 @@ class Cmd(Enum):
     ENTER_BOOTLOADER = 23
     DISPLAY_OFF = 24
     SET_HANDEDNESS = 25
+    SAVE_MRU = 26

--- a/polyhost/device/poly_kybd.py
+++ b/polyhost/device/poly_kybd.py
@@ -269,6 +269,16 @@ class PolyKybd:
                        "True" if idle else "False")
         return self.hid.send_and_read_validate(compose_cmd(Cmd.IDLE_STATE, 1 if idle else 0))
 
+    def save_mru(self) -> tuple[bool, Any]:
+        """Ask the keyboard to persist its emoji/language MRU recents to EEPROM.
+
+        The firmware only writes when the lists actually changed, so this is
+        cheap to send on system suspend/shutdown. The keyboard also saves the
+        MRU autonomously on USB suspend; this is the host-driven "do both" path
+        for clean shutdowns where USB suspend may not fire."""
+        self.log.debug("Requesting MRU save...")
+        return self.hid.send_and_read_validate(compose_cmd(Cmd.SAVE_MRU))
+
     def set_handedness(self, master_is_left: bool) -> tuple[bool, Any]:
         """Fix which half is the left side and which is the right side.
 

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -1016,11 +1016,16 @@ class PolyHost(QApplication):
             if self.keeb:
                 self.keeb.save_mru()
         except Exception as e:  # never let a save attempt break shutdown/sleep
-            self.log.debug("MRU save request failed: %s", e)
+            self.log.debug("MRU save request failed: %s: %s", type(e).__name__, e)
 
     def _install_sleep_listener(self):
         """On Linux, ask systemd-logind to tell us just before the system sleeps
         so we can persist the keyboard MRU. No-op (logged) where unavailable."""
+        # logind / Qt DBus is Linux-only; skip cleanly elsewhere so the QtDBus
+        # import is never attempted on platforms (or minimal Qt builds) without it.
+        if not sys.platform.startswith("linux"):
+            self.log.debug("Sleep listener is Linux-only; skipping on %s.", sys.platform)
+            return
         try:
             from PyQt5.QtDBus import QDBusConnection
             bus = QDBusConnection.systemBus()
@@ -1033,7 +1038,7 @@ class PolyHost(QApplication):
                 self._on_prepare_for_sleep)
             self.log.debug("logind PrepareForSleep listener installed: %s", ok)
         except Exception as e:
-            self.log.debug("Could not install sleep listener: %s", e)
+            self.log.debug("Could not install sleep listener: %s: %s", type(e).__name__, e)
 
     def _on_prepare_for_sleep(self, going_to_sleep):
         # PrepareForSleep(true) fires just before the system suspends.

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -258,7 +258,9 @@ class PolyHost(QApplication):
         
         
         self.setApplicationName('PolyHost')
-        
+
+        # Persist the keyboard MRU just before the system sleeps (Linux/logind).
+        self._install_sleep_listener()
 
         self.setQuitOnLastWindowClosed(False)
         self.is_closing = False
@@ -998,8 +1000,46 @@ class PolyHost(QApplication):
     def quit_app(self):
         self.icon_manager.set_disconnected()
         self.is_closing = True
+        # Persist the keyboard's MRU recents on a clean shutdown (the firmware
+        # only writes if they changed). USB suspend covers the sleep case; this
+        # covers a clean quit/logout where USB suspend may not fire.
+        self.save_keeb_mru()
         self.overlay_handler.close()
         self.quit()
+
+    def save_keeb_mru(self):
+        """Best-effort request to persist the keyboard's emoji/language MRU.
+
+        Safe to call when disconnected — the HID layer just reports failure and
+        we swallow any error so shutdown/sleep is never blocked."""
+        try:
+            if self.keeb:
+                self.keeb.save_mru()
+        except Exception as e:  # never let a save attempt break shutdown/sleep
+            self.log.debug("MRU save request failed: %s", e)
+
+    def _install_sleep_listener(self):
+        """On Linux, ask systemd-logind to tell us just before the system sleeps
+        so we can persist the keyboard MRU. No-op (logged) where unavailable."""
+        try:
+            from PyQt5.QtDBus import QDBusConnection
+            bus = QDBusConnection.systemBus()
+            if not bus.isConnected():
+                self.log.debug("System D-Bus not available; no sleep listener.")
+                return
+            ok = bus.connect(
+                "org.freedesktop.login1", "/org/freedesktop/login1",
+                "org.freedesktop.login1.Manager", "PrepareForSleep",
+                self._on_prepare_for_sleep)
+            self.log.debug("logind PrepareForSleep listener installed: %s", ok)
+        except Exception as e:
+            self.log.debug("Could not install sleep listener: %s", e)
+
+    def _on_prepare_for_sleep(self, going_to_sleep):
+        # PrepareForSleep(true) fires just before the system suspends.
+        if going_to_sleep:
+            self.log.info("System is about to sleep — saving keyboard MRU.")
+            self.save_keeb_mru()
 
     # noinspection PyPep8Naming
     def closeEvent(self, _):


### PR DESCRIPTION
## Summary

Host-side counterpart to the firmware MRU work: triggers the keyboard to persist its MRU recents (emoji + language) to EEPROM when the host system suspends or shuts down, so recents survive a power cycle without writing flash on every selection.

## Notes

- The branch is based on an older `main` and is currently ~16 commits behind it. The PR diff is just this single commit; if GitHub flags a conflict I'll rebase/merge `main` in.

https://claude.ai/code/session_017CnvKvY1mqSFLAaUoLUGBR

---
_Generated by [Claude Code](https://claude.ai/code/session_017CnvKvY1mqSFLAaUoLUGBR)_

## Summary by Sourcery

Persist keyboard MRU recents when the host system suspends or shuts down to survive power cycles without frequent flash writes.

New Features:
- Add a host-initiated command to request the keyboard to save its emoji/language MRU state to EEPROM.
- Hook into Linux systemd-logind sleep notifications to trigger MRU persistence on system suspend.
- Trigger MRU persistence on clean application quit to cover shutdown/logout scenarios where USB suspend may not occur.