### PR TITLE
Language list: packed-only (cmd 27), drop retired ASCII fallback

### DIFF
--- a/polyhost/_version.py
+++ b/polyhost/_version.py
@@ -1,5 +1,5 @@
 __major__ = 0
 __minor__ = 8
 __patch__ = 22
-__protocol__ = 1
+__protocol__ = 2
 __version__ = str(__major__) + "." + str(__minor__) + "." + str(__patch__)

--- a/polyhost/device/command_ids.py
+++ b/polyhost/device/command_ids.py
@@ -29,7 +29,7 @@ class HidId(Enum):
 class Cmd(Enum):
     GET_ID = 6
     GET_LANG = 7
-    GET_LANG_LIST = 8
+    GET_LANG_LIST = 8  # RETIRED (protocol v2): firmware NACKs it — use GET_LANG_LIST_PACKED (27)
     CHANGE_LANG = 9
     SEND_OVERLAY = 10
     OVERLAY_FLAGS_ON = 11

--- a/polyhost/device/poly_kybd.py
+++ b/polyhost/device/poly_kybd.py
@@ -11,7 +11,6 @@ from polyhost.device.device_settings import DeviceSettings
 from polyhost.device.serial_helper import SerialHelper
 from polyhost.input.unicode_input import InputMethod
 from polyhost.settings import PolySettings
-from polyhost.util.dict_util import split_by_n_chars
 from polyhost.device.bit_packing import pack_dict_10_bit
 from polyhost.device.cmd_composer import compose_cmd, compose_request, expect, compose_cmd_str, compose_roi_header, expectReq
 from polyhost.device.command_ids import Cmd, HidId
@@ -21,10 +20,10 @@ from polyhost.device.keys import KeyCode, Modifier
 from polyhost.device.overlay_cache import OverlayMRUCache
 from polyhost.services import iso_lang_country
 
-# Firmware PROTOCOL_VERSION at which GET_LANG_LIST_PACKED (the compact 2-byte
-# index encoding of the language list) became available. Older firmware (or
-# firmware that reports no protocol version) only understands the ASCII
-# GET_LANG_LIST, so the host stays on that path and never probes the new command.
+# Minimum firmware PROTOCOL_VERSION required for GET_LANG_LIST_PACKED (the compact
+# 2-byte index encoding of the language list). This is now the *only* way the host
+# reads the list: the legacy ASCII GET_LANG_LIST (cmd 8) has been retired and the
+# firmware NACKs it, so firmware reporting a lower version (or none) is unsupported.
 PACKED_LANG_LIST_MIN_PROTOCOL = 2
 
 import hid
@@ -328,16 +327,17 @@ class PolyKybd:
         if not result:
             return False, msg
 
