### PR TITLE
2026-06 world language batch: host support + fw-up rewind protocol

### DIFF
--- a/polyhost/device/hid_fw_up.py
+++ b/polyhost/device/hid_fw_up.py
@@ -260,18 +260,23 @@ def flash_firmware(hid, bin_path: str, progress_cb=None, cancel_flag: list = Non
     report(2, f"Staging erased. Sending {total_chunks} chunks…")
 
     # -- FW_UP_CHUNK x N --
-    # The firmware relays each chunk to the slave via the split bridge, which
-    # does up to 10 back-to-back retries.  The slave's per-page flash program
-    # (~5 ms IRQ-off every 5th chunk) can occasionally outlast that whole burst,
-    # in which case the master NACKs — but it deliberately keeps both write
-    # cursors un-advanced so the host can SAFELY RE-SEND THE SAME CHUNK (see
-    # hid_fw_up.c CMD_FW_UP_CHUNK).  So a NACK is retried here too, with a
-    # growing pause that gives the slave time to drain its flash work; only
-    # repeated failure of the same chunk aborts.  Use an 8 s read window so a
-    # late NACK still lands inside it.
+    # The firmware relays each chunk to the slave via the split bridge with an
+    # identity-bound reply (the slave echoes its write cursor), so a delivered
+    # chunk is delivered for sure.  Two recovery paths remain:
+    #   * NACK with a resume offset (bytes 3..6 of the reply): the master
+    #     reports the lower of the two halves' write cursors — the stream is
+    #     REWOUND to that offset and re-sent from there.  Both halves ACK
+    #     duplicate chunks idempotently, so overlap is harmless.
+    #   * NACK without a usable resume offset (older firmware sends zeros) or
+    #     a timeout: re-send the same chunk with a growing pause, which rides
+    #     out slave flash-write blackouts; repeated failure aborts.
     _CHUNK_TIMEOUT  = 8000
     _CHUNK_ATTEMPTS = 8
-    for i in range(total_chunks):
+    _MAX_REWINDS    = 100
+    i        = 0
+    attempts = 0
+    rewinds  = 0
+    while i < total_chunks:
         if cancelled():
             _abort_cleanup(hid)
             hid.close_interface()
@@ -282,32 +287,49 @@ def flash_firmware(hid, bin_path: str, progress_cb=None, cancel_flag: list = Non
         padded    = raw_chunk + b'\xff' * (FW_UP_CHUNK_SIZE - len(raw_chunk))
         pkt       = bytearray([HID_POLYKYBD, CMD_FW_UP_CHUNK]) + struct.pack('<I', offset) + padded
 
-        for attempt in range(_CHUNK_ATTEMPTS):
-            ok, reply = hid.send_and_read(pkt, timeout=_CHUNK_TIMEOUT)
-            if ok and len(reply) >= 3 and reply[2] == ord('.'):
-                break
-            if attempt == _CHUNK_ATTEMPTS - 1:
-                reason = ("keyboard rejected the chunk" if ok and len(reply) >= 3
-                          else "no reply from the keyboard")
-                _abort_cleanup(hid)
-                hid.close_interface()
-                return False, (
-                    f"FW_UP_CHUNK failed at offset {offset} after {_CHUNK_ATTEMPTS} attempts "
-                    f"— {reason}.\n"
-                    "Ensure both keyboard halves are connected and running the same firmware, "
-                    "then try again — the update resumes from scratch and is safe to repeat."
-                )
-            # NACK or timeout: back off so the slave half can finish its flash
-            # write / split-link recovery, then re-send the same offset.
-            pause = min(0.05 * (2 ** attempt), 1.0)
-            report(2 + int(96 * (i + 1) / total_chunks),
-                   f"Chunk {i + 1}/{total_chunks} — retry {attempt + 1}/{_CHUNK_ATTEMPTS - 1} "
-                   f"(waiting {int(pause * 1000)} ms)…")
-            time.sleep(pause)
+        ok, reply = hid.send_and_read(pkt, timeout=_CHUNK_TIMEOUT)
+        if ok and len(reply) >= 3 and reply[2] == ord('.'):
+            attempts = 0
+            if i % 100 == 0 or i == total_chunks - 1:
+                pct = 2 + int(96 * (i + 1) / total_chunks)
+                report(pct, f"Chunk {i + 1}/{total_chunks} ({(offset + FW_UP_CHUNK_SIZE) // 1024} KB sent)…")
+            i += 1
+            continue
 
-        if i % 100 == 0 or i == total_chunks - 1:
-            pct = 2 + int(96 * (i + 1) / total_chunks)
-            report(pct, f"Chunk {i + 1}/{total_chunks} ({(offset + FW_UP_CHUNK_SIZE) // 1024} KB sent)…")
+        # Failure.  A NACK reply carries the keyboard's resume offset (the
+        # lower of the two halves' write cursors) in bytes 3..6.
+        resume = struct.unpack_from('<I', reply, 3)[0] if ok and len(reply) >= 7 else 0
+        if (ok and len(reply) >= 7 and reply[2] == ord('!')
+                and 0 < resume < offset and resume % FW_UP_CHUNK_SIZE == 0
+                and rewinds < _MAX_REWINDS):
+            rewinds += 1
+            attempts = 0
+            i = resume // FW_UP_CHUNK_SIZE
+            report(2 + int(96 * (i + 1) / total_chunks),
+                   f"Keyboard halves resynced — rewinding to chunk {i + 1}/{total_chunks} "
+                   f"(offset {resume}, resync {rewinds})…")
+            time.sleep(0.05)
+            continue
+
+        attempts += 1
+        if attempts >= _CHUNK_ATTEMPTS:
+            reason = ("keyboard rejected the chunk" if ok and len(reply) >= 3
+                      else "no reply from the keyboard")
+            _abort_cleanup(hid)
+            hid.close_interface()
+            return False, (
+                f"FW_UP_CHUNK failed at offset {offset} after {_CHUNK_ATTEMPTS} attempts "
+                f"— {reason}.\n"
+                "Ensure both keyboard halves are connected and running the same firmware, "
+                "then try again — the update resumes from scratch and is safe to repeat."
+            )
+        # NACK without a usable resume offset, or timeout: back off so the slave
+        # half can finish its flash write / split-link recovery, then re-send.
+        pause = min(0.05 * (2 ** (attempts - 1)), 1.0)
+        report(2 + int(96 * (i + 1) / total_chunks),
+               f"Chunk {i + 1}/{total_chunks} — retry {attempts}/{_CHUNK_ATTEMPTS - 1} "
+               f"(waiting {int(pause * 1000)} ms)…")
+        time.sleep(pause)
 
     # -- FW_UP_COMMIT --
     # COMMIT verifies the running CRC32 the keyboard accumulated while it staged

--- a/polyhost/device/hid_fw_up.py
+++ b/polyhost/device/hid_fw_up.py
@@ -139,6 +139,25 @@ def get_fw_version(hid) -> tuple[bool, dict]:
     return True, {'version': version, 'fw_size': fw_size, 'fw_crc': fw_crc}
 
 
+def _abort_cleanup(hid) -> None:
+    """Best-effort cleanup after a failed/cancelled transfer.
+
+    A started update leaves BOTH halves in fw_up mode: housekeeping is
+    suppressed and core1 is halted (no overlay decompression), so without
+    cleanup the keyboard appears stuck until it is replugged.  FW_UP_COMMIT's
+    fw_staging_finalize() clears fw_up_active and restarts core1 on each half
+    unconditionally — its CRC verdict only decides the reply — so sending a
+    COMMIT doubles as the abort signal.  The expected '!' (CRC mismatch) reply
+    is ignored; the partially-staged image is never marked valid (the staging
+    header is only stamped on a CRC match).
+    """
+    try:
+        pkt = bytearray([HID_POLYKYBD, CMD_FW_UP_COMMIT])
+        hid.send_and_read(pkt, timeout=5000)
+    except Exception:   # noqa: BLE001 — cleanup must never mask the original error
+        pass
+
+
 def flash_firmware(hid, bin_path: str, progress_cb=None, cancel_flag: list = None) -> tuple[bool, str]:
     """Full HID firmware update flow: BEGIN -> N*CHUNK -> COMMIT.
 
@@ -203,6 +222,7 @@ def flash_firmware(hid, bin_path: str, progress_cb=None, cancel_flag: list = Non
 
     while not begin_ready:
         if time.monotonic() > deadline:
+            _abort_cleanup(hid)
             return False, ("FW_UP_BEGIN timed out — keyboard did not finish erasing "
                            "within 90 s.  Check the USB cable and try again.")
 
@@ -228,6 +248,7 @@ def flash_firmware(hid, bin_path: str, progress_cb=None, cancel_flag: list = Non
             # Loop continues — re-poll.
         else:
             # Explicit '!' NACK — slave can't be prepared (disconnected, old fw, etc.)
+            _abort_cleanup(hid)
             hid.close_interface()
             return False, (
                 "FW_UP_BEGIN failed — the slave half could not be prepared.\n"
@@ -240,13 +261,19 @@ def flash_firmware(hid, bin_path: str, progress_cb=None, cancel_flag: list = Non
 
     # -- FW_UP_CHUNK x N --
     # The firmware relays each chunk to the slave via the split bridge, which
-    # does up to 10 retries.  With a slow/disconnected slave each retry can
-    # take ~500 ms → up to ~5 s total before the firmware sends a NACK.
-    # Use 8 s so the NACK arrives within the window; retry only on genuine
-    # timeouts (empty reply), not on explicit NACKs.
-    _CHUNK_TIMEOUT = 8000
+    # does up to 10 back-to-back retries.  The slave's per-page flash program
+    # (~5 ms IRQ-off every 5th chunk) can occasionally outlast that whole burst,
+    # in which case the master NACKs — but it deliberately keeps both write
+    # cursors un-advanced so the host can SAFELY RE-SEND THE SAME CHUNK (see
+    # hid_fw_up.c CMD_FW_UP_CHUNK).  So a NACK is retried here too, with a
+    # growing pause that gives the slave time to drain its flash work; only
+    # repeated failure of the same chunk aborts.  Use an 8 s read window so a
+    # late NACK still lands inside it.
+    _CHUNK_TIMEOUT  = 8000
+    _CHUNK_ATTEMPTS = 8
     for i in range(total_chunks):
         if cancelled():
+            _abort_cleanup(hid)
             hid.close_interface()
             return False, "Update cancelled by user."
 
@@ -255,20 +282,28 @@ def flash_firmware(hid, bin_path: str, progress_cb=None, cancel_flag: list = Non
         padded    = raw_chunk + b'\xff' * (FW_UP_CHUNK_SIZE - len(raw_chunk))
         pkt       = bytearray([HID_POLYKYBD, CMD_FW_UP_CHUNK]) + struct.pack('<I', offset) + padded
 
-        for attempt in range(3):
+        for attempt in range(_CHUNK_ATTEMPTS):
             ok, reply = hid.send_and_read(pkt, timeout=_CHUNK_TIMEOUT)
             if ok and len(reply) >= 3 and reply[2] == ord('.'):
                 break
-            if ok and len(reply) >= 3 and reply[2] != ord('.'):
-                # Firmware sent explicit NACK — slave half likely not ready.
+            if attempt == _CHUNK_ATTEMPTS - 1:
+                reason = ("keyboard rejected the chunk" if ok and len(reply) >= 3
+                          else "no reply from the keyboard")
+                _abort_cleanup(hid)
                 hid.close_interface()
                 return False, (
-                    f"FW_UP_CHUNK failed at offset {offset} — keyboard rejected the chunk.\n"
-                    "Ensure both keyboard halves are connected and running the same firmware."
+                    f"FW_UP_CHUNK failed at offset {offset} after {_CHUNK_ATTEMPTS} attempts "
+                    f"— {reason}.\n"
+                    "Ensure both keyboard halves are connected and running the same firmware, "
+                    "then try again — the update resumes from scratch and is safe to repeat."
                 )
-            if attempt == 2:
-                hid.close_interface()
-                return False, f"FW_UP_CHUNK timed out at offset {offset} after 3 retries."
+            # NACK or timeout: back off so the slave half can finish its flash
+            # write / split-link recovery, then re-send the same offset.
+            pause = min(0.05 * (2 ** attempt), 1.0)
+            report(2 + int(96 * (i + 1) / total_chunks),
+                   f"Chunk {i + 1}/{total_chunks} — retry {attempt + 1}/{_CHUNK_ATTEMPTS - 1} "
+                   f"(waiting {int(pause * 1000)} ms)…")
+            time.sleep(pause)
 
         if i % 100 == 0 or i == total_chunks - 1:
             pct = 2 + int(96 * (i + 1) / total_chunks)

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -39,7 +39,7 @@ from polyhost.input.linux_gnome_helper import LinuxGnomeInputHelper
 from polyhost.input.linux_kde_helper import LinuxPlasmaHelper
 from polyhost.input.macos_helper import MacOSInputHelper
 from polyhost.input.win_helper import WindowsInputHelper
-from polyhost.services.lang_regions import LANG_REGION, LANG_REGION_ORDER
+from polyhost.services.lang_regions import LANG_REGION, LANG_REGION_ORDER, LANG_REGION_OVERRIDE
 from polyhost.services.unicode_cache import UnicodeCache
 from polyhost.settings import PolySettings
 from polyhost.device.poly_kybd import PolyKybd
@@ -575,7 +575,7 @@ class PolyHost(QApplication):
             self.log.debug("Adding %s to language menu", all_languages)
             by_region: dict[str, list] = {}
             for lang in all_languages:
-                region = LANG_REGION.get(lang[2:].upper(), "Other")
+                region = LANG_REGION_OVERRIDE.get(lang, LANG_REGION.get(lang[2:].upper(), "Other"))
                 by_region.setdefault(region, []).append(lang)
 
             for region in LANG_REGION_ORDER + (["Other"] if "Other" in by_region else []):

--- a/polyhost/res/forced_country_match.txt
+++ b/polyhost/res/forced_country_match.txt
@@ -49,3 +49,40 @@ id=us
 # keyboard onto "us" - the keycaps carry no Han glyphs, matching real mainland
 # Pinyin keyboards. (Shape-based Cangjie/Bopomofo live on zh-HK / zh-TW instead.)
 cn=us
+
+# Plain-US-QWERTY markets (2026-06 world batch): English locales typed on a US
+# board (en-AU/en-NZ/en-ZA/en-CA/en-PG), plain-Latin languages with no extra
+# letters (fj-FJ, tl-PH Filipino, sw-KE Swahili, ms-MY Malay) and IME-composed
+# scripts on a US base (am-ET Amharic phonetic input). The xkb country layouts,
+# where they exist (au/nz/za/ke/ng/ph/et), are preferred automatically because
+# set_language() matches the country code first - these folds are the fallback
+# when only "us" is installed.
+au=us
+nz=us
+fj=us
+ws=us
+ph=us
+za=us
+ke=us
+et=us
+ng=us
+my=us
+ca=us
+pg=us
+
+# French Polynesia (ty-PF): Tahitian is typed on the French AZERTY layout.
+pf=fr
+
+# Maghreb / Mashreq Arabic locales (ar-EG / ar-MA / ar-IQ) use the common xkb
+# "ara" Arabic layout like ar-SA (Morocco's azerty variant keeps the same
+# Arabic letter positions).
+eg=ara
+ma=ara
+iq=ara
+
+# Argentina (es-AR) types on the common Latin-American layout, xkb "latam".
+ar=latam
+
+# Uzbek Latin: the xkb "uz" default is Cyrillic; the Latin variant differs from
+# plain US only by the tutuq (ʻ) on the apostrophe key - fall back to "us".
+uz=us

--- a/polyhost/services/lang_regions.py
+++ b/polyhost/services/lang_regions.py
@@ -111,6 +111,14 @@ LANG_REGION = {
     "TV": "Oceania", "VU": "Oceania", "WF": "Oceania", "WS": "Oceania",
 }
 
+# Per-language overrides for languages whose geographic/cultural home differs
+# from their ISO country code's continent. Key = the keyboard's 4-char language
+# code (e.g. "hwUS"); checked before the country-based LANG_REGION lookup.
+# Keep in sync with REGION_LANGS in qmk_firmware .../polykybd/lang_layer.c.
+LANG_REGION_OVERRIDE = {
+    "hwUS": "Oceania",   # Hawaiian: US country code, but Polynesian
+}
+
 LANG_REGION_ORDER = [
     "Americas",
     "Europe",

--- a/tests/device/hid_fw_up_test.py
+++ b/tests/device/hid_fw_up_test.py
@@ -20,7 +20,7 @@ import struct
 import tempfile
 import os
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from polyhost.device.hid_fw_up import (
     get_fw_version,
@@ -641,35 +641,65 @@ class TestFlashFirmwareChunks(unittest.TestCase):
         finally:
             os.unlink(path)
 
-    def test_chunk_nack_fails_immediately_no_retry(self):
-        # Explicit NACK (slave not ready) must not be retried — fail on first attempt.
+    def test_chunk_nack_retried_then_succeeds(self):
+        # Explicit NACK (slave missed the split RPC) is retried — the firmware
+        # keeps both write cursors un-advanced so re-sending the same offset is
+        # safe (see hid_fw_up.c CMD_FW_UP_CHUNK).
         fw   = _make_polykybd_fw()
         path = _write_bin(fw)
+        n    = _chunks(fw)
         try:
-            hid = _make_hid(
-                [(True, _ack_reply(CMD_FW_UP_BEGIN))] +
-                [(True, _nack_reply(CMD_FW_UP_CHUNK))]   # single NACK → immediate fail
-            )
-            ok, msg = flash_firmware(hid, path)
-            self.assertFalse(ok)
-            self.assertIn('CHUNK', msg)
-            self.assertEqual(hid.send_and_read.call_count, 2)  # 1 BEGIN + 1 attempt only
+            with patch('polyhost.device.hid_fw_up.time.sleep'):
+                hid = _make_hid(
+                    [(True, _ack_reply(CMD_FW_UP_BEGIN)),
+                     (True, _nack_reply(CMD_FW_UP_CHUNK)),    # NACK → retry
+                     (True, _ack_reply(CMD_FW_UP_CHUNK))] +   # retry succeeds
+                    [(True, _ack_reply(CMD_FW_UP_CHUNK))] * (n - 1) +
+                    [(True, _ack_reply(CMD_FW_UP_COMMIT))]
+                )
+                ok, _ = flash_firmware(hid, path)
+                self.assertTrue(ok)
         finally:
             os.unlink(path)
 
-    def test_chunk_timeout_retried_3_times_then_fails(self):
-        # Timeout (ok=False / empty reply) should be retried up to 3 times.
+    def test_chunk_nack_fails_after_8_attempts_with_cleanup(self):
+        # A chunk NACK'd on all 8 attempts aborts — and a cleanup COMMIT is sent
+        # so both halves leave fw_up mode (core1 restart, housekeeping resumes).
         fw   = _make_polykybd_fw()
         path = _write_bin(fw)
         try:
-            hid = _make_hid(
-                [(True, _ack_reply(CMD_FW_UP_BEGIN))] +
-                [(False, bytearray(64))] * 3            # 3 timeouts → fail
-            )
-            ok, msg = flash_firmware(hid, path)
-            self.assertFalse(ok)
-            self.assertIn('CHUNK', msg)
-            self.assertEqual(hid.send_and_read.call_count, 4)  # 1 BEGIN + 3 attempts
+            with patch('polyhost.device.hid_fw_up.time.sleep'):
+                hid = _make_hid(
+                    [(True, _ack_reply(CMD_FW_UP_BEGIN))] +
+                    [(True, _nack_reply(CMD_FW_UP_CHUNK))] * 8 +     # all attempts NACK
+                    [(True, _nack_reply(CMD_FW_UP_COMMIT))]          # cleanup commit
+                )
+                ok, msg = flash_firmware(hid, path)
+                self.assertFalse(ok)
+                self.assertIn('CHUNK', msg)
+                # 1 BEGIN + 8 chunk attempts + 1 cleanup COMMIT
+                self.assertEqual(hid.send_and_read.call_count, 10)
+                last_pkt = hid.send_and_read.call_args_list[-1][0][0]
+                self.assertEqual(last_pkt[1], CMD_FW_UP_COMMIT)
+        finally:
+            os.unlink(path)
+
+    def test_chunk_timeout_retried_8_times_then_fails(self):
+        # Timeout (ok=False / empty reply) is retried up to 8 attempts total.
+        fw   = _make_polykybd_fw()
+        path = _write_bin(fw)
+        try:
+            with patch('polyhost.device.hid_fw_up.time.sleep'):
+                hid = _make_hid(
+                    [(True, _ack_reply(CMD_FW_UP_BEGIN))] +
+                    [(False, bytearray(64))] * 8 +                   # 8 timeouts → fail
+                    [(True, _nack_reply(CMD_FW_UP_COMMIT))]          # cleanup commit
+                )
+                ok, msg = flash_firmware(hid, path)
+                self.assertFalse(ok)
+                self.assertIn('CHUNK', msg)
+                # 1 BEGIN + 8 attempts + 1 cleanup COMMIT
+                self.assertEqual(hid.send_and_read.call_count, 10)
         finally:
             os.unlink(path)
 
@@ -775,7 +805,8 @@ class TestFlashFirmwareCancellation(unittest.TestCase):
             ok, msg = flash_firmware(hid, path, cancel_flag=cancel_flag)
             self.assertFalse(ok)
             self.assertIn('cancel', msg.lower())
-            self.assertEqual(calls[0], 1)  # only BEGIN was sent
+            # BEGIN + the cleanup COMMIT that takes both halves out of fw_up mode
+            self.assertEqual(calls[0], 2)
         finally:
             os.unlink(path)
 
@@ -799,7 +830,8 @@ class TestFlashFirmwareCancellation(unittest.TestCase):
             ok, msg = flash_firmware(hid, path, cancel_flag=cancel_flag)
             self.assertFalse(ok)
             self.assertIn('cancel', msg.lower())
-            self.assertEqual(calls[0], 4)  # BEGIN + 3 chunks
+            # BEGIN + 3 chunks + the cleanup COMMIT
+            self.assertEqual(calls[0], 5)
         finally:
             os.unlink(path)
 

--- a/tests/device/hid_fw_up_test.py
+++ b/tests/device/hid_fw_up_test.py
@@ -662,6 +662,46 @@ class TestFlashFirmwareChunks(unittest.TestCase):
         finally:
             os.unlink(path)
 
+    def test_chunk_nack_with_resume_offset_rewinds(self):
+        # A NACK carrying a resume offset (bytes 3..6) rewinds the stream to
+        # that offset: the keyboard reported the lower of its two halves' write
+        # cursors after a desync, and duplicate chunks are ACK'd idempotently.
+        fw   = _make_polykybd_fw()          # 280 bytes = 5 chunks
+        path = _write_bin(fw)
+        n    = _chunks(fw)
+        sent_offsets = []
+
+        def nack_with_resume(resume):
+            buf = _nack_reply(CMD_FW_UP_CHUNK)
+            struct.pack_into('<I', buf, 3, resume)
+            return buf
+
+        replies = (
+            [(True, _ack_reply(CMD_FW_UP_BEGIN))] +
+            [(True, _ack_reply(CMD_FW_UP_CHUNK))] * 3 +          # chunks 0,1,2
+            [(True, nack_with_resume(1 * FW_UP_CHUNK_SIZE))] +   # chunk 3 → rewind to 1
+            [(True, _ack_reply(CMD_FW_UP_CHUNK))] * (n - 1) +    # chunks 1..4 again
+            [(True, _ack_reply(CMD_FW_UP_COMMIT))]
+        )
+        reply_iter = iter(replies)
+
+        def side_effect(pkt, timeout):
+            if pkt[1] == CMD_FW_UP_CHUNK:
+                sent_offsets.append(struct.unpack_from('<I', pkt, 2)[0])
+            return next(reply_iter)
+
+        try:
+            with patch('polyhost.device.hid_fw_up.time.sleep'):
+                hid = MagicMock()
+                hid.send_and_read.side_effect = side_effect
+                ok, _ = flash_firmware(hid, path)
+                self.assertTrue(ok)
+                # 0,1,2,3 then rewind: 1,2,3,4
+                expected = [0, 56, 112, 168, 56, 112, 168, 224]
+                self.assertEqual(sent_offsets, expected)
+        finally:
+            os.unlink(path)
+
     def test_chunk_nack_fails_after_8_attempts_with_cleanup(self):
         # A chunk NACK'd on all 8 attempts aborts — and a cleanup COMMIT is sent
         # so both halves leave fw_up mode (core1 restart, housekeeping resumes).

--- a/tests/device/poly_kybd_mock_test.py
+++ b/tests/device/poly_kybd_mock_test.py
@@ -172,12 +172,14 @@ class TestPolyKybdMockLanguage(unittest.TestCase):
         self.assertEqual(self.mock.get_current_lang(), "enUS")
 
 
-# All 58 languages from hid_com.c case 8 (cog-generated, 4 HID packets)
+# All 81 languages from hid_com.c case 8 (cog-generated, 6 HID packets)
 _ALL_FIRMWARE_LANGS = (
     "enUSdeDEfrFResESptPTitITtrTRkoKRjaJParSAelGRukUAruRUbeBYkkKZ"  # packet 1
     "bgBGplPLroROzhCNnlNLheILsvSEfiFInnNOdaDKhuHUcsCZhrHRskSKltLT"  # packet 2
     "lvLVetEEptBRsrRSmkMKfaIRhiINmrINneNPmnMNurPKenGBesMXdeCHfrBE"  # packet 3
-    "frCAthTHbnINteINtaINzhTWkaGEhyAMidIDazAZisISviVNzhHK"          # packet 4
+    "frCAthTHbnINteINtaINzhTWkaGEhyAMidIDazAZisISviVNzhHKenAUenNZ"  # packet 4
+    "miNZsmWSfjFJtlPHhwUSenZAafZAarEGswKEamETyoNGenNGarMAarIQkuIQ"  # packet 5
+    "msMYuzUZenCAesARenPGtyPF"                                      # packet 6
 )
 
 _ALL_FIRMWARE_LANG_CODES = [
@@ -192,12 +194,17 @@ _ALL_FIRMWARE_LANG_CODES = [
     "neNP", "mnMN", "urPK", "enGB", "esMX", "deCH", "frBE",
     # packet 4
     "frCA", "thTH", "bnIN", "teIN", "taIN", "zhTW", "kaGE", "hyAM",
-    "idID", "azAZ", "isIS", "viVN", "zhHK",
+    "idID", "azAZ", "isIS", "viVN", "zhHK", "enAU", "enNZ",
+    # packet 5
+    "miNZ", "smWS", "fjFJ", "tlPH", "hwUS", "enZA", "afZA", "arEG",
+    "swKE", "amET", "yoNG", "enNG", "arMA", "arIQ", "kuIQ",
+    # packet 6
+    "msMY", "uzUZ", "enCA", "esAR", "enPG", "tyPF",
 ]
 
 
 class TestPolyKybdMockAllFirmwareLanguages(unittest.TestCase):
-    """Mock initialised with the full 58-language set from the firmware."""
+    """Mock initialised with the full 81-language set from the firmware."""
 
     def setUp(self):
         self.mock = make_mock(lang="enUS", langs=_ALL_FIRMWARE_LANGS)
@@ -207,8 +214,8 @@ class TestPolyKybdMockAllFirmwareLanguages(unittest.TestCase):
         self.assertTrue(ok)
         self.assertEqual(langs, _ALL_FIRMWARE_LANGS)
 
-    def test_lang_list_has_58_entries(self):
-        self.assertEqual(len(self.mock.get_lang_list()), 58)
+    def test_lang_list_has_81_entries(self):
+        self.assertEqual(len(self.mock.get_lang_list()), 81)
 
     def test_all_language_codes_present(self):
         langs = self.mock.get_lang_list()

--- a/tests/device/poly_kybd_test.py
+++ b/tests/device/poly_kybd_test.py
@@ -1,7 +1,7 @@
 """Unit tests for PolyKybd.enumerate_lang multi-packet reading.
 
-The firmware sends 4 HID reports in sequence for GET_LANG_LIST.
-These tests verify that all 4 are consumed and parsed, not just the first.
+The firmware sends 6 HID reports in sequence for GET_LANG_LIST.
+These tests verify that all 6 are consumed and parsed, not just the first.
 """
 import unittest
 from unittest.mock import MagicMock
@@ -19,7 +19,9 @@ def _pad(data: bytes, size: int = 64) -> bytes:
 _P1 = _pad(b"P\x08.enUSdeDEfrFResESptPTitITtrTRkoKRjaJParSAelGRukUAruRUbeBYkkKZ")
 _P2 = _pad(b"P\x08.bgBGplPLroROzhCNnlNLheILsvSEfiFInnNOdaDKhuHUcsCZhrHRskSKltLT")
 _P3 = _pad(b"P\x08.lvLVetEEptBRsrRSmkMKfaIRhiINmrINneNPmnMNurPKenGBesMXdeCHfrBE")
-_P4 = _pad(b"P\x08.frCAthTHbnINteINtaINzhTWkaGEhyAMidIDazAZisISviVNzhHK")
+_P4 = _pad(b"P\x08.frCAthTHbnINteINtaINzhTWkaGEhyAMidIDazAZisISviVNzhHKenAUenNZ")
+_P5 = _pad(b"P\x08.miNZsmWSfjFJtlPHhwUSenZAafZAarEGswKEamETyoNGenNGarMAarIQkuIQ")
+_P6 = _pad(b"P\x08.msMYuzUZenCAesARenPGtyPF")
 _GET_LANG_ACK = _pad(b"P\x07.enUS")  # response to GET_LANG (query_current_lang)
 
 
@@ -34,17 +36,17 @@ def _make_keeb() -> PolyKybd:
 class TestEnumerateLangMultiPacket(unittest.TestCase):
 
     def _setup_reads(self, keeb: PolyKybd, extra_packets: list[bytes] = None):
-        packets = [_P2, _P3, _P4] + (extra_packets or []) + [b'']
+        packets = [_P2, _P3, _P4, _P5, _P6] + (extra_packets or []) + [b'']
         keeb.hid.send_and_read_validate_with_lock.return_value = (True, _P1, None)
         keeb.hid.read_with_lock.side_effect = [(True, p, None) for p in packets]
 
-    def test_all_four_packets_consumed(self):
+    def test_all_six_packets_consumed(self):
         keeb = _make_keeb()
         self._setup_reads(keeb)
         ok, _ = keeb.enumerate_lang()
         self.assertTrue(ok)
-        # 3 follow-up reads (P2, P3, P4) + 1 empty sentinel = 4 total
-        self.assertEqual(keeb.hid.read_with_lock.call_count, 4)
+        # 5 follow-up reads (P2..P6) + 1 empty sentinel = 6 total
+        self.assertEqual(keeb.hid.read_with_lock.call_count, 6)
 
     def test_languages_from_all_packets_present(self):
         keeb = _make_keeb()
@@ -58,7 +60,11 @@ class TestEnumerateLangMultiPacket(unittest.TestCase):
         self.assertIn("lvLV", langs)   # packet 3
         self.assertIn("frBE", langs)   # last in packet 3
         self.assertIn("frCA", langs)   # packet 4
-        self.assertIn("zhHK", langs)   # last in packet 4
+        self.assertIn("enNZ", langs)   # last in packet 4
+        self.assertIn("miNZ", langs)   # packet 5
+        self.assertIn("kuIQ", langs)   # last in packet 5
+        self.assertIn("msMY", langs)   # packet 6
+        self.assertIn("tyPF", langs)   # last in packet 6
 
     def test_only_first_packet_if_reads_time_out_early(self):
         keeb = _make_keeb()

--- a/tools/oled_preview.py
+++ b/tools/oled_preview.py
@@ -235,7 +235,12 @@ def render_key(L: Lang, R: Renderer, lang: str, kc: str, shift: bool, caps: bool
         if v_off != HIDE and h_off != HIDE:
             alt = L.var(li, row, VAR_ALTGR)
             if alt is not None:
-                R.draw(px, alt, 28 + h_off, BASELINE + v_off)
+                # mirror the firmware's right-edge clamp (keymap.c altgr preview)
+                amin, amax = R.bounds(alt)
+                alt_x = 28 + h_off
+                if alt_x + amax > BUFFER_X + SCREEN_WIDTH - 1:
+                    alt_x = (BUFFER_X + SCREEN_WIDTH - 1) - amax
+                R.draw(px, alt, alt_x, BASELINE + v_off)
     return img
 
 


### PR DESCRIPTION
## Summary

- **Host support for 23 new firmware languages** (58 → 81): `forced_country_match.txt` fold entries for all plain-QWERTY locales (au/nz/fj/ws/ph/za/ke/ng/my/ca/pg/uz → us; pf → fr; eg/ma/iq → ara; ar → latam); `lang_regions.py` region assignments for every new country code.
- **`hw-US` geographic override**: `LANG_REGION_OVERRIDE = {"hwUS": "Oceania"}` in `lang_regions.py`; `host.py` checks override before the standard ISO country → region lookup so Hawaiian appears in the Oceania submenu.
- **fw-up rewind-capable chunk stream** (`hid_fw_up.py`): host now handles NACK-with-resume-offset by rewinding the chunk index to `resume_offset // FW_UP_CHUNK_SIZE` and continuing from there — fixes the stale-ACK desync that previously caused firmware update to time out at ~83%. Backoff retry (8 attempts, 50 ms → 1 s) retained for transient errors. `_abort_cleanup()` sends a COMMIT to clear `fw_up_active` on both halves when aborting.
- **`oled_preview.py` AltGr right-edge clamp**: mirrors the firmware fix so the tool stays pixel-accurate.
- **Tests updated**: `hid_fw_up_test.py` covers the rewind path (`test_chunk_nack_with_resume_offset_rewinds`) and cleanup on final failure; language mock tests updated for 81-language firmware (6 GET_LANG_LIST packets).

## Test plan

- [ ] All 403 host unit tests pass (`PolyKybdHost/.venv/bin/python -m unittest discover -v -s ./tests -p "*_test.py"`)
- [ ] Language menu shows all 23 new languages in correct region submenus
- [ ] Hawaiian (`hw-US`) appears in Oceania submenu
- [ ] Firmware update completes end-to-end without desync
- [ ] NACK-with-resume-offset test case passes (rewind path exercised)
- [ ] Abort sends COMMIT cleanup to device

---
_Generated by [Claude Code](https://claude.ai/code/session_014yYQbiMLUu3CD3P5JXXwnZ)_

## Summary by Sourcery

Extend host language support to match new firmware locales, improve firmware update robustness with rewind-aware chunk handling and cleanup, and align UI previews and region menus with updated language data.

New Features:
- Support 81 firmware languages on the host, including additional multi-packet language enumeration and region overrides for special cases like Hawaiian.
- Add rewind-capable firmware update chunk streaming that can resume from keyboard-provided offsets during desync recovery.

Bug Fixes:
- Ensure cancelled or failed firmware updates send a cleanup COMMIT so both halves exit firmware-update mode instead of appearing stuck.
- Fix OLED key preview AltGr positioning at the right edge to match firmware rendering and prevent text from overflowing.

Enhancements:
- Increase firmware update chunk retry logic with backoff, clearer error reporting, and idempotent handling of NACKs and timeouts.
- Update language enumeration tests and mocks to validate the larger language set and multi-packet responses.