### PR TITLE
Decode packed ISO-index language list (cmd 27), protocol-gated

### DIFF
--- a/polyhost/device/command_ids.py
+++ b/polyhost/device/command_ids.py
@@ -48,3 +48,4 @@ class Cmd(Enum):
     DISPLAY_OFF = 24
     SET_HANDEDNESS = 25
     SAVE_MRU = 26
+    GET_LANG_LIST_PACKED = 27

--- a/polyhost/device/poly_kybd.py
+++ b/polyhost/device/poly_kybd.py
@@ -19,6 +19,13 @@ from polyhost.device.hid_helper import HidHelper
 from polyhost.device.im_converter import ImageConverter
 from polyhost.device.keys import KeyCode, Modifier
 from polyhost.device.overlay_cache import OverlayMRUCache
+from polyhost.services import iso_lang_country
+
+# Firmware PROTOCOL_VERSION at which GET_LANG_LIST_PACKED (the compact 2-byte
+# index encoding of the language list) became available. Older firmware (or
+# firmware that reports no protocol version) only understands the ASCII
+# GET_LANG_LIST, so the host stays on that path and never probes the new command.
+PACKED_LANG_LIST_MIN_PROTOCOL = 2
 
 import hid
 
@@ -321,6 +328,53 @@ class PolyKybd:
         if not result:
             return False, msg
 
+        # Firmware new enough for the compact 2-byte-per-language encoding sends
+        # it via GET_LANG_LIST_PACKED. Fall back to the ASCII list if that fails.
+        if (self.protocol_version is not None
+                and self.protocol_version >= PACKED_LANG_LIST_MIN_PROTOCOL):
+            ok, value = self._enumerate_lang_packed()
+            if ok:
+                return ok, value
+            self.log.warning(
+                "Packed language list failed, falling back to ASCII list.")
+        return self._enumerate_lang_ascii()
+
+    def _enumerate_lang_packed(self) -> tuple[bool, str]:
+        """Read the language list as packed (lang_idx, country_idx) byte pairs.
+
+        Wire format mirrors the ASCII list: every HID report is prefixed with the
+        "P<cmd>." response header; the payload across reports is a count byte
+        followed by two index bytes per language. The count makes the total length
+        known after the first report, so termination is deterministic (no reliance
+        on a read timeout). Payload is binary, so it must not be decoded/stripped.
+        """
+        lock = None
+        result, reply, lock = self.hid.send_and_read_validate_with_lock(
+            compose_cmd(Cmd.GET_LANG_LIST_PACKED), 15,
+            expect(Cmd.GET_LANG_LIST_PACKED), lock)
+        # reply[2] is the ACK ('.') / NACK ('!') marker; anything else => unsupported.
+        if not result or len(reply) < 4 or reply[2] != ord('.'):
+            if lock:
+                lock.release()
+            return False, "Could not receive packed language list."
+
+        data = bytearray(reply[3:])
+        total = 1 + 2 * data[0]  # count byte + 2 bytes per language
+        while len(data) < total and result:
+            result, reply, lock = self.hid.read_with_lock(15, lock)
+            data += reply[3:]
+        if lock:
+            lock.release()
+
+        if len(data) < total:
+            return False, "Truncated packed language list."
+        try:
+            self.all_languages = iso_lang_country.decode_packed(data[:total])
+        except (KeyError, IndexError) as e:
+            return False, f"Could not decode packed language list: {e}"
+        return True, "".join(self.all_languages)
+
+    def _enumerate_lang_ascii(self) -> tuple[bool, str]:
         lock = None
         result, reply, lock = self.hid.send_and_read_validate_with_lock(
             compose_cmd(Cmd.GET_LANG_LIST), 15, expect(Cmd.GET_LANG_LIST), lock)

