### PR TITLE
Add compat folds for the 62 easy-win languages (143 total)

### DIFF
--- a/polyhost/res/forced_country_match.txt
+++ b/polyhost/res/forced_country_match.txt
@@ -86,3 +86,85 @@ ar=latam
 # Uzbek Latin: the xkb "uz" default is Cyrillic; the Latin variant differs from
 # plain US only by the tutuq (ʻ) on the apostrophe key - fall back to "us".
 uz=us
+
+# ── 2026-06 compat easy-win batch (62 fold/clone languages) ──────────────────
+# Spanish Latin-American locales all type on the common "latam" layout (the same
+# layout es-MX / es-AR use); none have a dedicated country xkb code.
+co=latam
+pe=latam
+ve=latam
+cl=latam
+ec=latam
+gt=latam
+do=latam
+bo=latam
+py=latam
+cr=latam
+sv=latam
+hn=latam
+pa=latam
+uy=latam
+ni=latam
+
+# Arabic states (Levant / Gulf / Maghreb) use the shared xkb "ara" layout like
+# ar-SA. dz/sd/tn/ly are Maghreb/Sudan; the rest are the Arabian peninsula+Levant.
+ae=ara
+sy=ara
+jo=ara
+lb=ara
+ye=ara
+kw=ara
+om=ara
+ps=ara
+qa=ara
+bh=ara
+dz=ara
+sd=ara
+tn=ara
+ly=ara
+
+# Francophone Africa + New Caledonia type on the French AZERTY layout ("fr").
+cd=fr
+ci=fr
+cm=fr
+sn=fr
+mg=fr
+nc=fr
+
+# Lusophone Africa types on the Portuguese layout ("pt").
+ao=pt
+mz=pt
+
+# Kyrgyz / Tajik are Cyrillic; their own xkb codes (kg/tj) are preferred, with
+# Russian as the fallback (same Cyrillic base, a few letters differ).
+kg=ru
+tj=ru
+
+# Bengali Bangladesh: the "bd" xkb layout is preferred; India Bengali ("in") is
+# an acceptable fallback (same Bengali script, InScript-family positions).
+bd=in
+
+# European folds whose own country xkb code is normally present; these are the
+# last-resort fallbacks. Austrian->German already mapped above (at=de). Bosnian
+# and Slovenian share the ex-Yugoslav Latin QWERTZ (hr); Faroese shares the
+# Danish layout. (nl-BE=be, ca-ES=es and fr-CH=ch resolve via the country code.)
+ba=hr
+si=hr
+fo=dk
+
+# Plain-US-QWERTY English (and Swahili-TZ) markets without a distinct layout.
+# Where a national xkb layout exists it is matched first by country code; "us"
+# is the fold fallback. ie prefers the UK layout, then US.
+ie=gb,us
+gh=us
+ug=us
+zm=us
+tz=us
+in=us
+pk=us
+sg=us
+lk=us
+gu=us
+sb=us
+vu=us
+fm=us

--- a/tests/device/poly_kybd_mock_test.py
+++ b/tests/device/poly_kybd_mock_test.py
@@ -172,14 +172,18 @@ class TestPolyKybdMockLanguage(unittest.TestCase):
         self.assertEqual(self.mock.get_current_lang(), "enUS")
 
 