-        # Firmware new enough for the compact 2-byte-per-language encoding sends
-        # it via GET_LANG_LIST_PACKED. Fall back to the ASCII list if that fails.
-        if (self.protocol_version is not None
-                and self.protocol_version >= PACKED_LANG_LIST_MIN_PROTOCOL):
-            ok, value = self._enumerate_lang_packed()
-            if ok:
-                return ok, value
-            self.log.warning(
-                "Packed language list failed, falling back to ASCII list.")
-        return self._enumerate_lang_ascii()
+        # Protocol v2+ delivers the language list via GET_LANG_LIST_PACKED
+        # (compact 2-byte ISO index pairs). The legacy ASCII GET_LANG_LIST
+        # (cmd 8) has been retired — the firmware NACKs it — so there is no
+        # fallback: firmware older than v2 is simply unsupported here.
+        if (self.protocol_version is None
+                or self.protocol_version < PACKED_LANG_LIST_MIN_PROTOCOL):
+            return False, (
+                "Firmware protocol too old for the packed language list "
+                f"(need v{PACKED_LANG_LIST_MIN_PROTOCOL}+). Please update the "
+                "PolyKybd firmware.")
+        return self._enumerate_lang_packed()
 
     def _enumerate_lang_packed(self) -> tuple[bool, str]:
         """Read the language list as packed (lang_idx, country_idx) byte pairs.
@@ -373,33 +373,6 @@ class PolyKybd:
         except (KeyError, IndexError) as e:
             return False, f"Could not decode packed language list: {e}"
         return True, "".join(self.all_languages)
-
-    def _enumerate_lang_ascii(self) -> tuple[bool, str]:
-        lock = None
-        result, reply, lock = self.hid.send_and_read_validate_with_lock(
-            compose_cmd(Cmd.GET_LANG_LIST), 15, expect(Cmd.GET_LANG_LIST), lock)
-
-        if not result:
-            if lock:
-                lock.release()
-            return False, "Could not receive language list."
-        lang_str = ""
-
-        expected = expect(Cmd.GET_LANG_LIST).decode()
-        reply = reply.decode().strip('\x00')
-        while result and len(reply) > 3:
-            if not reply.startswith(expected):
-                self.log.warning("enumerate_lang: unexpected reply prefix, stopping early")
-                break
-            lang_str = f"{lang_str}{reply[3:]}"
-            result, reply, lock = self.hid.read_with_lock(15, lock)
-            reply = reply.decode().strip('\x00')
-
-        if lock:
-            lock.release()
-
-        self.all_languages = split_by_n_chars(lang_str, 4)
-        return True, lang_str
 
     def get_lang_list(self) -> list:
         return self.all_languages

--- a/tests/device/poly_kybd_mock_test.py
+++ b/tests/device/poly_kybd_mock_test.py
@@ -172,7 +172,9 @@ class TestPolyKybdMockLanguage(unittest.TestCase):
         self.assertEqual(self.mock.get_current_lang(), "enUS")
 
 
-# All 143 languages from hid_com.c case 8 (cog-generated, 10 HID packets)
+# The full 143-language firmware list (the cog-generated `languages` table that
+# hid_com.c now emits via the packed GET_LANG_LIST_PACKED, cmd 27). Grouped below
+# in the original 15-per-row layout purely for readability.
 _ALL_FIRMWARE_LANGS = (
     "enUSdeDEfrFResESptPTitITtrTRkoKRjaJParSAelGRukUAruRUbeBYkkKZ"  # packet 1
     "bgBGplPLroROzhCNnlNLheILsvSEfiFInnNOdaDKhuHUcsCZhrHRskSKltLT"  # packet 2

--- a/tests/device/poly_kybd_test.py
+++ b/tests/device/poly_kybd_test.py
@@ -1,7 +1,12 @@
-"""Unit tests for PolyKybd.enumerate_lang multi-packet reading.
+"""Unit tests for PolyKybd.enumerate_lang.
 
-The firmware sends 6 HID reports in sequence for GET_LANG_LIST.
-These tests verify that all 6 are consumed and parsed, not just the first.
+The language list is read exclusively via GET_LANG_LIST_PACKED (cmd 27,
+protocol v2+): a count byte followed by two ISO index bytes per language, split
+across 64-byte HID reports. The legacy ASCII GET_LANG_LIST (cmd 8) has been
+retired — the firmware NACKs it — so there is no ASCII fallback and firmware
+older than protocol v2 is unsupported. These tests verify multi-report packed
+reassembly and that old firmware is rejected cleanly rather than silently
+downgraded to the retired command.
 """
 import unittest
 from unittest.mock import MagicMock
@@ -16,99 +21,21 @@ def _pad(data: bytes, size: int = 64) -> bytes:
     return data + b'\x00' * (size - len(data))
 
 