--- a/polyhost/services/iso_lang_country.py
+++ b/polyhost/services/iso_lang_country.py
@@ -1,10 +1,14 @@
 """FROZEN single source of truth: ISO 639-1 language + ISO 3166-1 alpha-2
 country code <-> 1-byte index tables for the PolyKybd GET_LANG_LIST payload.
 
+The keyboard's language list is transmitted as one (lang_idx, country_idx) byte
+pair per language instead of the 4 ASCII chars (cmd GET_LANG_LIST_PACKED). Each
+index is the position of the code in the tuples below.
+
 Generated once from the `iso-codes` package (json), then FROZEN. The index of a
-code is its position in these tuples and is APPEND-ONLY: never reorder, never
-delete; new ISO codes get appended at the next free index. Both the host decoder
-and the firmware encoder must agree on these exact indices.
+code is APPEND-ONLY: never reorder, never delete; new ISO codes get appended at
+the next free index. The host decoder and the firmware encoder must agree on
+these exact indices, so this file is the shared source both are generated from.
 
 Initial assignment (2026-06-10): alphabetical, for determinism only.
 ISO 639-1: 184 codes (idx 0..183); private langs start at 184.
@@ -15,7 +19,10 @@ _LANG = (
     "aa ab ae af ak am an ar as av ay az ba be bg bh bi bm bn bo br bs ca ce ch co cr cs cu cv cy da de dv dz ee el en eo es et eu fa ff fi fj fo fr fy ga gd gl gn gu gv ha he hi ho hr ht hu hy hz ia id ie ig ii ik io is it iu ja jv ka kg ki kj kk kl km kn ko kr ks ku kv kw ky la lb lg li ln lo lt lu lv mg mh mi mk ml mn mr ms mt my na nb nd ne ng nl nn no nr nv ny oc oj om or os pa pi pl ps pt qu rm rn ro ru rw sa sc sd se sg si sk sl sm sn so sq sr ss st su sv sw ta te tg th ti tk tl tn to tr ts tt tw ty ug uk ur uz ve vi vo wa wo xh yi yo za zh zu"
 ).split()
 
-PRIVATE_LANGS = ["hw"]  # appended after the standard block, idx >= len(LANG_CODES)
+# Private-use language pseudo-codes with no ISO 639-1 entry, appended above the
+# standard block. hw = Hawaiian (ISO 639-2/3 'haw' cannot fit the 2-char field).
+PRIVATE_LANGS = ["hw"]
+
 _COUNTRY = (
     "AD AE AF AG AI AL AM AO AQ AR AS AT AU AW AX AZ BA BB BD BE BF BG BH BI BJ BL BM BN BO BQ BR BS BT BV BW BY BZ CA CC CD CF CG CH CI CK CL CM CN CO CR CU CV CW CX CY CZ DE DJ DK DM DO DZ EC EE EG EH ER ES ET FI FJ FK FM FO FR GA GB GD GE GF GG GH GI GL GM GN GP GQ GR GS GT GU GW GY HK HM HN HR HT HU ID IE IL IM IN IO IQ IR IS IT JE JM JO JP KE KG KH KI KM KN KP KR KW KY KZ LA LB LC LI LK LR LS LT LU LV LY MA MC MD ME MF MG MH MK ML MM MN MO MP MQ MR MS MT MU MV MW MX MY MZ NA NC NE NF NG NI NL NO NP NR NU NZ OM PA PE PF PG PH PK PL PM PN PR PS PT PW PY QA RE RO RS RU RW SA SB SC SD SE SG SH SI SJ SK SL SM SN SO SR SS ST SV SX SY SZ TC TD TF TG TH TJ TK TL TM TN TO TR TT TV TW TZ UA UG UM US UY UZ VA VC VE VG VI VN VU WF WS YE YT ZA ZM ZW"
 ).split()
@@ -35,4 +42,19 @@ def encode_pair(code: str) -> bytes:
 
 
 def decode_pair(lang_idx: int, country_idx: int) -> str:
+    """Inverse of encode_pair: 2 indices -> 4-char 'llCC' code."""
     return LANG_CODES[lang_idx] + COUNTRY_CODES[country_idx]
+
+
+def encode_packed(codes) -> bytes:
+    """Encode a list of 4-char codes as: 1 count byte + 2 index bytes per code."""
+    out = bytearray([len(codes)])
+    for code in codes:
+        out += encode_pair(code)
+    return bytes(out)
+
+
+def decode_packed(buf) -> list:
+    """Inverse of encode_packed. buf[0] = count, then count*(lang,country) pairs."""
+    count = buf[0]
+    return [decode_pair(buf[1 + 2 * i], buf[2 + 2 * i]) for i in range(count)]

--- a/tests/device/poly_kybd_test.py
+++ b/tests/device/poly_kybd_test.py
@@ -6,9 +6,10 @@ These tests verify that all 6 are consumed and parsed, not just the first.
 import unittest
 from unittest.mock import MagicMock
 
-from polyhost.device.poly_kybd import PolyKybd
+from polyhost.device.poly_kybd import PolyKybd, PACKED_LANG_LIST_MIN_PROTOCOL
 from polyhost.device.device_settings import DeviceSettings
 from polyhost.settings import PolySettings
+from polyhost.services import iso_lang_country as iso
 
 
 def _pad(data: bytes, size: int = 64) -> bytes:
@@ -99,3 +100,84 @@ class TestEnumerateLangMultiPacket(unittest.TestCase):
         self.assertIn("enUS", langs)   # P1 retained
         self.assertIn("bgBG", langs)   # P2 retained (arrived before junk)
         self.assertNotIn("lvLV", langs)  # P3 never reached
+
+
+# Full firmware language list reconstructed from the ASCII reference packets.
+_ALL_LANGS = [
+    "".join(p[3:].rstrip(b"\x00").decode())
+    for p in (_P1, _P2, _P3, _P4, _P5, _P6)
+]
+_ALL_LANGS = [c for chunk in _ALL_LANGS for c in
+              [chunk[i:i + 4] for i in range(0, len(chunk), 4)]]
+
+
+def _packed_reports(codes, cmd_val=27):
+    """Split iso.encode_packed(codes) into firmware-style HID reports:
+    each report = 'P<cmd>.' header + up to 61 payload bytes, padded to 64."""
+    payload = iso.encode_packed(codes)
+    header = b"P" + bytes([cmd_val]) + b"."
+    reports = []
+    for i in range(0, len(payload), 61):
+        reports.append(_pad(header + payload[i:i + 61]))
+    return reports
+
+
+class TestEnumerateLangPacked(unittest.TestCase):
+
+    def _make_keeb(self, protocol):
+        keeb = PolyKybd(DeviceSettings(), PolySettings())
+        keeb.protocol_version = protocol
+        keeb.hid = MagicMock()
+        keeb.hid.send_and_read_validate.return_value = (True, _GET_LANG_ACK)
+        return keeb
+
+    def test_packed_path_decodes_all_languages(self):
+        keeb = self._make_keeb(PACKED_LANG_LIST_MIN_PROTOCOL)
+        reports = _packed_reports(_ALL_LANGS)
+        keeb.hid.send_and_read_validate_with_lock.return_value = (True, reports[0], None)
+        keeb.hid.read_with_lock.side_effect = [(True, r, None) for r in reports[1:]]
+
+        ok, value = keeb.enumerate_lang()
+        self.assertTrue(ok)
+        self.assertEqual(keeb.get_lang_list(), _ALL_LANGS)
+        for tricky in ("enUS", "hwUS", "kuIQ", "tyPF", "amET"):
+            self.assertIn(tricky, keeb.get_lang_list())
+
+    def test_packed_uses_packed_command_not_ascii(self):
+        keeb = self._make_keeb(PACKED_LANG_LIST_MIN_PROTOCOL)
+        reports = _packed_reports(_ALL_LANGS)
+        keeb.hid.send_and_read_validate_with_lock.return_value = (True, reports[0], None)
+        keeb.hid.read_with_lock.side_effect = [(True, r, None) for r in reports[1:]]
+        keeb.enumerate_lang()
+        sent_cmd = keeb.hid.send_and_read_validate_with_lock.call_args[0][0]
+        self.assertEqual(sent_cmd[1], 27)  # Cmd.GET_LANG_LIST_PACKED
+
+    def test_old_protocol_uses_ascii_path(self):
+        keeb = self._make_keeb(1)  # below the packed threshold
+        keeb.hid.send_and_read_validate_with_lock.return_value = (True, _P1, None)
+        keeb.hid.read_with_lock.side_effect = [(True, b'', None)]
+        ok, _ = keeb.enumerate_lang()
+        self.assertTrue(ok)
+        sent_cmd = keeb.hid.send_and_read_validate_with_lock.call_args[0][0]
+        self.assertEqual(sent_cmd[1], 8)  # Cmd.GET_LANG_LIST (ASCII)
+
+    def test_no_protocol_version_uses_ascii_path(self):
+        keeb = self._make_keeb(None)  # old firmware, no protocol field
+        keeb.hid.send_and_read_validate_with_lock.return_value = (True, _P1, None)
+        keeb.hid.read_with_lock.side_effect = [(True, b'', None)]
+        ok, _ = keeb.enumerate_lang()
+        self.assertTrue(ok)
+        sent_cmd = keeb.hid.send_and_read_validate_with_lock.call_args[0][0]
+        self.assertEqual(sent_cmd[1], 8)
+
+    def test_packed_nack_falls_back_to_ascii(self):
+        keeb = self._make_keeb(PACKED_LANG_LIST_MIN_PROTOCOL)
+        nack = _pad(b"P\x1b!")  # firmware NACKs the packed command
+        # First call (packed) -> NACK; second call (ASCII fallback) -> P1.
+        keeb.hid.send_and_read_validate_with_lock.side_effect = [
+            (True, nack, None), (True, _P1, None)]
+        keeb.hid.read_with_lock.side_effect = [(True, b'', None)]
+        ok, _ = keeb.enumerate_lang()
+        self.assertTrue(ok)
+        self.assertIn("enUS", keeb.get_lang_list())
+        self.assertEqual(keeb.hid.send_and_read_validate_with_lock.call_count, 2)

--- a/tests/services/iso_lang_country_test.py
+++ b/tests/services/iso_lang_country_test.py
@@ -1,0 +1,71 @@
+"""Tests for the frozen ISO 639-1 / ISO 3166-1 alpha-2 code tables and the
+packed (2-byte-per-language) GET_LANG_LIST codec."""
+import unittest
+
+from polyhost.services import iso_lang_country as iso
+
+# A representative slice of the firmware's real language list, including the
+# tricky cases: hw (private pseudo-code), ku/ty (real ISO 639-1), am (Ethiopic).
+SAMPLE = ["enUS", "deDE", "frFR", "arSA", "zhCN", "hwUS", "kuIQ", "tyPF",
+          "amET", "miNZ", "ptBR", "enPG"]
+
+
+class TestIsoTables(unittest.TestCase):
+
+    def test_indices_fit_one_byte(self):
+        self.assertLessEqual(len(iso.LANG_CODES), 256)
+        self.assertLessEqual(len(iso.COUNTRY_CODES), 256)
+
+    def test_codes_are_unique(self):
+        self.assertEqual(len(iso.LANG_CODES), len(set(iso.LANG_CODES)))
+        self.assertEqual(len(iso.COUNTRY_CODES), len(set(iso.COUNTRY_CODES)))
+
+    def test_private_hw_appended_after_standard_block(self):
+        self.assertIn("hw", iso.PRIVATE_LANGS)
+        # hw has no ISO 639-1 entry, so it must sit above the standard codes.
+        self.assertGreaterEqual(iso.LANG_CODES.index("hw"),
+                                len(iso.LANG_CODES) - len(iso.PRIVATE_LANGS))
+
+    def test_every_lang_index_round_trips(self):
+        for idx, code in enumerate(iso.LANG_CODES):
+            self.assertEqual(iso.decode_pair(idx, 0)[:2], code)
+
+    def test_every_country_index_round_trips(self):
+        for idx, code in enumerate(iso.COUNTRY_CODES):
+            self.assertEqual(iso.decode_pair(0, idx)[2:], code)
+
+
+class TestPairCodec(unittest.TestCase):
+
+    def test_pair_round_trip(self):
+        for code in SAMPLE:
+            lang_idx, country_idx = iso.encode_pair(code)
+            self.assertEqual(iso.decode_pair(lang_idx, country_idx), code)
+
+    def test_encode_pair_is_two_bytes(self):
+        self.assertEqual(len(iso.encode_pair("enUS")), 2)
+
+    def test_unknown_code_raises(self):
+        with self.assertRaises(KeyError):
+            iso.encode_pair("zzZZ")  # zz is not an assigned ISO 639-1 code
+
+
+class TestPackedCodec(unittest.TestCase):
+
+    def test_packed_round_trip(self):
+        buf = iso.encode_packed(SAMPLE)
+        self.assertEqual(iso.decode_packed(buf), SAMPLE)
+
+    def test_packed_length_and_count(self):
+        buf = iso.encode_packed(SAMPLE)
+        self.assertEqual(buf[0], len(SAMPLE))            # count byte
+        self.assertEqual(len(buf), 1 + 2 * len(SAMPLE))  # count + 2B per code
+
+    def test_packed_empty(self):
+        buf = iso.encode_packed([])
+        self.assertEqual(buf, b"\x00")
+        self.assertEqual(iso.decode_packed(buf), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/util/iso_lang_country.py
+++ b/tests/util/iso_lang_country.py
@@ -1,0 +1,38 @@
+"""FROZEN single source of truth: ISO 639-1 language + ISO 3166-1 alpha-2
+country code <-> 1-byte index tables for the PolyKybd GET_LANG_LIST payload.
+
+Generated once from the `iso-codes` package (json), then FROZEN. The index of a
+code is its position in these tuples and is APPEND-ONLY: never reorder, never
+delete; new ISO codes get appended at the next free index. Both the host decoder
+and the firmware encoder must agree on these exact indices.
+
+Initial assignment (2026-06-10): alphabetical, for determinism only.
+ISO 639-1: 184 codes (idx 0..183); private langs start at 184.
+ISO 3166-1 alpha-2: 249 codes (idx 0..248).
+"""
+
+_LANG = (
+    "aa ab ae af ak am an ar as av ay az ba be bg bh bi bm bn bo br bs ca ce ch co cr cs cu cv cy da de dv dz ee el en eo es et eu fa ff fi fj fo fr fy ga gd gl gn gu gv ha he hi ho hr ht hu hy hz ia id ie ig ii ik io is it iu ja jv ka kg ki kj kk kl km kn ko kr ks ku kv kw ky la lb lg li ln lo lt lu lv mg mh mi mk ml mn mr ms mt my na nb nd ne ng nl nn no nr nv ny oc oj om or os pa pi pl ps pt qu rm rn ro ru rw sa sc sd se sg si sk sl sm sn so sq sr ss st su sv sw ta te tg th ti tk tl tn to tr ts tt tw ty ug uk ur uz ve vi vo wa wo xh yi yo za zh zu"
+).split()
+
+PRIVATE_LANGS = ["hw"]  # appended after the standard block, idx >= len(LANG_CODES)
+_COUNTRY = (
+    "AD AE AF AG AI AL AM AO AQ AR AS AT AU AW AX AZ BA BB BD BE BF BG BH BI BJ BL BM BN BO BQ BR BS BT BV BW BY BZ CA CC CD CF CG CH CI CK CL CM CN CO CR CU CV CW CX CY CZ DE DJ DK DM DO DZ EC EE EG EH ER ES ET FI FJ FK FM FO FR GA GB GD GE GF GG GH GI GL GM GN GP GQ GR GS GT GU GW GY HK HM HN HR HT HU ID IE IL IM IN IO IQ IR IS IT JE JM JO JP KE KG KH KI KM KN KP KR KW KY KZ LA LB LC LI LK LR LS LT LU LV LY MA MC MD ME MF MG MH MK ML MM MN MO MP MQ MR MS MT MU MV MW MX MY MZ NA NC NE NF NG NI NL NO NP NR NU NZ OM PA PE PF PG PH PK PL PM PN PR PS PT PW PY QA RE RO RS RU RW SA SB SC SD SE SG SH SI SJ SK SL SM SN SO SR SS ST SV SX SY SZ TC TD TF TG TH TJ TK TL TM TN TO TR TT TV TW TZ UA UG UM US UY UZ VA VC VE VG VI VN VU WF WS YE YT ZA ZM ZW"
+).split()
+
+LANG_CODES = _LANG + PRIVATE_LANGS
+COUNTRY_CODES = _COUNTRY
+
+_LANG_IDX = {c: i for i, c in enumerate(LANG_CODES)}
+_COUNTRY_IDX = {c: i for i, c in enumerate(COUNTRY_CODES)}
+
+assert len(LANG_CODES) <= 256 and len(COUNTRY_CODES) <= 256, "index must fit one byte"
+
+
+def encode_pair(code: str) -> bytes:
+    """4-char 'llCC' (lang lower + country UPPER) -> 2 bytes (lang_idx, country_idx)."""
+    return bytes((_LANG_IDX[code[:2]], _COUNTRY_IDX[code[2:]]))
+
+
+def decode_pair(lang_idx: int, country_idx: int) -> str:
+    return LANG_CODES[lang_idx] + COUNTRY_CODES[country_idx]

--- a/tests/util/lang_pack_prototype.py
+++ b/tests/util/lang_pack_prototype.py
@@ -12,7 +12,13 @@ round-trips the 5-bit codec to prove it is lossless.
 Run:  PolyKybdHost/.venv/bin/python tests/util/lang_pack_prototype.py
 """
 