-# All 81 languages from hid_com.c case 8 (cog-generated, 6 HID packets)
+# All 143 languages from hid_com.c case 8 (cog-generated, 10 HID packets)
 _ALL_FIRMWARE_LANGS = (
     "enUSdeDEfrFResESptPTitITtrTRkoKRjaJParSAelGRukUAruRUbeBYkkKZ"  # packet 1
     "bgBGplPLroROzhCNnlNLheILsvSEfiFInnNOdaDKhuHUcsCZhrHRskSKltLT"  # packet 2
     "lvLVetEEptBRsrRSmkMKfaIRhiINmrINneNPmnMNurPKenGBesMXdeCHfrBE"  # packet 3
     "frCAthTHbnINteINtaINzhTWkaGEhyAMidIDazAZisISviVNzhHKenAUenNZ"  # packet 4
     "miNZsmWSfjFJtlPHhwUSenZAafZAarEGswKEamETyoNGenNGarMAarIQkuIQ"  # packet 5
-    "msMYuzUZenCAesARenPGtyPF"                                      # packet 6
+    "msMYuzUZenCAesARenPGtyPFesCOesPEesVEesCLesECesGTesDOesBOesPY"  # packet 6
+    "esCResSVesHNesPAesUYesNIdeATnlBEcaESenIEbsBAfrCHslSIfoFOarAE"  # packet 7
+    "arSYarJOarLBarYEarKWarOMarPSarQAarBHarDZarSDarTNarLYfrCDfrCI"  # packet 8
+    "frCMfrSNfrMGenGHenUGenZMswTZptAOptMZbnBDenINenPKenPHenSGenLK"  # packet 9
+    "kyKGtgTJenGUenSBenVUenFMfrNCtoTO"                              # packet 10
 )
 
 _ALL_FIRMWARE_LANG_CODES = [
@@ -199,12 +203,24 @@ _ALL_FIRMWARE_LANG_CODES = [
     "miNZ", "smWS", "fjFJ", "tlPH", "hwUS", "enZA", "afZA", "arEG",
     "swKE", "amET", "yoNG", "enNG", "arMA", "arIQ", "kuIQ",
     # packet 6
-    "msMY", "uzUZ", "enCA", "esAR", "enPG", "tyPF",
+    "msMY", "uzUZ", "enCA", "esAR", "enPG", "tyPF", "esCO", "esPE",
+    "esVE", "esCL", "esEC", "esGT", "esDO", "esBO", "esPY",
+    # packet 7
+    "esCR", "esSV", "esHN", "esPA", "esUY", "esNI", "deAT", "nlBE",
+    "caES", "enIE", "bsBA", "frCH", "slSI", "foFO", "arAE",
+    # packet 8
+    "arSY", "arJO", "arLB", "arYE", "arKW", "arOM", "arPS", "arQA",
+    "arBH", "arDZ", "arSD", "arTN", "arLY", "frCD", "frCI",
+    # packet 9
+    "frCM", "frSN", "frMG", "enGH", "enUG", "enZM", "swTZ", "ptAO",
+    "ptMZ", "bnBD", "enIN", "enPK", "enPH", "enSG", "enLK",
+    # packet 10
+    "kyKG", "tgTJ", "enGU", "enSB", "enVU", "enFM", "frNC", "toTO",
 ]
 
 
 class TestPolyKybdMockAllFirmwareLanguages(unittest.TestCase):
-    """Mock initialised with the full 81-language set from the firmware."""
+    """Mock initialised with the full 143-language set from the firmware."""
 
     def setUp(self):
         self.mock = make_mock(lang="enUS", langs=_ALL_FIRMWARE_LANGS)
@@ -214,8 +230,8 @@ class TestPolyKybdMockAllFirmwareLanguages(unittest.TestCase):
         self.assertTrue(ok)
         self.assertEqual(langs, _ALL_FIRMWARE_LANGS)
 
-    def test_lang_list_has_81_entries(self):
-        self.assertEqual(len(self.mock.get_lang_list()), 81)
+    def test_lang_list_has_143_entries(self):
+        self.assertEqual(len(self.mock.get_lang_list()), 143)
 
     def test_all_language_codes_present(self):
         langs = self.mock.get_lang_list()


### PR DESCRIPTION
Host-side companion to the firmware PR (thpoll83/qmk_firmware#72) that adds 62 fold/clone keyboard-layout languages.

## Changes

**`polyhost/res/forced_country_match.txt`** — maps the 62 new firmware language country codes to their OS keyboard layout:
- Spanish Latin-American locales → `latam`
- Arabic states (Levant/Gulf/Maghreb) → `ara`
- Francophone Africa + New Caledonia → `fr`
- Lusophone Africa → `pt`
- Kyrgyz / Tajik → `ru` (Cyrillic; native kg/tj preferred first)
- Bengali-BD → `in` (native `bd` preferred first)
- ex-Yugoslav / Faroese → `hr` / `dk`
- plain-US-QWERTY English (and Swahili-TZ) → `us` (ie prefers `gb`, then `us`)

Where a national xkb layout exists it is still matched first by country code; these are the fold **fallbacks** — the same model as the existing tl-PH / zh-TW / id-ID folds.

**`tests/device/poly_kybd_mock_test.py`** — updated to the full 143-language GET_LANG_LIST (10 ASCII packets), regenerated from the firmware enum order; the `len == 143` assertion updated.

## Notes
- No change to the frozen `iso_lang_country.py` (all 62 codes are standard ISO 639-1 / 3166-1; verified byte-identical across qmk_firmware / PolyKybdHost / polykybd-ctnd).
- No `lang_regions.py` change — the region map already covers every ISO country code, so the new languages land in the right submenu automatically.

### Known limitation
The compat map is keyed by country code, so en-IN / en-PK fall back to US only when the native IN/PK layout isn't installed (the native layout wins the country match first). Inherent to the existing architecture.

## Verification
- Full host test suite passes (73 tests, incl. the updated 143-language mock).

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQTxFUtrDWh8diD1BftV6d)_