-# Exact firmware GET_LANG_LIST response packets (from hid_com.c case 8)
-_P1 = _pad(b"P\x08.enUSdeDEfrFResESptPTitITtrTRkoKRjaJParSAelGRukUAruRUbeBYkkKZ")
-_P2 = _pad(b"P\x08.bgBGplPLroROzhCNnlNLheILsvSEfiFInnNOdaDKhuHUcsCZhrHRskSKltLT")
-_P3 = _pad(b"P\x08.lvLVetEEptBRsrRSmkMKfaIRhiINmrINneNPmnMNurPKenGBesMXdeCHfrBE")
-_P4 = _pad(b"P\x08.frCAthTHbnINteINtaINzhTWkaGEhyAMidIDazAZisISviVNzhHKenAUenNZ")
-_P5 = _pad(b"P\x08.miNZsmWSfjFJtlPHhwUSenZAafZAarEGswKEamETyoNGenNGarMAarIQkuIQ")
-_P6 = _pad(b"P\x08.msMYuzUZenCAesARenPGtyPF")
+# A representative slice of the firmware language list, as 4-char codes in
+# firmware order. Used purely as a round-trip fixture: encoded to the packed
+# wire format below, then expected back out of the decoder unchanged. The exact
+# count is irrelevant to the multi-report parsing logic under test.
+_LANG_CODES = (
+    "enUSdeDEfrFResESptPTitITtrTRkoKRjaJParSAelGRukUAruRUbeBYkkKZ"
+    "bgBGplPLroROzhCNnlNLheILsvSEfiFInnNOdaDKhuHUcsCZhrHRskSKltLT"
+    "lvLVetEEptBRsrRSmkMKfaIRhiINmrINneNPmnMNurPKenGBesMXdeCHfrBE"
+    "frCAthTHbnINteINtaINzhTWkaGEhyAMidIDazAZisISviVNzhHKenAUenNZ"
+    "miNZsmWSfjFJtlPHhwUSenZAafZAarEGswKEamETyoNGenNGarMAarIQkuIQ"
+    "msMYuzUZenCAesARenPGtyPF"
+)
+_ALL_LANGS = [_LANG_CODES[i:i + 4] for i in range(0, len(_LANG_CODES), 4)]
+
 _GET_LANG_ACK = _pad(b"P\x07.enUS")  # response to GET_LANG (query_current_lang)
-
-
-def _make_keeb() -> PolyKybd:
-    keeb = PolyKybd(DeviceSettings(), PolySettings())
-    hid = MagicMock()
-    hid.send_and_read_validate.return_value = (True, _GET_LANG_ACK)
-    keeb.hid = hid
-    return keeb
-
-
-class TestEnumerateLangMultiPacket(unittest.TestCase):
-
-    def _setup_reads(self, keeb: PolyKybd, extra_packets: list[bytes] = None):
-        packets = [_P2, _P3, _P4, _P5, _P6] + (extra_packets or []) + [b'']
-        keeb.hid.send_and_read_validate_with_lock.return_value = (True, _P1, None)
-        keeb.hid.read_with_lock.side_effect = [(True, p, None) for p in packets]
-
-    def test_all_six_packets_consumed(self):
-        keeb = _make_keeb()
-        self._setup_reads(keeb)
-        ok, _ = keeb.enumerate_lang()
-        self.assertTrue(ok)
-        # 5 follow-up reads (P2..P6) + 1 empty sentinel = 6 total
-        self.assertEqual(keeb.hid.read_with_lock.call_count, 6)
-
-    def test_languages_from_all_packets_present(self):
-        keeb = _make_keeb()
-        self._setup_reads(keeb)
-        keeb.enumerate_lang()
-        langs = keeb.get_lang_list()
-        self.assertIn("enUS", langs)   # packet 1
-        self.assertIn("kkKZ", langs)   # last in packet 1
-        self.assertIn("bgBG", langs)   # packet 2
-        self.assertIn("ltLT", langs)   # last in packet 2
-        self.assertIn("lvLV", langs)   # packet 3
-        self.assertIn("frBE", langs)   # last in packet 3
-        self.assertIn("frCA", langs)   # packet 4
-        self.assertIn("enNZ", langs)   # last in packet 4
-        self.assertIn("miNZ", langs)   # packet 5
-        self.assertIn("kuIQ", langs)   # last in packet 5
-        self.assertIn("msMY", langs)   # packet 6
-        self.assertIn("tyPF", langs)   # last in packet 6
-
-    def test_only_first_packet_if_reads_time_out_early(self):
-        keeb = _make_keeb()
-        keeb.hid.send_and_read_validate_with_lock.return_value = (True, _P1, None)
-        keeb.hid.read_with_lock.side_effect = [(True, b'', None)]
-        ok, _ = keeb.enumerate_lang()
-        self.assertTrue(ok)
-        langs = keeb.get_lang_list()
-        self.assertIn("enUS", langs)
-        self.assertNotIn("bgBG", langs)  # P2 was never read
-
-    def test_unexpected_prefix_stops_loop(self):
-        keeb = _make_keeb()
-        junk = _pad(b"X\x00.garbage")
-        keeb.hid.send_and_read_validate_with_lock.return_value = (True, _P1, None)
-        keeb.hid.read_with_lock.side_effect = [(True, junk, None)]
-        ok, _ = keeb.enumerate_lang()
-        self.assertTrue(ok)
-        langs = keeb.get_lang_list()
-        self.assertIn("enUS", langs)   # P1 was processed
-        self.assertNotIn("bgBG", langs)  # loop stopped before P2
-
-    def test_unexpected_prefix_mid_stream_stops_loop(self):
-        """Bad prefix after a valid follow-up packet: earlier langs kept, later ones dropped."""
-        keeb = _make_keeb()
-        junk = _pad(b"X\x00.garbage")
-        keeb.hid.send_and_read_validate_with_lock.return_value = (True, _P1, None)
-        keeb.hid.read_with_lock.side_effect = [(True, _P2, None), (True, junk, None)]
-        ok, _ = keeb.enumerate_lang()
-        self.assertTrue(ok)
-        langs = keeb.get_lang_list()
-        self.assertIn("enUS", langs)   # P1 retained
-        self.assertIn("bgBG", langs)   # P2 retained (arrived before junk)
-        self.assertNotIn("lvLV", langs)  # P3 never reached
-
-
-# Full firmware language list reconstructed from the ASCII reference packets.
-_ALL_LANGS = [
-    "".join(p[3:].rstrip(b"\x00").decode())
-    for p in (_P1, _P2, _P3, _P4, _P5, _P6)
-]
-_ALL_LANGS = [c for chunk in _ALL_LANGS for c in
-              [chunk[i:i + 4] for i in range(0, len(chunk), 4)]]
 
 
 def _packed_reports(codes, cmd_val=27):