+import os
+import sys
+
 from polyhost.util.rle_util import rle_compress
+
+sys.path.insert(0, os.path.dirname(__file__))
+import iso_lang_country as iso  # frozen ISO 639-1 / 3166-1 index tables
 
 # The full 81-code list, exactly as firmware hid_com.c case 0x08 emits it.
 LANGS = (
@@ -88,21 +94,40 @@ def unpack5(buf: bytearray) -> list[str]:
     return codes
 
 
+# ---------------------------------------------------------------------------
+# ISO-index: 1 count byte, then (lang_idx, country_idx) byte pair per code,
+# using the frozen ISO 639-1 / ISO 3166-1 alpha-2 tables (single source of truth).
+# ---------------------------------------------------------------------------
+def pack_iso(codes: list[str]) -> bytearray:
+    out = bytearray([len(codes)])
+    for code in codes:
+        out += iso.encode_pair(code)
+    return out
+
+
+def unpack_iso(buf: bytearray) -> list[str]:
+    count = buf[0]
+    return [iso.decode_pair(buf[1 + 2 * i], buf[2 + 2 * i]) for i in range(count)]
+
+
 def main() -> None:
     n = len(LANGS)
     raw = "".join(LANGS).encode("ascii")
 
     rle = rle_compress(raw)
     packed = pack5(LANGS)
+    isobuf = pack_iso(LANGS)
 
     # correctness
     assert unpack5(packed) == LANGS, "5-bit round-trip FAILED"
+    assert unpack_iso(isobuf) == LANGS, "ISO-index round-trip FAILED"
 
     print(f"languages: {n}\n")
     rows = [
         ("current (raw 4-char ASCII)", len(raw)),
         ("existing bit-RLE",           len(rle)),
         ("proposed 5-bit pack",        len(packed)),
+        ("proposed ISO-index (2 B)",   len(isobuf)),
     ]
     print(f"{'scheme':<30}{'bytes':>8}{'reports':>9}{'vs raw':>9}")
     print("-" * 56)
@@ -110,7 +135,16 @@ def main() -> None:
     for name, size in rows:
         print(f"{name:<30}{size:>8}{reports_for(size):>9}{size / base:>8.0%}")
 
-    print("\n5-bit round-trip: OK (lossless)")
+    print("\n5-bit round-trip:     OK (lossless)")
+    print("ISO-index round-trip: OK (lossless)")
+
+    # Firmware side carries NO runtime table: each language emits 2 precomputed
+    # index bytes instead of the 4 ASCII bytes it stores today -> .rodata shrinks.
+    fw_now = n * 4
+    fw_iso = n * 2
+    print(f"\nfirmware payload .rodata: {fw_now} B -> {fw_iso} B "
+          f"({fw_iso - fw_now:+d} B). Host decode table: "
+          f"{len(iso.LANG_CODES)}+{len(iso.COUNTRY_CODES)} codes (frozen, shared).")
 
 
 if __name__ == "__main__":

--- a/tests/util/lang_pack_prototype.py
+++ b/tests/util/lang_pack_prototype.py
@@ -16,9 +16,7 @@ import os
 import sys
 
 from polyhost.util.rle_util import rle_compress
-
-sys.path.insert(0, os.path.dirname(__file__))
-import iso_lang_country as iso  # frozen ISO 639-1 / 3166-1 index tables
+from polyhost.services import iso_lang_country as iso  # frozen ISO index tables
 
 # The full 81-code list, exactly as firmware hid_com.c case 0x08 emits it.
 LANGS = (
@@ -98,29 +96,17 @@ def unpack5(buf: bytearray) -> list[str]:
 # ISO-index: 1 count byte, then (lang_idx, country_idx) byte pair per code,
 # using the frozen ISO 639-1 / ISO 3166-1 alpha-2 tables (single source of truth).
 # ---------------------------------------------------------------------------
-def pack_iso(codes: list[str]) -> bytearray:
-    out = bytearray([len(codes)])
-    for code in codes:
-        out += iso.encode_pair(code)
-    return out
-
-
-def unpack_iso(buf: bytearray) -> list[str]:
-    count = buf[0]
-    return [iso.decode_pair(buf[1 + 2 * i], buf[2 + 2 * i]) for i in range(count)]
-
-
 def main() -> None:
     n = len(LANGS)
     raw = "".join(LANGS).encode("ascii")
 
     rle = rle_compress(raw)
     packed = pack5(LANGS)
-    isobuf = pack_iso(LANGS)
+    isobuf = iso.encode_packed(LANGS)
 
     # correctness
     assert unpack5(packed) == LANGS, "5-bit round-trip FAILED"
-    assert unpack_iso(isobuf) == LANGS, "ISO-index round-trip FAILED"
+    assert iso.decode_packed(isobuf) == LANGS, "ISO-index round-trip FAILED"
 
     print(f"languages: {n}\n")
     rows = [

--- a/tests/util/lang_pack_prototype.py
+++ b/tests/util/lang_pack_prototype.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Prototype: shrinking the GET_LANG_LIST HID payload.
+
+Compares three encodings of the keyboard's language list:
+  1. current  - raw concatenated 4-char ASCII codes (what firmware cmd 0x08 sends)
+  2. bit-RLE  - the EXISTING rle_compress() used for keycap bitmaps
+  3. 5-bit    - pack each [a-z]/[A-Z] letter into 5 bits (proposed)
+
+Reports the wire size and the number of 64-byte HID reports each needs, and
+round-trips the 5-bit codec to prove it is lossless.
+
+Run:  PolyKybdHost/.venv/bin/python tests/util/lang_pack_prototype.py
+"""
+
+from polyhost.util.rle_util import rle_compress
+
+# The full 81-code list, exactly as firmware hid_com.c case 0x08 emits it.
+LANGS = (
+    "enUS deDE frFR esES ptPT itIT trTR koKR jaJP arSA elGR ukUA ruRU beBY kkKZ "
+    "bgBG plPL roRO zhCN nlNL heIL svSE fiFI nnNO daDK huHU csCZ hrHR skSK ltLT "
+    "lvLV etEE ptBR srRS mkMK faIR hiIN mrIN neNP mnMN urPK enGB esMX deCH frBE "
+    "frCA thTH bnIN teIN taIN zhTW kaGE hyAM idID azAZ isIS viVN zhHK enAU enNZ "
+    "miNZ smWS fjFJ tlPH hwUS enZA afZA arEG swKE amET yoNG enNG arMA arIQ kuIQ "
+    "msMY uzUZ enCA esAR enPG tyPF"
+).split()
+
+# HID framing: 64-byte report, 3-byte response header "P\x08." -> 61 payload bytes.
+REPORT_SIZE = 64
+HEADER = 3
+PAYLOAD = REPORT_SIZE - HEADER
+
+
+def reports_for(nbytes: int) -> int:
+    return -(-nbytes // PAYLOAD)  # ceil
+
+
+# ---------------------------------------------------------------------------
+# 5-bit packer: each code is [a-z][a-z][A-Z][A-Z]; map letter->0..25, 5 bits each.
+# Stream layout: 1 count byte, then count*20 bits, MSB-first, zero-padded.
+# ---------------------------------------------------------------------------
+def _letter_to_val(ch: str) -> int:
+    if "a" <= ch <= "z":
+        return ord(ch) - ord("a")
+    if "A" <= ch <= "Z":
+        return ord(ch) - ord("A")
+    raise ValueError(f"non-letter in code: {ch!r}")
+
+
+def _val_to_letter(val: int, upper: bool) -> str:
+    return chr(val + (ord("A") if upper else ord("a")))
+
+
+def pack5(codes: list[str]) -> bytearray:
+    bits = 0
+    nbits = 0
+    out = bytearray([len(codes)])
+    for code in codes:
+        assert len(code) == 4, code
+        for i, ch in enumerate(code):
+            bits = (bits << 5) | _letter_to_val(ch)
+            nbits += 5
+            while nbits >= 8:
+                nbits -= 8
+                out.append((bits >> nbits) & 0xFF)
+    if nbits:
+        out.append((bits << (8 - nbits)) & 0xFF)
+    return out
+
+
+def unpack5(buf: bytearray) -> list[str]:
+    count = buf[0]
+    bits = 0
+    nbits = 0
+    vals = []
+    for byte in buf[1:]:
+        bits = (bits << 8) | byte
+        nbits += 8
+        while nbits >= 5 and len(vals) < count * 4:
+            nbits -= 5
+            vals.append((bits >> nbits) & 0x1F)
+    codes = []
+    for i in range(count):
+        v = vals[i * 4:i * 4 + 4]
+        codes.append(
+            _val_to_letter(v[0], False) + _val_to_letter(v[1], False)
+            + _val_to_letter(v[2], True) + _val_to_letter(v[3], True)
+        )
+    return codes
+
+
+def main() -> None:
+    n = len(LANGS)
+    raw = "".join(LANGS).encode("ascii")
+
+    rle = rle_compress(raw)
+    packed = pack5(LANGS)
+
+    # correctness
+    assert unpack5(packed) == LANGS, "5-bit round-trip FAILED"
+
+    print(f"languages: {n}\n")
+    rows = [
+        ("current (raw 4-char ASCII)", len(raw)),
+        ("existing bit-RLE",           len(rle)),
+        ("proposed 5-bit pack",        len(packed)),
+    ]
+    print(f"{'scheme':<30}{'bytes':>8}{'reports':>9}{'vs raw':>9}")
+    print("-" * 56)
+    base = len(raw)
+    for name, size in rows:
+        print(f"{name:<30}{size:>8}{reports_for(size):>9}{size / base:>8.0%}")
+
+    print("\n5-bit round-trip: OK (lossless)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Teaches the host to read the compact language list (firmware cmd 27 / `GET_LANG_LIST_PACKED`).

- **`polyhost/services/iso_lang_country.py`** — the frozen, append-only ISO 639-1 / ISO 3166-1 alpha-2 index tables (the shared single source of truth) plus the wire codec (`encode_packed` / `decode_packed`: 1 count byte + 2 index bytes per language).
- **`enumerate_lang()`** now prefers `GET_LANG_LIST_PACKED` when the firmware reports `protocol_version >= 2`, decoding binary index pairs with **count-driven, deterministic termination** (no read-timeout guessing). It **falls back** to the existing ASCII `GET_LANG_LIST` on any failure (NACK / timeout / truncation).
- **`command_ids.py`**: `GET_LANG_LIST_PACKED = 27`.

## Negotiation / no regression

Current firmware reports protocol **1**, so the host **never probes** cmd 27 against it — zero startup penalty — and auto-switches once v2 firmware ships. The existing ASCII path is unchanged.

## Tests

- New `tests/services/iso_lang_country_test.py`: table invariants + codec round-trips.
- Packed-path / fallback / protocol-gate cases in `tests/device/poly_kybd_test.py`.
- **Full suite green: 419 tests.**

## Prototype / measurements

`tests/util/lang_pack_prototype.py` compares schemes on the real 81-code list:

| scheme | bytes | reports |
|---|---:|---:|
| current (raw ASCII) | 324 | 6 |
| existing bit-RLE | 1581 | 26 |
| 5-bit pack | 204 | 4 |
| **ISO-index (this PR)** | **163** | **3** |

## Single source of truth ⚠️

`polyhost/services/iso_lang_country.py` is **byte-identical** (verified with `cmp`) to copies in `qmk_firmware` (`keyboards/handwired/polykybd/lang/`) and `polykybd-ctnd` (`station/`).

## Companion PRs (same branch `claude/keen-mccarthy-pqsclf`)

- **qmk_firmware** — firmware cmd 27 + protocol v2 (required for this to activate)
- **polykybd-ctnd** — HIL cross-check test

https://claude.ai/code/session_01Lfcket9qE5W6YU5YQfn8tn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lfcket9qE5W6YU5YQfn8tn)_