@@ -128,6 +55,7 @@ class TestEnumerateLangPacked(unittest.TestCase):
         keeb = PolyKybd(DeviceSettings(), PolySettings())
         keeb.protocol_version = protocol
         keeb.hid = MagicMock()
+        # GET_LANG (query_current_lang) runs before the list read; let it succeed.
         keeb.hid.send_and_read_validate.return_value = (True, _GET_LANG_ACK)
         return keeb
 
@@ -137,13 +65,14 @@ class TestEnumerateLangPacked(unittest.TestCase):
         keeb.hid.send_and_read_validate_with_lock.return_value = (True, reports[0], None)
         keeb.hid.read_with_lock.side_effect = [(True, r, None) for r in reports[1:]]
 
-        ok, value = keeb.enumerate_lang()
+        ok, _ = keeb.enumerate_lang()
         self.assertTrue(ok)
         self.assertEqual(keeb.get_lang_list(), _ALL_LANGS)
-        for tricky in ("enUS", "hwUS", "kuIQ", "tyPF", "amET"):
+        # Spot-check pseudo-codes / multi-packet entries decode correctly.
+        for tricky in ("enUS", "hwUS", "kuIQ", "tyPF"):
             self.assertIn(tricky, keeb.get_lang_list())
 
-    def test_packed_uses_packed_command_not_ascii(self):
+    def test_packed_uses_packed_command(self):
         keeb = self._make_keeb(PACKED_LANG_LIST_MIN_PROTOCOL)
         reports = _packed_reports(_ALL_LANGS)
         keeb.hid.send_and_read_validate_with_lock.return_value = (True, reports[0], None)
@@ -152,32 +81,32 @@ class TestEnumerateLangPacked(unittest.TestCase):
         sent_cmd = keeb.hid.send_and_read_validate_with_lock.call_args[0][0]
         self.assertEqual(sent_cmd[1], 27)  # Cmd.GET_LANG_LIST_PACKED
 
-    def test_old_protocol_uses_ascii_path(self):
-        keeb = self._make_keeb(1)  # below the packed threshold
-        keeb.hid.send_and_read_validate_with_lock.return_value = (True, _P1, None)
-        keeb.hid.read_with_lock.side_effect = [(True, b'', None)]
+    def test_old_protocol_is_unsupported(self):
+        """Protocol below v2: the ASCII fallback is gone, so enumeration fails
+        cleanly and the host never sends a list command (no downgrade to cmd 8)."""
+        keeb = self._make_keeb(1)
         ok, _ = keeb.enumerate_lang()
-        self.assertTrue(ok)
-        sent_cmd = keeb.hid.send_and_read_validate_with_lock.call_args[0][0]
-        self.assertEqual(sent_cmd[1], 8)  # Cmd.GET_LANG_LIST (ASCII)
+        self.assertFalse(ok)
+        keeb.hid.send_and_read_validate_with_lock.assert_not_called()
 
-    def test_no_protocol_version_uses_ascii_path(self):
-        keeb = self._make_keeb(None)  # old firmware, no protocol field
-        keeb.hid.send_and_read_validate_with_lock.return_value = (True, _P1, None)
-        keeb.hid.read_with_lock.side_effect = [(True, b'', None)]
+    def test_no_protocol_version_is_unsupported(self):
+        """Firmware that reports no protocol version (very old) is likewise
+        unsupported — the retired ASCII command is not attempted."""
+        keeb = self._make_keeb(None)
         ok, _ = keeb.enumerate_lang()
-        self.assertTrue(ok)
-        sent_cmd = keeb.hid.send_and_read_validate_with_lock.call_args[0][0]
-        self.assertEqual(sent_cmd[1], 8)
+        self.assertFalse(ok)
+        keeb.hid.send_and_read_validate_with_lock.assert_not_called()
 
-    def test_packed_nack_falls_back_to_ascii(self):
+    def test_packed_nack_does_not_fall_back(self):
+        """A NACK to the packed command on a v2 board is a hard failure — it is
+        NOT retried as the retired ASCII list. Exactly one command is sent."""
         keeb = self._make_keeb(PACKED_LANG_LIST_MIN_PROTOCOL)
         nack = _pad(b"P\x1b!")  # firmware NACKs the packed command
-        # First call (packed) -> NACK; second call (ASCII fallback) -> P1.
-        keeb.hid.send_and_read_validate_with_lock.side_effect = [
-            (True, nack, None), (True, _P1, None)]
-        keeb.hid.read_with_lock.side_effect = [(True, b'', None)]
+        keeb.hid.send_and_read_validate_with_lock.return_value = (True, nack, None)
         ok, _ = keeb.enumerate_lang()
-        self.assertTrue(ok)
-        self.assertIn("enUS", keeb.get_lang_list())
-        self.assertEqual(keeb.hid.send_and_read_validate_with_lock.call_count, 2)
+        self.assertFalse(ok)
+        self.assertEqual(keeb.hid.send_and_read_validate_with_lock.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What & why

The firmware retired the legacy ASCII `GET_LANG_LIST` (cmd 8) and now NACKs it. This makes the host **packed-only**:

- `enumerate_lang()` uses `GET_LANG_LIST_PACKED` (cmd 27) exclusively for protocol v2+, and returns a clear *"firmware protocol too old — please update"* error below v2. **No ASCII fallback, no silent downgrade** if the packed command fails.
- Removes `_enumerate_lang_ascii()` and its now-unused `split_by_n_chars` import.
- Unit tests rewritten for the packed-only path.

## Verification

This repo has no CI, so tests were run locally:
- Shared codec test `tests/services/iso_lang_country_test.py` — **11/11 pass**.
- The real `enumerate_lang()` logic exercised across 5 scenarios (v2 decode + cmd-27 assertion; protocol 1 / none rejected with **no** list command sent; packed-NACK hard-fail with no fallback) — **all pass**.
- All changed files byte-compile.

## Coordinated change (3 repos, branch `claude/funny-thompson-7851hp`)

Companion PRs: **qmk_firmware** (retire cmd 8 → NACK) and **polykybd-ctnd** (HIL packed-only + a cmd-8-NACK regression guard).

https://claude.ai/code/session_01K95YjhhA8vuuYD2FYVZBRU

---
_Generated by [Claude Code](https://claude.ai/code/session_01K95YjhhA8vuuYD2FYVZBRU)_