### PR TITLE
keycap tuner: all-layouts dropdown + xlsx write-back

### DIFF
--- a/tools/KEYCAP_TUNER.md
+++ b/tools/KEYCAP_TUNER.md
@@ -5,12 +5,14 @@ a PolyKybd language layout (base / Shift / AltGr) and the whole-layout offsets, 
 exporting the result for `lang_lut.xlsx`. It renders **pixel-identical to the
 firmware**, so what you see is what the panel shows.
 
-## Generate one for any layout
+## Generate one for any layout — or all of them
 
 ```bash
 cd PolyKybdHost/tools
-python gen_keycap_tuner.py --lang ps-AF          # -> /tmp/ps-AF_tuner.html
+python gen_keycap_tuner.py --lang ps-AF          # one layout   -> /tmp/ps-AF_tuner.html
 python gen_keycap_tuner.py --lang te-IN --out /tmp/te.html
+python gen_keycap_tuner.py --all                 # every layout -> /tmp/all_tuner.html
+python gen_keycap_tuner.py --all --out /tmp/all.html
 ```
 
 Open the file in any browser (no install, no network). It already shows the layout's
@@ -19,6 +21,14 @@ Open the file in any browser (no install, no network). It already shows the layo
 It works for **every** layout in `lang_lut.xlsx` — the generator pulls that lang's
 cells, the exact glyph bitmaps it uses (any script), the category offsets, and the
 en-US fallback glyphs, and embeds them in the page.
+
+`--all` bakes **every** layout into one file behind a **Layout dropdown** at the top.
+The glyph bitmaps are stored once in a **shared pool keyed by codepoint** (Latin
+layouts reuse the same a/b/c bitmaps), so the page stays a few MB even with every
+script. Switching the dropdown keeps each layout's edits alive, and **Export** emits
+one `=== code ===` block per edited layout — feed the whole box straight to
+`apply_tuner.py` (below). `--lang X` is just `--all` restricted to one layout (the
+dropdown then has a single entry); both share the same render mirror and page code.
 
 ## Using it
 
@@ -37,13 +47,29 @@ en-US fallback glyphs, and embeds them in the page.
 ## Export format → how to apply
 
 ```
+=== ps-AF ===                          # one block per edited layout (Export adds these)
 KC_Q base: U"\f\f" ARABIC_DAD          # a cell value -> lang_lut.xlsx (var base/shift/altgr)
 KC_D altgr: <drop / empty>             # clear that cell
 [offset] letter shift H = 44           # a settings value -> the SET[cat] offset rows
 ```
-Per-key lines go into the `key_lut` sheet (`KC_* row`, col = lang*4 + {base:0,shift:1,
-altgr:3}); `[offset]` lines go into the offset rows (`oled_preview.SET[cat]` = the
-voffset/hoffset rows). Then `cog -r lang_lut.c`, build, flash.
+
+**Apply it automatically** — `apply_tuner.py` parses exactly this format and writes the
+cells straight back into `lang_lut.xlsx`:
+
+```bash
+python apply_tuner.py changes.txt              # from a file
+pbpaste | python apply_tuner.py -              # from the clipboard (paste the Export box)
+python apply_tuner.py changes.txt --dry-run    # just print the resolved cell edits
+```
+
+It edits **only** `xl/worksheets/sheet2.xml` (set / clear cells) and copies every other
+zip entry byte-for-byte, so the formula caches in the other sheets stay intact — the
+same surgical approach as `lang/_patch_xlsx.py`, which only *appends* columns. Per-key
+lines map to the `key_lut` sheet (`KC_* row`, col = lang\*4 + {base:0, shift:1,
+altgr:3}); `[offset]` lines map to the offset rows (`oled_preview.SET[cat]` =
+voffset/hoffset, var {small:0, shift:1, altgr:3}); `<drop / empty>` clears the cell.
+After applying: `cog -r lang_lut.c`, build, flash. (To apply by hand instead, the same
+row/col mapping is all you need.)
 
 ## The 2px positioning control codes (cells)
 
@@ -78,10 +104,13 @@ the JS must agree with the firmware-faithful `oled_preview.warn_key` for every k
 
 ```bash
 # render the JS render logic in node and diff its per-key out-of-bounds/overlap
-# against oled_preview.py --check-bounds for the same lang (they must be identical)
+# against oled_preview.py --check-bounds for the same lang (they must be identical).
+# Slice off the DOM-touching init (node has no document), then load the layout and
+# walk the keys. Generate the file with --lang ps-AF so DATA.order[0] is that layout.
 node <(python - <<'PY'
 import re; h=open("/tmp/ps-AF_tuner.html").read()
-print(re.search(r"<script>(.*)</script>",h,re.S).group(1).split("buildOffPanel();")[0]
+js=re.search(r"<script>(.*)</script>",h,re.S).group(1).split("const _sel=")[0]
+print(js + 'loadLang(DATA.order[0]);'
   + 'for(const r of DATA.rows)for(const k of r){if(!(k in st))continue;const w=keyWarn(renderKey(k));if(w)console.log(k,w);}')
 PY
 )
@@ -90,7 +119,8 @@ python oled_preview.py --lang ps-AF --check-bounds
 
 ## Notes / limits
 
-- One layout per file (the glyph set is per-lang to keep the page small).
+- `--lang` is one layout per file; `--all` puts every layout in one file behind the
+  dropdown, sharing a single codepoint-keyed glyph pool to keep the page small.
 - Combining marks the layout drops (e.g. Arabic harakat, the nukta hint) follow the
   layout; the tuner shows what `lang_lut.xlsx` has.
 - A key with no own glyph renders the **en-US** fallback (tagged); nudging it exports a

--- a/tools/KEYCAP_TUNER.md
+++ b/tools/KEYCAP_TUNER.md
@@ -67,7 +67,7 @@ button); both share the same render mirror and page code.
 
 ## Export format → how to apply
 
-```
+```text
 === ps-AF ===                          # one block per edited layout (Export adds these)
 KC_Q base: U"\f\f" ARABIC_DAD          # a cell value -> lang_lut.xlsx (var base/shift/altgr)
 KC_D altgr: <drop / empty>             # clear that cell

--- a/tools/KEYCAP_TUNER.md
+++ b/tools/KEYCAP_TUNER.md
@@ -55,6 +55,14 @@ button); both share the same render mirror and page code.
   3, …`). Each category × small/shift/altgr is a **d-pad** (▲▼ = V up/down, ◀▶ = H
   left/right) over H/V number inputs, mirroring the per-key d-pad. **Click a category
   label** to frame all of that category's keys in its colour (click again to clear).
+  The centre **H** button hides that variation (both axes → `HIDE_KEY` = **-128**, the
+  firmware "do not show" sentinel, exported as the cell string `HIDE`); a hidden axis
+  shows blank. Stepping (or typing) into the negative also hides; the first step out of
+  a hidden/negative state wakes both axes to 0. Note `HIDE_KEY` is honoured per *view*:
+  it hides the shift-preview (`VAR_SHIFT`), the altgr-preview (`VAR_ALTGR`) and the
+  AltGr-held view (`VAR_SMALL`); the unshifted **base** is never hidden (it always
+  draws), so hiding **small** only affects the AltGr-held view — in the tuner's
+  unshifted preview it just pushes the base off-keycap (flagged out-of-bounds).
 - **Export changes** → paste the box back to whoever applies it.
 
 ## Export format → how to apply

--- a/tools/KEYCAP_TUNER.md
+++ b/tools/KEYCAP_TUNER.md
@@ -50,9 +50,11 @@ button); both share the same render mirror and page code.
   gets a tint overlay showing its origin quadrant — everything except the **top-right**
   of the origin. Click an element's control block to activate it and preview its tint
   **without nudging**; selecting a key activates **base** by default.
-- Bottom-right: the **whole-layout offsets** (letter/num/sym × small/shift/altgr) — each
-  is a **d-pad** (▲▼ = V up/down, ◀▶ = H left/right) over H/V number inputs, mirroring
-  the per-key d-pad.
+- Bottom-right: the **whole-layout offsets** grouped by category (**letter** = purple,
+  **num** = orange, **sym** = apple-green; each labelled with examples, e.g. `num: 1, 2,
+  3, …`). Each category × small/shift/altgr is a **d-pad** (▲▼ = V up/down, ◀▶ = H
+  left/right) over H/V number inputs, mirroring the per-key d-pad. **Click a category
+  label** to frame all of that category's keys in its colour (click again to clear).
 - **Export changes** → paste the box back to whoever applies it.
 
 ## Export format → how to apply

--- a/tools/KEYCAP_TUNER.md
+++ b/tools/KEYCAP_TUNER.md
@@ -50,8 +50,9 @@ button); both share the same render mirror and page code.
   gets a tint overlay showing its origin quadrant — everything except the **top-right**
   of the origin. Click an element's control block to activate it and preview its tint
   **without nudging**; selecting a key activates **base** by default.
-- Bottom-right: the **whole-layout offsets** (letter/num/sym × small/shift/altgr × H/V)
-  with ◀▶ / ▲▼ buttons.
+- Bottom-right: the **whole-layout offsets** (letter/num/sym × small/shift/altgr) — each
+  is a **d-pad** (▲▼ = V up/down, ◀▶ = H left/right) over H/V number inputs, mirroring
+  the per-key d-pad.
 - **Export changes** → paste the box back to whoever applies it.
 
 ## Export format → how to apply

--- a/tools/KEYCAP_TUNER.md
+++ b/tools/KEYCAP_TUNER.md
@@ -37,6 +37,8 @@ button); both share the same render mirror and page code.
 - **base = green, Shift = blue, AltGr = red**; overlaps mix; faded pixels are
   **clipped off the 72×40 keycap**; a faint crosshair marks each element's **offset
   origin** (the anchor the H/V offset sets).
+- Keys are grouped into three rows: **symbols**, then **numbers** (1-9, 0), then
+  **letters A-Z** — matching the offset categories.
 - A red border / label flags a key with out-of-bounds or overlap; the top line tallies
   them. An **en-US** badge marks a key with no own glyph (Latin fallback).
 - The line **under each preview** is that key's positioning **control-char sequence**

--- a/tools/KEYCAP_TUNER.md
+++ b/tools/KEYCAP_TUNER.md
@@ -38,8 +38,10 @@ dropdown then has a single entry); both share the same render mirror and page co
 - A red border / label flags a key with out-of-bounds or overlap; the top line tallies
   them. An **en-US** badge marks a key with no own glyph (Latin fallback).
 - Click a key → bottom-left: nudge **base/Shift/AltGr** with the ↑↓←→ d-pad (2px per
-  press) or tick **drop**. The active Shift/AltGr element gets a tint overlay showing
-  its origin quadrant.
+  press) or tick **drop**. The active element (base/Shift/AltGr, in its own colour)
+  gets a tint overlay showing its origin quadrant — everything except the **top-right**
+  of the origin. Click an element's control block to activate it and preview its tint
+  **without nudging**; selecting a key activates **base** by default.
 - Bottom-right: the **whole-layout offsets** (letter/num/sym × small/shift/altgr × H/V)
   with ◀▶ / ▲▼ buttons.
 - **Export changes** → paste the box back to whoever applies it.

--- a/tools/KEYCAP_TUNER.md
+++ b/tools/KEYCAP_TUNER.md
@@ -22,13 +22,15 @@ It works for **every** layout in `lang_lut.xlsx` — the generator pulls that la
 cells, the exact glyph bitmaps it uses (any script), the category offsets, and the
 en-US fallback glyphs, and embeds them in the page.
 
-`--all` bakes **every** layout into one file behind a **Layout dropdown** at the top.
-The glyph bitmaps are stored once in a **shared pool keyed by codepoint** (Latin
-layouts reuse the same a/b/c bitmaps), so the page stays a few MB even with every
-script. Switching the dropdown keeps each layout's edits alive, and **Export** emits
-one `=== code ===` block per edited layout — feed the whole box straight to
-`apply_tuner.py` (below). `--lang X` is just `--all` restricted to one layout (the
-dropdown then has a single entry); both share the same render mirror and page code.
+`--all` bakes **every** layout into one file behind a **push-button layout bar** at
+the top — one button per layout; click to switch. The glyph bitmaps are stored once
+in a **shared pool keyed by codepoint** (Latin layouts reuse the same a/b/c bitmaps),
+so the page stays a few MB even with every script. Switching keeps each layout's edits
+alive, and an edited layout's button turns **amber** (the current one is highlighted).
+**Reset layout** reverts every edit of the current layout; **Export** emits one
+`=== code ===` block per edited layout — feed the whole box straight to `apply_tuner.py`
+(below). `--lang X` is just `--all` restricted to one layout (the bar then has a single
+button); both share the same render mirror and page code.
 
 ## Using it
 
@@ -117,7 +119,7 @@ the JS must agree with the firmware-faithful `oled_preview.warn_key` for every k
 # walk the keys. Generate the file with --lang ps-AF so DATA.order[0] is that layout.
 node <(python - <<'PY'
 import re; h=open("/tmp/ps-AF_tuner.html").read()
-js=re.search(r"<script>(.*)</script>",h,re.S).group(1).split("const _sel=")[0]
+js=re.search(r"<script>(.*)</script>",h,re.S).group(1).split("buildLangBar();")[0]
 print(js + 'loadLang(DATA.order[0]);'
   + 'for(const r of DATA.rows)for(const k of r){if(!(k in st))continue;const w=keyWarn(renderKey(k));if(w)console.log(k,w);}')
 PY
@@ -128,7 +130,7 @@ python oled_preview.py --lang ps-AF --check-bounds
 ## Notes / limits
 
 - `--lang` is one layout per file; `--all` puts every layout in one file behind the
-  dropdown, sharing a single codepoint-keyed glyph pool to keep the page small.
+  layout button bar, sharing a single codepoint-keyed glyph pool to keep the page small.
 - Combining marks the layout drops (e.g. Arabic harakat, the nukta hint) follow the
   layout; the tuner shows what `lang_lut.xlsx` has.
 - A key with no own glyph renders the **en-US** fallback (tagged); nudging it exports a

--- a/tools/KEYCAP_TUNER.md
+++ b/tools/KEYCAP_TUNER.md
@@ -37,6 +37,12 @@ dropdown then has a single entry); both share the same render mirror and page co
   origin** (the anchor the H/V offset sets).
 - A red border / label flags a key with out-of-bounds or overlap; the top line tallies
   them. An **en-US** badge marks a key with no own glyph (Latin fallback).
+- The line **under each preview** is that key's positioning **control-char sequence**
+  (`\f` up · `\x05` down · `\b` left · `\x06` right), coloured per element — i.e. the
+  escapes that get written into the cell. `·` means no offset.
+- On the selected key you can **drag** the active glyph in the preview to position it;
+  it **snaps to 2px** (one control char — the firmware has no 1px positioning code).
+  The d-pad does the same in fixed 2px steps.
 - Click a key → bottom-left: nudge **base/Shift/AltGr** with the ↑↓←→ d-pad (2px per
   press) or tick **drop**. The active element (base/Shift/AltGr, in its own colour)
   gets a tint overlay showing its origin quadrant — everything except the **top-right**

--- a/tools/apply_tuner.py
+++ b/tools/apply_tuner.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Apply a keycap-tuner export back into lang_lut.xlsx (surgical sheet2.xml edit).
+
+Reads the "Export changes" text the keycap tuner produces — one `=== code ===`
+block per layout — and writes the changed key_lut cells + category-offset cells
+straight into lang_lut.xlsx, modifying ONLY xl/worksheets/sheet2.xml so the
+formula caches in the other sheets / sharedStrings stay intact (same surgical
+approach as lang/_patch_xlsx.py, but it *edits existing cells* — set / clear —
+instead of appending new language columns).
+
+    python apply_tuner.py changes.txt
+    pbpaste | python apply_tuner.py -                       # from the clipboard
+    python apply_tuner.py changes.txt --qmk /path/to/qmk_firmware
+    python apply_tuner.py changes.txt --dry-run             # just print the edits
+
+Export format (exactly what the tuner's Export box emits):
+
+    === ps-AF ===
+    KC_Q base: U"\\f\\f" ARABIC_DAD       # set key_lut cell (var base/shift/altgr)
+    KC_D altgr: <drop / empty>            # clear that cell
+    [offset] letter shift H = 44          # set a category-offset cell
+
+After applying, regenerate + rebuild:
+    cd <qmk>/keyboards/handwired/polykybd/lang && cog -r lang_lut.c
+    (then build / flash as usual)
+"""
+import sys, os, re, json, zipfile, shutil, tempfile, atexit, argparse
+from xml.sax.saxutils import escape
+
+# --- keycode -> key_lut row, mirroring oled_preview.ROW (kept inline so this
+#     script needs only openpyxl, not PIL/gfx_font) -------------------------
+LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+ROW = {f"KC_{c}": 2 + i for i, c in enumerate(LETTERS)}
+for _i in range(1, 10): ROW[f"KC_{_i}"] = 27 + _i
+ROW["KC_0"] = 37
+ROW.update({"KC_MINUS": 43, "KC_EQUAL": 44, "KC_LBRC": 45, "KC_RBRC": 46,
+            "KC_BACKSLASH": 47, "KC_NONUS_HASH": 48, "KC_SEMICOLON": 49,
+            "KC_QUOTE": 50, "KC_GRAVE": 51, "KC_COMMA": 52, "KC_DOT": 53,
+            "KC_SLASH": 54, "KC_NONUS_BACKSLASH": 55})
+SET = {"letter": (57, 56), "num": (59, 58), "sym": (61, 60)}   # (voffset_row, hoffset_row)
+VAR = {"base": 0, "small": 0, "shift": 1, "caps": 2, "altgr": 3}
+HIDE = -128
+
+
+def colname(n):                            # 1-based index -> A1 letters
+    s = ""
+    while n:
+        n, r = divmod(n - 1, 26); s = chr(65 + r) + s
+    return s
+
+
+def col_of_ref(ref):                       # 'AB12' -> col index
+    n = 0
+    for ch in re.match(r'[A-Z]+', ref).group(0):
+        n = n * 26 + (ord(ch) - 64)
+    return n
+
+
+def num_cell(ref, v): return f'<c r="{ref}"><v>{v}</v></c>'
+def str_cell(ref, v): return f'<c r="{ref}" t="inlineStr"><is><t xml:space="preserve">{escape(v)}</t></is></c>'
+
+
+# A cell is either self-closing `<c .../>` or `<c ...>...</c>`; try self-closing first.
+CELL_RE = re.compile(r'<c (?:[^>]*?/>|[^>]*?>.*?</c>)', re.S)
+
+
+def parse_export(text):
+    """text -> { lang_code: [ (row, col_in_group, value), ... ] }.
+
+    value is the inline-string token, an int (offset), or None to clear a cell.
+    col_in_group is the 0-based offset from the language's base column.
+    """
+    edits = {}
+    lang = None
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        m = re.match(r'^===\s*(\S+)\s*===$', line)
+        if m:
+            lang = m.group(1); edits.setdefault(lang, []); continue
+        mo = re.match(r'^\[offset\]\s+(letter|num|sym)\s+(small|shift|altgr)\s+([HV])\s*=\s*(-?\d+)$', line)
+        if mo:
+            if lang is None: sys.exit("offset line before any === code === header")
+            cat, var, ax, val = mo.group(1), mo.group(2), mo.group(3), int(mo.group(4))
+            vrow, hrow = SET[cat]
+            row = hrow if ax == "H" else vrow
+            edits[lang].append((row, VAR[var], "HIDE" if val == HIDE else val))
+            continue
+        mk = re.match(r'^(KC_\w+)\s+(base|shift|altgr):\s*(.*)$', line)
+        if mk:
+            if lang is None: sys.exit("key line before any === code === header")
+            kc, el, val = mk.group(1), mk.group(2), mk.group(3).strip()
+            if kc not in ROW: sys.exit(f"unknown keycode {kc}")
+            cell = None if val.startswith("<drop") or val in ("", "<empty>") else val
+            edits[lang].append((ROW[kc], VAR[el], cell))
+            continue
+        sys.exit(f"unparseable export line: {raw!r}")
+    return edits
+
+
+def set_cell(xml, r, c, new_cell):
+    """Insert / replace / delete (new_cell=None) the cell at (row r, col c) in sheet2.xml."""
+    ref = colname(c) + str(r)
+    rm = re.search(r'(<row r="%d"[^>]*>)(.*?)(</row>)' % r, xml, re.S)
+    if not rm:                              # row absent — every populated row exists, so this is unexpected
+        if new_cell is None:
+            return xml
+        sys.exit(f"row {r} not found in sheet2.xml (cannot place {ref})")
+    head, body, tail = rm.group(1), rm.group(2), rm.group(3)
+    existing = next((cm for cm in CELL_RE.finditer(body)
+                     if re.search(r'r="([A-Z]+\d+)"', cm.group(0)).group(1) == ref), None)
+    if existing:
+        body = body[:existing.start()] + (new_cell or "") + body[existing.end():]
+    elif new_cell is not None:             # insert before the first cell of a higher column
+        pos = len(body)
+        for cm in CELL_RE.finditer(body):
+            if col_of_ref(re.search(r'r="([A-Z]+\d+)"', cm.group(0)).group(1)) > c:
+                pos = cm.start(); break
+        body = body[:pos] + new_cell + body[pos:]
+    return xml[:rm.start()] + head + body + tail + xml[rm.end():]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('export', help="the tuner's exported text, or - for stdin")
+    _here = os.path.dirname(os.path.abspath(__file__))
+    ap.add_argument('--qmk', default=os.path.join(os.path.dirname(os.path.dirname(_here)), 'qmk_firmware'))
+    ap.add_argument('--xlsx', default=None, help='override path to lang_lut.xlsx')
+    ap.add_argument('--dry-run', action='store_true', help='print the resolved edits, write nothing')
+    a = ap.parse_args()
+
+    text = sys.stdin.read() if a.export == '-' else open(a.export, encoding='utf-8').read()
+    edits = parse_export(text)
+    if not edits or not any(edits.values()):
+        print("no edits in export — nothing to do"); return
+
+    XLSX = a.xlsx or os.path.join(a.qmk, 'keyboards', 'handwired', 'polykybd', 'lang', 'lang_lut.xlsx')
+    if not os.path.exists(XLSX):
+        sys.exit(f"lang_lut.xlsx not found at {XLSX} (use --qmk or --xlsx)")
+
+    from openpyxl import load_workbook
+    wb = load_workbook(XLSX, data_only=True, read_only=True)
+    sh = wb['key_lut']
+    langs, i = [], 0
+    while sh.cell(row=1, column=2 + i * 4).value:
+        langs.append(sh.cell(row=1, column=2 + i * 4).value); i += 1
+    wb.close()
+
+    # resolve every edit to an absolute (row, col, cell_xml|None)
+    resolved, total = [], 0
+    for lang, items in edits.items():
+        if not items:
+            continue
+        if lang not in langs:
+            sys.exit(f"layout {lang!r} is not in lang_lut.xlsx (have {len(langs)} layouts)")
+        base = 2 + langs.index(lang) * 4
+        for row, var, val in items:
+            c = base + var
+            ref = colname(c) + str(row)
+            if val is None:
+                cell = None; shown = "<clear>"
+            elif isinstance(val, int):
+                cell = num_cell(ref, val); shown = str(val)
+            else:
+                cell = str_cell(ref, val); shown = val
+            resolved.append((row, c, cell))
+            total += 1
+            print(f"  {lang:8s} {ref:>5s}  {shown}")
+    print(f"{total} cell edit(s) across {sum(1 for v in edits.values() if v)} layout(s)")
+
+    if a.dry_run:
+        print("(dry run — nothing written)"); return
+
+    tmp = tempfile.mkdtemp(prefix="xlsx_apply_")
+    atexit.register(shutil.rmtree, tmp, ignore_errors=True)
+    with zipfile.ZipFile(XLSX) as z:
+        z.extractall(tmp)
+    sheet2 = os.path.join(tmp, "xl/worksheets/sheet2.xml")
+    xml = open(sheet2, encoding="utf-8").read()
+    for row, c, cell in resolved:
+        xml = set_cell(xml, row, c, cell)
+    open(sheet2, "w", encoding="utf-8").write(xml)
+
+    out = XLSX + ".new"
+    with zipfile.ZipFile(XLSX) as zin, zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED) as zout:
+        for item in zin.infolist():
+            data = open(os.path.join(tmp, item.filename), "rb").read() if item.filename == "xl/worksheets/sheet2.xml" else zin.read(item.filename)
+            zout.writestr(item, data)
+    shutil.move(out, XLSX)
+    print(f"patched {XLSX}")
+    print("next:  cd %s/keyboards/handwired/polykybd/lang && cog -r lang_lut.c" % a.qmk)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/gen_keycap_tuner.py
+++ b/tools/gen_keycap_tuner.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """Generate a self-contained HTML keycap tuner for PolyKybd language layouts.
 
-    python gen_keycap_tuner.py --lang ps-AF            # one layout
-    python gen_keycap_tuner.py --lang te-IN --out /tmp/te.html
-    python gen_keycap_tuner.py --all                   # every layout, one file
-    python gen_keycap_tuner.py --all --out /tmp/all.html
+    .venv/bin/python gen_keycap_tuner.py --lang ps-AF            # one layout
+    .venv/bin/python gen_keycap_tuner.py --lang te-IN --out /tmp/te.html
+    .venv/bin/python gen_keycap_tuner.py --all                   # every layout, one file
+    .venv/bin/python gen_keycap_tuner.py --all --out /tmp/all.html
 
 The tuner is a single offline HTML file (open it in a browser) that renders the
 per-keycap OLED preview *exactly* like the firmware and lets you nudge each glyph
@@ -144,7 +144,9 @@ def main():
     codes = None if a.all else [a.lang]
     data = build_data(a.qmk, codes)
     tmpl = open(os.path.join(HERE, 'keycap_tuner_template.html'), encoding='utf-8').read()
-    html = tmpl.replace('__DATA__', json.dumps(data))
+    # escape "</" so a glyph/token containing "</script>" can't close the <script> block
+    data_json = json.dumps(data).replace('</', '<\\/')
+    html = tmpl.replace('__DATA__', data_json)
     out = a.out or os.path.join('/tmp', ('all' if a.all else a.lang) + '_tuner.html')
     open(out, 'w', encoding='utf-8').write(html)
     nkeys = sum(len(v["keys"]) for v in data["langs"].values())

--- a/tools/gen_keycap_tuner.py
+++ b/tools/gen_keycap_tuner.py
@@ -1,12 +1,20 @@
 #!/usr/bin/env python3
-"""Generate a self-contained HTML keycap tuner for any PolyKybd language layout.
+"""Generate a self-contained HTML keycap tuner for PolyKybd language layouts.
 
-    python gen_keycap_tuner.py --lang ps-AF
+    python gen_keycap_tuner.py --lang ps-AF            # one layout
     python gen_keycap_tuner.py --lang te-IN --out /tmp/te.html
+    python gen_keycap_tuner.py --all                   # every layout, one file
+    python gen_keycap_tuner.py --all --out /tmp/all.html
 
 The tuner is a single offline HTML file (open it in a browser) that renders the
 per-keycap OLED preview *exactly* like the firmware and lets you nudge each glyph
 (base / Shift / AltGr) and the whole-layout offsets, then export the changes.
+
+With --all every layout is baked into the same file behind a dropdown. The glyph
+bitmaps are stored once in a *shared pool* keyed by codepoint (Latin layouts reuse
+the same a/b/c bitmaps), so the file stays a few MB even with every script. Edits
+are kept per-layout while you switch; Export emits one `=== code ===` block per
+edited layout, which apply_tuner.py writes straight back into lang_lut.xlsx.
 
 It reuses oled_preview.py for the layout/glyph/offset data, so the JS render mirror
 in keycap_tuner_template.html MUST be kept in sync with oled_preview.render_key /
@@ -21,36 +29,41 @@ import oled_preview as op
 CTRL = {0x05, 0x06, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x18}   # cursor / positioning control codes
 
 
-def extract(lang: str, qmk: str) -> dict:
-    pk = os.path.join(qmk, 'keyboards', 'handwired', 'polykybd')
-    named = op.load_named_glyphs(os.path.join(pk, 'lang', 'named_glyphs.h'))
-    L = op.Lang(os.path.join(pk, 'lang', 'lang_lut.xlsx'), named)
-    R = op.Renderer(op.load_all_fonts(os.path.join(pk, 'base', 'fonts')))
-    if lang not in L.langs:
-        sys.exit(f"unknown lang {lang}; have {L.langs}")
-    li = L.langs.index(lang)
-
-    cp2name = {}                                   # reverse map for a readable export token
+def reverse_named(named: dict) -> dict:
+    """codepoint -> a readable named-glyph token (for a friendlier export)."""
+    cp2name = {}
     for nm, cps in named.items():
         if len(cps) == 1 and cps[0] not in cp2name:
             cp2name[cps[0]] = nm
+    return cp2name
 
+
+def make_tok_for(cp2name: dict):
     def tok_for(g):
         if not g:
             return ""
         if len(g) == 1 and g[0] in cp2name:
             return cp2name[g[0]]
         return "".join(chr(c) if 0x20 <= c < 0x7f and chr(c) not in '"\\' else f"\\x{c:x}" for c in g)
+    return tok_for
 
-    def split_cps(cps):
-        """Split resolved codepoints into leading positioning escapes + the glyph(s)."""
-        if not cps:
-            return None
-        esc, i = [], 0
-        while i < len(cps) and cps[i] in CTRL:
-            esc.append(cps[i]); i += 1
-        return {"esc": esc, "glyph": cps[i:], "tok": tok_for(cps[i:]), "fb": False}
 
+def split_cps(cps, tok_for):
+    """Split resolved codepoints into leading positioning escapes + the glyph(s)."""
+    if not cps:
+        return None
+    esc, i = [], 0
+    while i < len(cps) and cps[i] in CTRL:
+        esc.append(cps[i]); i += 1
+    return {"esc": esc, "glyph": cps[i:], "tok": tok_for(cps[i:]), "fb": False}
+
+
+def extract_lang(L: "op.Lang", li: int, tok_for) -> tuple:
+    """Per-key base/Shift/AltGr tokens + category offsets for one language index.
+
+    Returns (keys, offsets, used) where `used` is the set of glyph codepoints the
+    caller folds into the shared pool.
+    """
     keys, used = {}, set()
     for rowk in op.SHEET:
         for kc in rowk:
@@ -58,19 +71,30 @@ def extract(lang: str, qmk: str) -> dict:
                 continue
             row = op.ROW[kc]; e = {}
             used_lang, base_cps = L.small(li, row)              # base: en-US fallback (like the firmware)
-            e["base"] = split_cps(base_cps)
+            e["base"] = split_cps(base_cps, tok_for)
             if e["base"] and used_lang != li:
                 e["base"]["fb"] = True
             scps = L.var(li, row, op.VAR_SHIFT)                 # shift: fallback only if no own shift+base
             if scps is None and L.cell(li, row, op.VAR_SMALL) is None:
                 scps = L.var(0, row, op.VAR_SHIFT)
-            e["shift"] = split_cps(scps)
-            e["altgr"] = split_cps(L.var(li, row, op.VAR_ALTGR))   # altgr: no fallback
+            e["shift"] = split_cps(scps, tok_for)
+            e["altgr"] = split_cps(L.var(li, row, op.VAR_ALTGR), tok_for)   # altgr: no fallback
             keys[kc] = e
             for el in e.values():
                 if el:
                     used.update(c for c in el["glyph"] if c >= 0x20)
 
+    def off(cat, var):
+        vrow, hrow = op.SET[cat]
+        return {"H": op.get_setting(L, hrow, li, var), "V": op.get_setting(L, vrow, li, var)}
+
+    offsets = {c: {v: off(c, getattr(op, f"VAR_{v.upper()}")) for v in ["small", "shift", "altgr"]}
+               for c in ["letter", "num", "sym"]}
+    return keys, offsets, used
+
+
+def glyph_pool(R: "op.Renderer", used: set) -> dict:
+    """Shared codepoint -> GFX glyph metrics + bitmap for every glyph any layout uses."""
     glyphs = {}
     for cp in sorted(used):
         f = R._font(cp)
@@ -80,14 +104,29 @@ def extract(lang: str, qmk: str) -> dict:
         nb = math.ceil(w * h / 8) if w > 0 and h > 0 else 0
         glyphs[str(cp)] = {"w": w, "h": h, "xadv": g['xAdvance'], "xo": g['xOffset'], "yo": g['yOffset'],
                            "yadv": f.yAdvance, "bits": list(f.bitmap[g['bitmapOffset']:g['bitmapOffset'] + nb])}
+    return glyphs
 
-    def off(cat, var):
-        vrow, hrow = op.SET[cat]
-        return {"H": op.get_setting(L, hrow, li, var), "V": op.get_setting(L, vrow, li, var)}
 
-    offsets = {c: {v: off(c, getattr(op, f"VAR_{v.upper()}")) for v in ["small", "shift", "altgr"]}
-               for c in ["letter", "num", "sym"]}
-    return {"lang": lang, "rows": op.SHEET, "keys": keys, "glyphs": glyphs, "offsets": offsets,
+def build_data(qmk: str, codes=None) -> dict:
+    """codes=None -> every layout in lang_lut.xlsx; else the given list (in order)."""
+    pk = os.path.join(qmk, 'keyboards', 'handwired', 'polykybd')
+    named = op.load_named_glyphs(os.path.join(pk, 'lang', 'named_glyphs.h'))
+    L = op.Lang(os.path.join(pk, 'lang', 'lang_lut.xlsx'), named)
+    R = op.Renderer(op.load_all_fonts(os.path.join(pk, 'base', 'fonts')))
+    tok_for = make_tok_for(reverse_named(named))
+
+    order = list(L.langs) if codes is None else list(codes)
+    for c in order:
+        if c not in L.langs:
+            sys.exit(f"unknown lang {c}; have {len(L.langs)} langs ({', '.join(L.langs[:6])} ...)")
+
+    langs, used = {}, set()
+    for c in order:
+        keys, offsets, u = extract_lang(L, L.langs.index(c), tok_for)
+        langs[c] = {"keys": keys, "offsets": offsets}
+        used |= u
+
+    return {"order": order, "langs": langs, "glyphs": glyph_pool(R, used), "rows": op.SHEET,
             "base_yadv": R.fonts[0].yAdvance, "HIDE": op.HIDE,
             "consts": {"BASELINE": op.BASELINE, "BUFFER_X": op.BUFFER_X, "OLED_W": op.OLED_W,
                        "OLED_H": op.OLED_H, "SCREEN_WIDTH": op.SCREEN_WIDTH}}
@@ -95,16 +134,21 @@ def extract(lang: str, qmk: str) -> dict:
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument('--lang', required=True, help='e.g. ps-AF, te-IN, hi-IN')
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument('--lang', help='single layout, e.g. ps-AF, te-IN, hi-IN')
+    g.add_argument('--all', action='store_true', help='bake every layout into one file (dropdown)')
     ap.add_argument('--qmk', default=os.path.join(os.path.dirname(os.path.dirname(HERE)), 'qmk_firmware'))
     ap.add_argument('--out', default=None)
     a = ap.parse_args()
-    data = extract(a.lang, a.qmk)
+
+    codes = None if a.all else [a.lang]
+    data = build_data(a.qmk, codes)
     tmpl = open(os.path.join(HERE, 'keycap_tuner_template.html'), encoding='utf-8').read()
-    html = tmpl.replace('__DATA__', json.dumps(data)).replace('__LANG__', a.lang)
-    out = a.out or os.path.join('/tmp', f'{a.lang}_tuner.html')
+    html = tmpl.replace('__DATA__', json.dumps(data))
+    out = a.out or os.path.join('/tmp', ('all' if a.all else a.lang) + '_tuner.html')
     open(out, 'w', encoding='utf-8').write(html)
-    print(f"wrote {out}  ({len(data['keys'])} keys, {len(data['glyphs'])} glyphs)")
+    nkeys = sum(len(v["keys"]) for v in data["langs"].values())
+    print(f"wrote {out}  ({len(data['order'])} layout(s), {nkeys} keys, {len(data['glyphs'])} shared glyphs)")
 
 
 if __name__ == '__main__':

--- a/tools/keycap_tuner_template.html
+++ b/tools/keycap_tuner_template.html
@@ -72,6 +72,12 @@ const CATEX={letter:"A, B, C, …",num:"1, 2, 3, …",sym:". , / …"};
 let hlCat=null;                                                     // clicking a category frames its keys
 function toggleCat(c){hlCat=(hlCat===c?null:c);buildOffPanel();buildGrid();}
 function escHtml(s){return String(s).replace(/[&<>"']/g,m=>({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[m]));}
+// grid order: all symbols (keyboard order), then numbers (1-9,0), then letters A-Z.
+function orderedRows(){const flat=[];for(const r of DATA.rows)for(const k of r)if(k in st)flat.push(k);
+ const sym=flat.filter(k=>catOf(k)==="sym");
+ const num=["KC_1","KC_2","KC_3","KC_4","KC_5","KC_6","KC_7","KC_8","KC_9","KC_0"].filter(k=>k in st);
+ const letter=flat.filter(k=>catOf(k)==="letter").sort();
+ return [sym,num,letter];}
 // All layouts share the DATA.glyphs pool; per-layout cells/offsets live in DATA.langs.
 // st (per-key nudge state), OFF (mutable offsets) and O0 (pristine offsets) are
 // repointed at the current layout by loadLang(); STATE keeps each layout's edits
@@ -145,7 +151,7 @@ function paintR(cv,kc){const r=renderKey(kc),ctx=cv.getContext("2d");ctx.fillSty
  return r;}
 let selected=null,activeEl=null;
 function buildGrid(){const g=document.getElementById("grid");g.innerHTML="";let warnN=0;
- for(const row of DATA.rows){const rd=document.createElement("div");rd.style.display="flex";rd.style.flexWrap="wrap";rd.style.gap="4px";rd.style.flexBasis="100%";
+ for(const row of orderedRows()){const rd=document.createElement("div");rd.style.display="flex";rd.style.flexWrap="wrap";rd.style.gap="4px";rd.style.flexBasis="100%";
   for(const kc of row){if(!(kc in st))continue;const d=document.createElement("div");d.className="key"+(kc===selected?" sel":"");
    if(hlCat&&catOf(kc)===hlCat){d.style.outline="2px solid "+CATCOL[hlCat];d.style.outlineOffset="1px";}
    const cv=document.createElement("canvas");cv.width=(OW+2*MARG)*SCALE;cv.height=(OH+2*MARG)*SCALE;

--- a/tools/keycap_tuner_template.html
+++ b/tools/keycap_tuner_template.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8"><title>PolyKybd __LANG__ keycap tuner</title>
+<html lang="en"><head><meta charset="utf-8"><title>PolyKybd keycap tuner</title>
 <style>
  body{font-family:system-ui,sans-serif;background:#1b1b1b;color:#ddd;margin:0;padding:12px 12px 215px}
  h1{font-size:17px;margin:0 0 2px} .sub{color:#888;font-size:12px;margin-bottom:6px;max-width:1150px}
@@ -35,9 +35,10 @@
  #exp{width:100%;max-width:1150px;height:80px;background:#111;color:#9f9;font-family:monospace;font-size:11px;border:1px solid #444;margin-top:4px}
  .hint{font-size:12px;color:#888;align-self:center}
 </style></head><body>
-<h1>PolyKybd · __LANG__ keycap tuner</h1>
+<h1>PolyKybd · <span id="langname"></span> keycap tuner</h1>
 <div class="sub">base=<span style="color:#4f4">green</span> · Shift=<span style="color:#6af">blue</span> · AltGr=<span style="color:#f66">red</span> · overlaps mix · faded = clipped off-keycap · faint crosshair = each element's offset <b>origin</b>. <span style="color:#a85">en-US</span>=Latin fallback. Click a key; nudge it (bottom-left) or the whole-layout offsets (bottom-right).</div>
-<div class="top"><button class="act" onclick="exportAll()">Export changes</button><span class="hint">…then paste the box back to Claude</span></div>
+<div class="top"><label class="hint">Layout <select id="langsel" onchange="switchLang(this.value)"></select></label>
+ <button class="act" onclick="exportAll()">Export changes</button><span class="hint">…then paste the box back to Claude (or feed it to apply_tuner.py)</span></div>
 <textarea id="exp" placeholder="changed cells + offsets appear here on Export"></textarea>
 <div id="warnsum"></div>
 <div id="grid"></div>
@@ -47,13 +48,23 @@ const DATA=__DATA__;
 const C=DATA.consts,HIDE=DATA.HIDE,BY=DATA.base_yadv;
 const OW=C.OLED_W,OH=C.OLED_H,BX=C.BUFFER_X,SW=C.SCREEN_WIDTH,BL=C.BASELINE;
 const SCALE=4,MARG=9,LETTERS="ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-const O0=JSON.parse(JSON.stringify(DATA.offsets));
 function catOf(kc){const c=kc.startsWith("KC_")&&kc.length===4?kc[3]:"";if(LETTERS.includes(c))return"letter";if(/^KC_[0-9]$/.test(kc))return"num";return"sym";}
-const st={};
-for(const kc in DATA.keys){st[kc]={};const K=DATA.keys[kc];
- for(const el of["base","shift","altgr"]){const s=K[el];if(!s){st[kc][el]=null;continue;}
-  let dx=0,dy=0;for(const cp of s.esc){if(cp===6)dx+=2;else if(cp===8)dx-=2;else if(cp===5)dy+=2;else if(cp===12)dy-=2;}
-  st[kc][el]={dx,dy,glyph:s.glyph,tok:s.tok,fb:!!s.fb,odx:dx,ody:dy,drop:false,odrop:false};}}
+// All layouts share the DATA.glyphs pool; per-layout cells/offsets live in DATA.langs.
+// st (per-key nudge state), OFF (mutable offsets) and O0 (pristine offsets) are
+// repointed at the current layout by loadLang(); STATE keeps each layout's edits
+// alive while you switch the dropdown so nothing is lost.
+let LANG=DATA.order[0],st,OFF,O0;
+const STATE={};
+function buildSt(keys){const s={};
+ for(const kc in keys){s[kc]={};const K=keys[kc];
+  for(const el of["base","shift","altgr"]){const sp=K[el];if(!sp){s[kc][el]=null;continue;}
+   let dx=0,dy=0;for(const cp of sp.esc){if(cp===6)dx+=2;else if(cp===8)dx-=2;else if(cp===5)dy+=2;else if(cp===12)dy-=2;}
+   s[kc][el]={dx,dy,glyph:sp.glyph,tok:sp.tok,fb:!!sp.fb,odx:dx,ody:dy,drop:false,odrop:false};}}
+ return s;}
+function loadLang(code){LANG=code;
+ if(!STATE[code]){const off=DATA.langs[code].offsets;
+  STATE[code]={st:buildSt(DATA.langs[code].keys),off:JSON.parse(JSON.stringify(off)),o0:JSON.parse(JSON.stringify(off))};}
+ const S=STATE[code];st=S.st;OFF=S.off;O0=S.o0;selected=null;activeEl=null;}
 function gen(dx,dy){const e=[];if(dy<0)for(let i=0;i<-dy/2;i++)e.push(12);if(dy>0)for(let i=0;i<dy/2;i++)e.push(5);
  if(dx<0)for(let i=0;i<-dx/2;i++)e.push(8);if(dx>0)for(let i=0;i<dx/2;i++)e.push(6);return e;}
 function glyphOf(cp){return DATA.glyphs[cp]||null;}
@@ -72,7 +83,7 @@ function draw(cps,x,y,plot){let xc=x,yc=y;
   for(let yy=0;yy<g.h;yy++)for(let xx=0;xx<g.w;xx++){if((bit&7)===0)bits=g.bits[bo++];
    if(bits&0x80)plot(xc+g.xo+xx-BX,gy+g.yo+yy);bits=(bits<<1)&0xFF;bit++;}xc+=g.xadv;}}
 function cpsOf(e){return e&&!e.drop?gen(e.dx,e.dy).concat(e.glyph):null;}
-function renderKey(kc){const o=DATA.offsets[catOf(kc)],K=st[kc];const base=cpsOf(K.base);if(!base)return{empty:true};
+function renderKey(kc){const o=OFF[catOf(kc)],K=st[kc];const base=cpsOf(K.base);if(!base)return{empty:true};
  let bx=28+o.small.H,bv=o.small.V;let scps=null,px2=0,pv=0;
  if(K.shift&&!K.shift.drop&&o.shift.H!==HIDE&&o.shift.V!==HIDE){scps=cpsOf(K.shift);
   const[bmin,bmax]=bounds(base),[pmin,pmax]=bounds(scps);px2=28+o.shift.H;
@@ -126,16 +137,16 @@ function buildKeyCtrl(){const p=document.getElementById("keyctrl");if(!selected)
   h+=`<span class="tok">${E.tok}${E.fb?' <span class=fbm>(en-US)</span>':''}</span>${dpad(selected,el)}<span class="off">dx=${E.dx} dy=${E.dy}</span>
    <label class="drop"><input type="checkbox" ${E.drop?"checked":""} onchange="setdrop('${selected}','${el}',this.checked)">drop</label></div>`;}
  p.innerHTML=h;}
-function offCtl(c,t){const o=DATA.offsets[c][t];
+function offCtl(c,t){const o=OFF[c][t];
  const f=(ax,d,s)=>`<button onclick="adjOff('${c}','${t}','${ax}',${d})">${s}</button>`;
  const ip=(ax)=>`<input id="o_${c}_${t}_${ax}" type="number" value="${o[ax]}" onchange="setOffV('${c}','${t}','${ax}',this.value)">`;
  return`<span class="offt ${t}"><b>${t}</b> H${f('H',-1,'◀')}${ip('H')}${f('H',1,'▶')} V${f('V',-1,'▲')}${ip('V')}${f('V',1,'▼')}</span>`;}
-function buildOffPanel(){let h='<div class="offhdr">layout offsets (whole __LANG__)</div>';
+function buildOffPanel(){let h=`<div class="offhdr">layout offsets (whole ${LANG})</div>`;
  for(const c of['letter','num','sym']){h+=`<div class="offcat"><span class="offcatn">${c}</span>`;
   for(const t of['small','shift','altgr'])h+=offCtl(c,t);h+='</div>';}
  document.getElementById("offctrl").innerHTML=h;}
-function adjOff(c,t,ax,d){DATA.offsets[c][t][ax]+=d;document.getElementById(`o_${c}_${t}_${ax}`).value=DATA.offsets[c][t][ax];buildGrid();}
-function setOffV(c,t,ax,v){DATA.offsets[c][t][ax]=parseInt(v,10)||0;buildGrid();}
+function adjOff(c,t,ax,d){OFF[c][t][ax]+=d;document.getElementById(`o_${c}_${t}_${ax}`).value=OFF[c][t][ax];buildGrid();}
+function setOffV(c,t,ax,v){OFF[c][t][ax]=parseInt(v,10)||0;buildGrid();}
 function nudge(kc,el,dx,dy){const E=st[kc][el];E.dx+=dx;E.dy+=dy;activeEl=el;buildGrid();buildKeyCtrl();}
 function reset1(kc,el){const E=st[kc][el];E.dx=E.odx;E.dy=E.ody;E.drop=E.odrop;buildGrid();buildKeyCtrl();}
 function setdrop(kc,el,v){st[kc][el].drop=v;buildGrid();buildKeyCtrl();}
@@ -143,12 +154,23 @@ function setActive(el){activeEl=el;buildGrid();buildKeyCtrl();}
 function escStr(cp){return cp===12?"\\f":cp===8?"\\b":cp===5?"\\x05":cp===6?"\\x06":"\\x"+cp.toString(16);}
 function cellFor(E){const esc=gen(E.dx,E.dy),named=/^[A-Z][A-Z0-9_]+$/.test(E.tok);
  if(esc.length===0)return E.tok;const s=esc.map(escStr).join("");return named?`U"${s}" ${E.tok}`:`U"${s}${E.tok}"`;}
-function exportAll(){const out=[];
- for(const kc in st)for(const el of["base","shift","altgr"]){const E=st[kc][el];if(!E)continue;
+// Emit one `=== code ===` block per layout that has changes (across every layout
+// visited this session). apply_tuner.py parses exactly this format.
+function exportLang(S){const out=[];
+ for(const kc in S.st)for(const el of["base","shift","altgr"]){const E=S.st[kc][el];if(!E)continue;
   if(E.drop&&!E.odrop){out.push(`${kc} ${el}: <drop / empty>`);continue;}
   if(E.dx!==E.odx||E.dy!==E.ody)out.push(`${kc} ${el}: ${cellFor(E)}`);}
- for(const c in DATA.offsets)for(const t in DATA.offsets[c])for(const ax of["H","V"])
-  if(DATA.offsets[c][t][ax]!==O0[c][t][ax])out.push(`[offset] ${c} ${t} ${ax} = ${DATA.offsets[c][t][ax]}`);
+ for(const c in S.off)for(const t in S.off[c])for(const ax of["H","V"])
+  if(S.off[c][t][ax]!==S.o0[c][t][ax])out.push(`[offset] ${c} ${t} ${ax} = ${S.off[c][t][ax]}`);
+ return out;}
+function exportAll(){const out=[];
+ for(const code of DATA.order){const S=STATE[code];if(!S)continue;
+  const lines=exportLang(S);if(lines.length){out.push(`=== ${code} ===`,...lines);}}
  document.getElementById("exp").value=out.length?out.join("\n"):"(no changes yet)";}
+function switchLang(code){loadLang(code);document.getElementById("langname").textContent=code;
+ buildOffPanel();buildGrid();buildKeyCtrl();}
+const _sel=document.getElementById("langsel");
+for(const code of DATA.order){const o=document.createElement("option");o.value=code;o.textContent=code;_sel.appendChild(o);}
+loadLang(DATA.order[0]);document.getElementById("langname").textContent=LANG;
 buildOffPanel();buildGrid();
 </script></body></html>

--- a/tools/keycap_tuner_template.html
+++ b/tools/keycap_tuner_template.html
@@ -26,16 +26,20 @@
  .el .fbm{color:#a85;font-size:10px}
  .el.active{background:#2e2e2e;border-radius:3px}
  .dpad{display:inline-grid;grid-template-columns:repeat(3,27px);grid-gap:2px}
- .dpad button,.offt button{background:#333;color:#ddd;border:1px solid #555;border-radius:3px;cursor:pointer}
+ .dpad button,.offpad button{background:#333;color:#ddd;border:1px solid #555;border-radius:3px;cursor:pointer}
  .dpad button{width:27px;height:21px;font-size:13px} .dpad button:hover{background:#444} .dpad .sp{visibility:hidden}
  .off{font-size:11px;color:#9c9;margin-left:4px} .drop{font-size:11px;margin-left:4px}
  #offctrl{border-left:2px solid #3a3a3a;padding-left:12px}
- .offhdr{font-size:12px;color:#9bd;margin-bottom:3px}
- .offcat{display:flex;align-items:center;gap:6px;margin:1px 0} .offcatn{width:42px;color:#9bd;font-size:12px;text-align:right}
- .offt{font-size:11px;color:#bbb;white-space:nowrap}
- .offt b{color:#888;font-weight:normal}.offt.shift b{color:#6af}.offt.altgr b{color:#f66}.offt.small b{color:#4f4}
- .offt button{width:18px;height:18px;font-size:10px;padding:0;vertical-align:middle}
- .offt input{width:34px;background:#111;color:#dd9;border:1px solid #444;font-size:11px;text-align:center;margin:0 1px}
+ .offhdr{font-size:12px;color:#9bd;margin-bottom:4px}
+ .offgroups{display:flex;gap:14px}
+ .offgroup{display:flex;flex-direction:column;gap:2px} .offgroup .gname{font-size:12px;color:#9bd}
+ .offrow{display:flex;gap:8px}
+ .offdpad{display:flex;flex-direction:column;align-items:center;gap:2px}
+ .offdpad .vn{font-size:11px;color:#888} .offdpad .vn.small{color:#4f4}.offdpad .vn.shift{color:#6af}.offdpad .vn.altgr{color:#f66}
+ .offpad{display:inline-grid;grid-template-columns:repeat(3,18px);grid-gap:1px}
+ .offpad button{width:18px;height:15px;font-size:10px;padding:0} .offpad button:hover{background:#444} .offpad .sp{visibility:hidden}
+ .offins{display:flex;align-items:center;gap:1px;font-size:10px;color:#888}
+ .offins input{width:26px;background:#111;color:#dd9;border:1px solid #444;font-size:10px;text-align:center}
  .top{display:flex;gap:10px;align-items:center;margin-bottom:6px;flex-wrap:wrap}
  button.act{background:#264;color:#cfc;border:1px solid #485;border-radius:4px;padding:5px 9px;cursor:pointer}
  #exp{width:100%;max-width:1150px;height:80px;background:#111;color:#9f9;font-family:monospace;font-size:11px;border:1px solid #444;margin-top:4px}
@@ -150,14 +154,18 @@ function buildKeyCtrl(){const p=document.getElementById("keyctrl");if(!selected)
   h+=`<span class="tok">${E.tok}${E.fb?' <span class=fbm>(en-US)</span>':''}</span>${dpad(selected,el)}<span class="off">dx=${E.dx} dy=${E.dy}</span>
    <label class="drop"><input type="checkbox" ${E.drop?"checked":""} onclick="event.stopPropagation()" onchange="setdrop('${selected}','${el}',this.checked)">drop</label></div>`;}
  p.innerHTML=h;}
+// a category offset as a d-pad (▲▼ = V up/down, ◀▶ = H left/right) over two number
+// inputs, mirroring the per-key d-pad so both feel the same to operate.
 function offCtl(c,t){const o=OFF[c][t];
  const f=(ax,d,s)=>`<button onclick="adjOff('${c}','${t}','${ax}',${d})">${s}</button>`;
  const ip=(ax)=>`<input id="o_${c}_${t}_${ax}" type="number" value="${o[ax]}" onchange="setOffV('${c}','${t}','${ax}',this.value)">`;
- return`<span class="offt ${t}"><b>${t}</b> H${f('H',-1,'◀')}${ip('H')}${f('H',1,'▶')} V${f('V',-1,'▲')}${ip('V')}${f('V',1,'▼')}</span>`;}
-function buildOffPanel(){let h=`<div class="offhdr">layout offsets (whole ${LANG})</div>`;
- for(const c of['letter','num','sym']){h+=`<div class="offcat"><span class="offcatn">${c}</span>`;
-  for(const t of['small','shift','altgr'])h+=offCtl(c,t);h+='</div>';}
- document.getElementById("offctrl").innerHTML=h;}
+ return`<div class="offdpad"><span class="vn ${t}">${t}</span>
+  <div class="offpad"><span class="sp"></span>${f('V',-1,'▲')}<span class="sp"></span>${f('H',-1,'◀')}<span class="sp"></span>${f('H',1,'▶')}<span class="sp"></span>${f('V',1,'▼')}<span class="sp"></span></div>
+  <div class="offins">H${ip('H')} V${ip('V')}</div></div>`;}
+function buildOffPanel(){let h=`<div class="offhdr">layout offsets (whole ${LANG})</div><div class="offgroups">`;
+ for(const c of['letter','num','sym']){h+=`<div class="offgroup"><span class="gname">${c}</span><div class="offrow">`;
+  for(const t of['small','shift','altgr'])h+=offCtl(c,t);h+='</div></div>';}
+ document.getElementById("offctrl").innerHTML=h+'</div>';}
 function adjOff(c,t,ax,d){OFF[c][t][ax]+=d;document.getElementById(`o_${c}_${t}_${ax}`).value=OFF[c][t][ax];buildGrid();}
 function setOffV(c,t,ax,v){OFF[c][t][ax]=parseInt(v,10)||0;buildGrid();}
 function nudge(kc,el,dx,dy){const E=st[kc][el];E.dx+=dx;E.dy+=dy;activeEl=el;buildGrid();buildKeyCtrl();}

--- a/tools/keycap_tuner_template.html
+++ b/tools/keycap_tuner_template.html
@@ -110,11 +110,11 @@ function paintR(cv,kc){const r=renderKey(kc),ctx=cv.getContext("2d");ctx.fillSty
   ctx.fillRect((ox+MARG)*SCALE-1,MARG*SCALE,3,OH*SCALE); ctx.fillRect(MARG*SCALE,(oy+MARG)*SCALE-1,OW*SCALE,3);}
  for(const k in r.map){const[vx,vy]=k.split(",").map(Number);const oo=(vx<0||vx>=OW||vy<0||vy>=OH);
   const c=COL[r.map[k]]||[200,200,200];ctx.fillStyle=`rgba(${c[0]},${c[1]},${c[2]},${oo?0.32:1})`;ctx.fillRect((vx+MARG)*SCALE,(vy+MARG)*SCALE,SCALE,SCALE);}
- if(kc===selected&&(activeEl==="shift"||activeEl==="altgr")&&r.origins[activeEl]){let[ox,oy]=r.origins[activeEl];
+ if(kc===selected&&activeEl&&r.origins[activeEl]){let[ox,oy]=r.origins[activeEl];   // base/shift/altgr all tint
   ox=Math.max(0,Math.min(OW,ox));oy=Math.max(0,Math.min(OH,oy));const g=GC[activeEl];
   ctx.fillStyle=`rgba(${g[0]},${g[1]},${g[2]},0.18)`;
-  ctx.fillRect(MARG*SCALE,MARG*SCALE,OW*SCALE,oy*SCALE);                 // above origin (full width)
-  ctx.fillRect(MARG*SCALE,(oy+MARG)*SCALE,ox*SCALE,(OH-oy)*SCALE);}     // left of origin, below it
+  ctx.fillRect(MARG*SCALE,(oy+MARG)*SCALE,OW*SCALE,(OH-oy)*SCALE);       // below origin (full width)
+  ctx.fillRect(MARG*SCALE,MARG*SCALE,ox*SCALE,oy*SCALE);}               // left of origin, above it -> top-right stays clear
  return r;}
 let selected=null,activeEl=null;
 function buildGrid(){const g=document.getElementById("grid");g.innerHTML="";let warnN=0;
@@ -126,16 +126,18 @@ function buildGrid(){const g=document.getElementById("grid");g.innerHTML="";let 
    if(st[kc].base&&st[kc].base.fb){const fb=document.createElement("div");fb.className="fb";fb.textContent="en-US";d.appendChild(fb);}
    const r=paintR(cv,kc),w=keyWarn(r);
    if(w){d.classList.add("warn");const wl=document.createElement("div");wl.className="wl";wl.textContent=w;d.appendChild(wl);warnN++;}
-   d.onclick=()=>{selected=kc;activeEl=(st[kc].shift?"shift":(st[kc].altgr?"altgr":null));buildGrid();buildKeyCtrl();};rd.appendChild(d);}g.appendChild(rd);}
+   d.onclick=()=>{selected=kc;activeEl=(st[kc].base?"base":(st[kc].shift?"shift":(st[kc].altgr?"altgr":null)));buildGrid();buildKeyCtrl();};rd.appendChild(d);}g.appendChild(rd);}
  document.getElementById("warnsum").textContent=warnN?(warnN+" key(s) flag out-of-bounds / overlap"):"no out-of-bounds or overlap ✓";}
-function dpad(kc,el){const b=(dx,dy,t)=>`<button onclick="nudge('${kc}','${el}',${dx},${dy})">${t}</button>`;
- return`<div class="dpad"><span class="sp"></span>${b(0,-2,"↑")}<span class="sp"></span>${b(-2,0,"←")}<button onclick="reset1('${kc}','${el}')">·</button>${b(2,0,"→")}<span class="sp"></span>${b(0,2,"↓")}<span class="sp"></span></div>`;}
+function dpad(kc,el){const b=(dx,dy,t)=>`<button onclick="event.stopPropagation();nudge('${kc}','${el}',${dx},${dy})">${t}</button>`;
+ return`<div class="dpad"><span class="sp"></span>${b(0,-2,"↑")}<span class="sp"></span>${b(-2,0,"←")}<button onclick="event.stopPropagation();reset1('${kc}','${el}')">·</button>${b(2,0,"→")}<span class="sp"></span>${b(0,2,"↓")}<span class="sp"></span></div>`;}
 function buildKeyCtrl(){const p=document.getElementById("keyctrl");if(!selected){p.innerHTML="<span class='hint'>click a key to edit</span>";return;}
  const K=st[selected];let h=`<h2>${selected.replace("KC_","")}</h2>`;
- for(const el of["base","shift","altgr"]){const E=K[el];h+=`<div class="el ${el}${el===activeEl?' active':''}"><span class="nm" style="cursor:pointer" onclick="setActive('${el}')">${el}</span>`;
+ // the whole .el block is clickable to activate that element (show its tint) without
+ // editing; the inner buttons/checkbox stopPropagation so they don't double-fire.
+ for(const el of["base","shift","altgr"]){const E=K[el];h+=`<div class="el ${el}${el===activeEl?' active':''}" style="cursor:pointer" onclick="setActive('${el}')"><span class="nm">${el}</span>`;
   if(!E){h+=` <span class='hint'>none</span></div>`;continue;}
   h+=`<span class="tok">${E.tok}${E.fb?' <span class=fbm>(en-US)</span>':''}</span>${dpad(selected,el)}<span class="off">dx=${E.dx} dy=${E.dy}</span>
-   <label class="drop"><input type="checkbox" ${E.drop?"checked":""} onchange="setdrop('${selected}','${el}',this.checked)">drop</label></div>`;}
+   <label class="drop"><input type="checkbox" ${E.drop?"checked":""} onclick="event.stopPropagation()" onchange="setdrop('${selected}','${el}',this.checked)">drop</label></div>`;}
  p.innerHTML=h;}
 function offCtl(c,t){const o=OFF[c][t];
  const f=(ax,d,s)=>`<button onclick="adjOff('${c}','${t}','${ax}',${d})">${s}</button>`;

--- a/tools/keycap_tuner_template.html
+++ b/tools/keycap_tuner_template.html
@@ -10,6 +10,8 @@
  .key .lab{position:absolute;top:1px;left:3px;font-size:9px;color:#9b9;pointer-events:none;text-shadow:0 0 2px #000}
  .key .wl{position:absolute;bottom:1px;right:3px;font-size:9px;color:#f66;pointer-events:none}
  .key .fb{position:absolute;top:1px;right:3px;font-size:8px;color:#a85;pointer-events:none}
+ .key .seq{font-size:8px;font-family:monospace;line-height:1.15;text-align:center;min-height:9px;word-break:break-all;margin-top:1px}
+ .key.sel canvas{cursor:move}
  #panel{position:fixed;left:0;right:0;bottom:0;height:198px;background:#242424;border-top:2px solid #444;
    padding:6px 10px;display:flex;gap:16px;box-sizing:border-box;overflow-x:auto}
  #keyctrl{display:flex;gap:10px;align-items:flex-start;min-width:480px}
@@ -36,7 +38,7 @@
  .hint{font-size:12px;color:#888;align-self:center}
 </style></head><body>
 <h1>PolyKybd · <span id="langname"></span> keycap tuner</h1>
-<div class="sub">base=<span style="color:#4f4">green</span> · Shift=<span style="color:#6af">blue</span> · AltGr=<span style="color:#f66">red</span> · overlaps mix · faded = clipped off-keycap · faint crosshair = each element's offset <b>origin</b>. <span style="color:#a85">en-US</span>=Latin fallback. Click a key; nudge it (bottom-left) or the whole-layout offsets (bottom-right).</div>
+<div class="sub">base=<span style="color:#4f4">green</span> · Shift=<span style="color:#6af">blue</span> · AltGr=<span style="color:#f66">red</span> · overlaps mix · faded = clipped off-keycap · faint crosshair = each element's offset <b>origin</b>. <span style="color:#a85">en-US</span>=Latin fallback. The line under each preview is its positioning <b>control-char sequence</b> (\f up · \x05 down · \b left · \x06 right). Click a key; <b>drag</b> the active glyph in the preview to move it (snaps to 2px), or nudge it (bottom-left) / the whole-layout offsets (bottom-right).</div>
 <div class="top"><label class="hint">Layout <select id="langsel" onchange="switchLang(this.value)"></select></label>
  <button class="act" onclick="exportAll()">Export changes</button><span class="hint">…then paste the box back to Claude (or feed it to apply_tuner.py)</span></div>
 <textarea id="exp" placeholder="changed cells + offsets appear here on Export"></textarea>
@@ -126,7 +128,9 @@ function buildGrid(){const g=document.getElementById("grid");g.innerHTML="";let 
    if(st[kc].base&&st[kc].base.fb){const fb=document.createElement("div");fb.className="fb";fb.textContent="en-US";d.appendChild(fb);}
    const r=paintR(cv,kc),w=keyWarn(r);
    if(w){d.classList.add("warn");const wl=document.createElement("div");wl.className="wl";wl.textContent=w;d.appendChild(wl);warnN++;}
-   d.onclick=()=>{selected=kc;activeEl=(st[kc].base?"base":(st[kc].shift?"shift":(st[kc].altgr?"altgr":null)));buildGrid();buildKeyCtrl();};rd.appendChild(d);}g.appendChild(rd);}
+   const sq=document.createElement("div");sq.className="seq";sq.innerHTML=seqLine(kc);d.appendChild(sq);
+   if(kc===selected)cv.addEventListener("mousedown",e=>startDrag(e,kc,cv));   // drag the active glyph (2px snap)
+   d.onclick=()=>{if(selected!==kc){selected=kc;activeEl=(st[kc].base?"base":(st[kc].shift?"shift":(st[kc].altgr?"altgr":null)));}buildGrid();buildKeyCtrl();};rd.appendChild(d);}g.appendChild(rd);}
  document.getElementById("warnsum").textContent=warnN?(warnN+" key(s) flag out-of-bounds / overlap"):"no out-of-bounds or overlap ✓";}
 function dpad(kc,el){const b=(dx,dy,t)=>`<button onclick="event.stopPropagation();nudge('${kc}','${el}',${dx},${dy})">${t}</button>`;
  return`<div class="dpad"><span class="sp"></span>${b(0,-2,"↑")}<span class="sp"></span>${b(-2,0,"←")}<button onclick="event.stopPropagation();reset1('${kc}','${el}')">·</button>${b(2,0,"→")}<span class="sp"></span>${b(0,2,"↓")}<span class="sp"></span></div>`;}
@@ -154,6 +158,23 @@ function reset1(kc,el){const E=st[kc][el];E.dx=E.odx;E.dy=E.ody;E.drop=E.odrop;b
 function setdrop(kc,el,v){st[kc][el].drop=v;buildGrid();buildKeyCtrl();}
 function setActive(el){activeEl=el;buildGrid();buildKeyCtrl();}
 function escStr(cp){return cp===12?"\\f":cp===8?"\\b":cp===5?"\\x05":cp===6?"\\x06":"\\x"+cp.toString(16);}
+// per-key control-char sequence line under the preview: the leading positioning
+// escapes (\f up, \x05 down, \b left, \x06 right) each element carries, coloured.
+const SEQCOL={base:"#4f4",shift:"#6af",altgr:"#f66"};
+function seqOf(E){return E&&!E.drop?gen(E.dx,E.dy).map(escStr).join(""):"";}
+function seqLine(kc){const K=st[kc],out=[];
+ for(const el of["base","shift","altgr"]){const s=seqOf(K[el]);if(s)out.push(`<span style="color:${SEQCOL[el]}">${el[0]}${s}</span>`);}
+ return out.join(" ")||"<span style='color:#555'>·</span>";}
+// drag the selected key's active element; snap to 2px (one positioning control char)
+let drag=null;
+function startDrag(e,kc,cv){if(kc!==selected||!activeEl)return;const E=st[kc][activeEl];if(!E||E.drop)return;
+ e.preventDefault();drag={kc,el:activeEl,sx:e.clientX,sy:e.clientY,dx0:E.dx,dy0:E.dy,cv};
+ document.addEventListener("mousemove",onDrag);document.addEventListener("mouseup",endDrag);}
+function onDrag(e){if(!drag)return;const f=SCALE/2;          // CSS px per OLED px
+ const E=st[drag.kc][drag.el];
+ E.dx=drag.dx0+2*Math.round((e.clientX-drag.sx)/f/2);E.dy=drag.dy0+2*Math.round((e.clientY-drag.sy)/f/2);
+ paintR(drag.cv,drag.kc);}                                  // live repaint just this key while dragging
+function endDrag(){if(!drag)return;document.removeEventListener("mousemove",onDrag);document.removeEventListener("mouseup",endDrag);drag=null;buildGrid();buildKeyCtrl();}
 function cellFor(E){const esc=gen(E.dx,E.dy),named=/^[A-Z][A-Z0-9_]+$/.test(E.tok);
  if(esc.length===0)return E.tok;const s=esc.map(escStr).join("");return named?`U"${s}" ${E.tok}`:`U"${s}${E.tok}"`;}
 // Emit one `=== code ===` block per layout that has changes (across every layout

--- a/tools/keycap_tuner_template.html
+++ b/tools/keycap_tuner_template.html
@@ -7,11 +7,15 @@
  #grid{display:flex;flex-wrap:wrap;gap:4px;max-width:1500px}
  .key{background:#000;border:2px solid #333;border-radius:4px;padding:2px;cursor:pointer;position:relative}
  .key.sel{border-color:#4af} .key.warn{border-color:#e44}
- .key .lab{position:absolute;top:1px;left:3px;font-size:9px;color:#9b9;pointer-events:none;text-shadow:0 0 2px #000}
+ .key .lab{position:absolute;top:1px;left:3px;font-size:10px;color:#9b9;pointer-events:none;text-shadow:0 0 2px #000}
  .key .wl{position:absolute;bottom:1px;right:3px;font-size:9px;color:#f66;pointer-events:none}
  .key .fb{position:absolute;top:1px;right:3px;font-size:8px;color:#a85;pointer-events:none}
- .key .seq{font-size:8px;font-family:monospace;line-height:1.15;text-align:center;min-height:9px;word-break:break-all;margin-top:1px}
+ .key .seq{font-size:9px;font-family:monospace;line-height:1.15;text-align:center;min-height:10px;word-break:break-all;overflow-wrap:anywhere;margin-top:1px}
  .key.sel canvas{cursor:move}
+ #langbar{display:flex;flex-wrap:wrap;gap:3px;margin-bottom:6px;max-width:1500px}
+ .langbtn{background:#2a2a2a;color:#bbb;border:1px solid #444;border-radius:3px;font-size:10px;font-family:monospace;padding:2px 4px;cursor:pointer;line-height:1.1}
+ .langbtn:hover{background:#383838} .langbtn.mod{background:#5a4a1e;color:#fd8;border-color:#a85}
+ .langbtn.cur{border-color:#4af;color:#fff;background:#243a4a} .langbtn.cur.mod{border-color:#4af;background:#4a3a14}
  #panel{position:fixed;left:0;right:0;bottom:0;height:198px;background:#242424;border-top:2px solid #444;
    padding:6px 10px;display:flex;gap:16px;box-sizing:border-box;overflow-x:auto}
  #keyctrl{display:flex;gap:10px;align-items:flex-start;min-width:480px}
@@ -39,8 +43,10 @@
 </style></head><body>
 <h1>PolyKybd · <span id="langname"></span> keycap tuner</h1>
 <div class="sub">base=<span style="color:#4f4">green</span> · Shift=<span style="color:#6af">blue</span> · AltGr=<span style="color:#f66">red</span> · overlaps mix · faded = clipped off-keycap · faint crosshair = each element's offset <b>origin</b>. <span style="color:#a85">en-US</span>=Latin fallback. The line under each preview is its positioning <b>control-char sequence</b> (\f up · \x05 down · \b left · \x06 right). Click a key; <b>drag</b> the active glyph in the preview to move it (snaps to 2px), or nudge it (bottom-left) / the whole-layout offsets (bottom-right).</div>
-<div class="top"><label class="hint">Layout <select id="langsel" onchange="switchLang(this.value)"></select></label>
- <button class="act" onclick="exportAll()">Export changes</button><span class="hint">…then paste the box back to Claude (or feed it to apply_tuner.py)</span></div>
+<div id="langbar"></div>
+<div class="top"><button class="act" onclick="exportAll()">Export changes</button>
+ <button class="act" onclick="resetLayout()">Reset layout</button>
+ <span class="hint">…then paste the box back to Claude (or feed it to apply_tuner.py)</span></div>
 <textarea id="exp" placeholder="changed cells + offsets appear here on Export"></textarea>
 <div id="warnsum"></div>
 <div id="grid"></div>
@@ -131,7 +137,8 @@ function buildGrid(){const g=document.getElementById("grid");g.innerHTML="";let 
    const sq=document.createElement("div");sq.className="seq";sq.innerHTML=seqLine(kc);d.appendChild(sq);
    if(kc===selected)cv.addEventListener("mousedown",e=>startDrag(e,kc,cv));   // drag the active glyph (2px snap)
    d.onclick=()=>{if(selected!==kc){selected=kc;activeEl=(st[kc].base?"base":(st[kc].shift?"shift":(st[kc].altgr?"altgr":null)));}buildGrid();buildKeyCtrl();};rd.appendChild(d);}g.appendChild(rd);}
- document.getElementById("warnsum").textContent=warnN?(warnN+" key(s) flag out-of-bounds / overlap"):"no out-of-bounds or overlap ✓";}
+ document.getElementById("warnsum").textContent=warnN?(warnN+" key(s) flag out-of-bounds / overlap"):"no out-of-bounds or overlap ✓";
+ refreshLangBar();}
 function dpad(kc,el){const b=(dx,dy,t)=>`<button onclick="event.stopPropagation();nudge('${kc}','${el}',${dx},${dy})">${t}</button>`;
  return`<div class="dpad"><span class="sp"></span>${b(0,-2,"↑")}<span class="sp"></span>${b(-2,0,"←")}<button onclick="event.stopPropagation();reset1('${kc}','${el}')">·</button>${b(2,0,"→")}<span class="sp"></span>${b(0,2,"↓")}<span class="sp"></span></div>`;}
 function buildKeyCtrl(){const p=document.getElementById("keyctrl");if(!selected){p.innerHTML="<span class='hint'>click a key to edit</span>";return;}
@@ -192,8 +199,21 @@ function exportAll(){const out=[];
  document.getElementById("exp").value=out.length?out.join("\n"):"(no changes yet)";}
 function switchLang(code){loadLang(code);document.getElementById("langname").textContent=code;
  buildOffPanel();buildGrid();buildKeyCtrl();}
-const _sel=document.getElementById("langsel");
-for(const code of DATA.order){const o=document.createElement("option");o.value=code;o.textContent=code;_sel.appendChild(o);}
+// revert every edit (nudges, drops, offsets) of the CURRENT layout to its loaded state
+function resetLayout(){const S=STATE[LANG];if(!S)return;
+ for(const kc in S.st)for(const el of["base","shift","altgr"]){const E=S.st[kc][el];if(E){E.dx=E.odx;E.dy=E.ody;E.drop=E.odrop;}}
+ for(const c in S.off)for(const t in S.off[c])for(const ax of["H","V"])S.off[c][t][ax]=S.o0[c][t][ax];
+ selected=null;activeEl=null;buildOffPanel();buildGrid();buildKeyCtrl();}
+// push-button matrix of every layout; buttons of edited layouts go amber (.mod),
+// the current one is highlighted (.cur). refreshLangBar only re-tags existing buttons.
+function buildLangBar(){const bar=document.getElementById("langbar");bar.innerHTML="";
+ for(const code of DATA.order){const b=document.createElement("button");b.id="lb_"+code;b.className="langbtn";b.textContent=code;
+  b.onclick=()=>switchLang(code);bar.appendChild(b);}
+ refreshLangBar();}
+function refreshLangBar(){for(const code of DATA.order){const b=document.getElementById("lb_"+code);if(!b)continue;
+ b.classList.toggle("cur",code===LANG);
+ b.classList.toggle("mod",!!STATE[code]&&exportLang(STATE[code]).length>0);}}
+buildLangBar();
 loadLang(DATA.order[0]);document.getElementById("langname").textContent=LANG;
 buildOffPanel();buildGrid();
 </script></body></html>

--- a/tools/keycap_tuner_template.html
+++ b/tools/keycap_tuner_template.html
@@ -63,11 +63,15 @@ const DATA=__DATA__;
 const C=DATA.consts,HIDE=DATA.HIDE,BY=DATA.base_yadv;
 const OW=C.OLED_W,OH=C.OLED_H,BX=C.BUFFER_X,SW=C.SCREEN_WIDTH,BL=C.BASELINE;
 const SCALE=4,MARG=9,LETTERS="ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-function catOf(kc){const c=kc.startsWith("KC_")&&kc.length===4?kc[3]:"";if(LETTERS.includes(c))return"letter";if(/^KC_[0-9]$/.test(kc))return"num";return"sym";}
+// mirror oled_preview: letter iff KC_<A-Z> (4 chars), num iff KC_<0-9>, else sym.
+// NB: guard the empty c — "ABC..".includes("") is true in JS, which used to make
+// every non-4-char keycode (KC_GRAVE, KC_MINUS, KC_LBRC, …) misclassify as letter.
+function catOf(kc){const c=kc.startsWith("KC_")&&kc.length===4?kc[3]:"";if(c&&LETTERS.includes(c))return"letter";if(/^KC_[0-9]$/.test(kc))return"num";return"sym";}
 const CATCOL={letter:"#b07cff",num:"#ff9a3c",sym:"#7ed957"};        // purple / orange / apple-green
 const CATEX={letter:"A, B, C, …",num:"1, 2, 3, …",sym:". , / …"};
 let hlCat=null;                                                     // clicking a category frames its keys
 function toggleCat(c){hlCat=(hlCat===c?null:c);buildOffPanel();buildGrid();}
+function escHtml(s){return String(s).replace(/[&<>"']/g,m=>({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[m]));}
 // All layouts share the DATA.glyphs pool; per-layout cells/offsets live in DATA.langs.
 // st (per-key nudge state), OFF (mutable offsets) and O0 (pristine offsets) are
 // repointed at the current layout by loadLang(); STATE keeps each layout's edits
@@ -77,8 +81,12 @@ const STATE={};
 function buildSt(keys){const s={};
  for(const kc in keys){s[kc]={};const K=keys[kc];
   for(const el of["base","shift","altgr"]){const sp=K[el];if(!sp){s[kc][el]=null;continue;}
-   let dx=0,dy=0;for(const cp of sp.esc){if(cp===6)dx+=2;else if(cp===8)dx-=2;else if(cp===5)dy+=2;else if(cp===12)dy-=2;}
-   s[kc][el]={dx,dy,glyph:sp.glyph,tok:sp.tok,fb:!!sp.fb,odx:dx,ody:dy,drop:false,odrop:false};}}
+   // the esc prefix may carry the four 2px nudge codes (editable -> dx/dy) AND other
+   // structural control chars (\t \n \v=0x0b \r \x18) that must be replayed verbatim,
+   // or glyphs like the Arabic 0x0b-prefixed shift legends render at the wrong place.
+   let dx=0,dy=0;const struct=[];
+   for(const cp of sp.esc){if(cp===6)dx+=2;else if(cp===8)dx-=2;else if(cp===5)dy+=2;else if(cp===12)dy-=2;else struct.push(cp);}
+   s[kc][el]={dx,dy,struct,glyph:sp.glyph,tok:sp.tok,fb:!!sp.fb,odx:dx,ody:dy,drop:false,odrop:false};}}
  return s;}
 function loadLang(code){LANG=code;
  if(!STATE[code]){const off=DATA.langs[code].offsets;
@@ -101,7 +109,7 @@ function draw(cps,x,y,plot){let xc=x,yc=y;
   let g=glyphOf(cp)||glyphOf(33);if(!g)continue;const gy=yc+(g.yadv-BY);let bo=0,bit=0,bits=0;
   for(let yy=0;yy<g.h;yy++)for(let xx=0;xx<g.w;xx++){if((bit&7)===0)bits=g.bits[bo++];
    if(bits&0x80)plot(xc+g.xo+xx-BX,gy+g.yo+yy);bits=(bits<<1)&0xFF;bit++;}xc+=g.xadv;}}
-function cpsOf(e){return e&&!e.drop?gen(e.dx,e.dy).concat(e.glyph):null;}
+function cpsOf(e){return e&&!e.drop?e.struct.concat(gen(e.dx,e.dy)).concat(e.glyph):null;}
 function renderKey(kc){const o=OFF[catOf(kc)],K=st[kc];const base=cpsOf(K.base);if(!base)return{empty:true};
  let bx=28+o.small.H,bv=o.small.V;let scps=null,px2=0,pv=0;
  if(K.shift&&!K.shift.drop&&o.shift.H!==HIDE&&o.shift.V!==HIDE){scps=cpsOf(K.shift);
@@ -159,7 +167,7 @@ function buildKeyCtrl(){const p=document.getElementById("keyctrl");if(!selected)
  // editing; the inner buttons/checkbox stopPropagation so they don't double-fire.
  for(const el of["base","shift","altgr"]){const E=K[el];h+=`<div class="el ${el}${el===activeEl?' active':''}" style="cursor:pointer" onclick="setActive('${el}')"><span class="nm">${el}</span>`;
   if(!E){h+=` <span class='hint'>none</span></div>`;continue;}
-  h+=`<span class="tok">${E.tok}${E.fb?' <span class=fbm>(en-US)</span>':''}</span>${dpad(selected,el)}<span class="off">dx=${E.dx} dy=${E.dy}</span>
+  h+=`<span class="tok">${escHtml(E.tok)}${E.fb?' <span class=fbm>(en-US)</span>':''}</span>${dpad(selected,el)}<span class="off">dx=${E.dx} dy=${E.dy}</span>
    <label class="drop"><input type="checkbox" ${E.drop?"checked":""} onclick="event.stopPropagation()" onchange="setdrop('${selected}','${el}',this.checked)">drop</label></div>`;}
  p.innerHTML=h;}
 // a category offset as a d-pad (▲▼ = V up/down, ◀▶ = H left/right) over two number
@@ -197,7 +205,7 @@ function escStr(cp){return cp===12?"\\f":cp===8?"\\b":cp===5?"\\x05":cp===6?"\\x
 // per-key control-char sequence line under the preview: the leading positioning
 // escapes (\f up, \x05 down, \b left, \x06 right) each element carries, coloured.
 const SEQCOL={base:"#4f4",shift:"#6af",altgr:"#f66"};
-function seqOf(E){return E&&!E.drop?gen(E.dx,E.dy).map(escStr).join(""):"";}
+function seqOf(E){return E&&!E.drop?E.struct.concat(gen(E.dx,E.dy)).map(escStr).join(""):"";}
 function seqLine(kc){const K=st[kc],out=[];
  for(const el of["base","shift","altgr"]){const s=seqOf(K[el]);if(s)out.push(`<span style="color:${SEQCOL[el]}">${el[0]}${s}</span>`);}
  return out.join(" ")||"<span style='color:#555'>·</span>";}
@@ -211,7 +219,7 @@ function onDrag(e){if(!drag)return;const f=SCALE/2;          // CSS px per OLED 
  E.dx=drag.dx0+2*Math.round((e.clientX-drag.sx)/f/2);E.dy=drag.dy0+2*Math.round((e.clientY-drag.sy)/f/2);
  paintR(drag.cv,drag.kc);}                                  // live repaint just this key while dragging
 function endDrag(){if(!drag)return;document.removeEventListener("mousemove",onDrag);document.removeEventListener("mouseup",endDrag);drag=null;buildGrid();buildKeyCtrl();}
-function cellFor(E){const esc=gen(E.dx,E.dy),named=/^[A-Z][A-Z0-9_]+$/.test(E.tok);
+function cellFor(E){const esc=E.struct.concat(gen(E.dx,E.dy)),named=/^[A-Z][A-Z0-9_]+$/.test(E.tok);
  if(esc.length===0)return E.tok;const s=esc.map(escStr).join("");return named?`U"${s}" ${E.tok}`:`U"${s}${E.tok}"`;}
 // Emit one `=== code ===` block per layout that has changes (across every layout
 // visited this session). apply_tuner.py parses exactly this format.

--- a/tools/keycap_tuner_template.html
+++ b/tools/keycap_tuner_template.html
@@ -31,8 +31,9 @@
  .off{font-size:11px;color:#9c9;margin-left:4px} .drop{font-size:11px;margin-left:4px}
  #offctrl{border-left:2px solid #3a3a3a;padding-left:12px}
  .offhdr{font-size:12px;color:#9bd;margin-bottom:4px}
- .offgroups{display:flex;gap:14px}
- .offgroup{display:flex;flex-direction:column;gap:2px} .offgroup .gname{font-size:12px;color:#9bd}
+ .offgroups{display:flex;gap:10px}
+ .offgroup{display:flex;flex-direction:column;gap:2px;border:1px solid #444;border-radius:4px;padding:3px 6px}
+ .offgroup .gname{font-size:11px;cursor:pointer;white-space:nowrap;user-select:none} .offgroup .gname .ex{color:#888;font-size:10px}
  .offrow{display:flex;gap:8px}
  .offdpad{display:flex;flex-direction:column;align-items:center;gap:2px}
  .offdpad .vn{font-size:11px;color:#888} .offdpad .vn.small{color:#4f4}.offdpad .vn.shift{color:#6af}.offdpad .vn.altgr{color:#f66}
@@ -61,6 +62,10 @@ const C=DATA.consts,HIDE=DATA.HIDE,BY=DATA.base_yadv;
 const OW=C.OLED_W,OH=C.OLED_H,BX=C.BUFFER_X,SW=C.SCREEN_WIDTH,BL=C.BASELINE;
 const SCALE=4,MARG=9,LETTERS="ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 function catOf(kc){const c=kc.startsWith("KC_")&&kc.length===4?kc[3]:"";if(LETTERS.includes(c))return"letter";if(/^KC_[0-9]$/.test(kc))return"num";return"sym";}
+const CATCOL={letter:"#b07cff",num:"#ff9a3c",sym:"#7ed957"};        // purple / orange / apple-green
+const CATEX={letter:"A, B, C, …",num:"1, 2, 3, …",sym:". , / …"};
+let hlCat=null;                                                     // clicking a category frames its keys
+function toggleCat(c){hlCat=(hlCat===c?null:c);buildOffPanel();buildGrid();}
 // All layouts share the DATA.glyphs pool; per-layout cells/offsets live in DATA.langs.
 // st (per-key nudge state), OFF (mutable offsets) and O0 (pristine offsets) are
 // repointed at the current layout by loadLang(); STATE keeps each layout's edits
@@ -132,6 +137,7 @@ let selected=null,activeEl=null;
 function buildGrid(){const g=document.getElementById("grid");g.innerHTML="";let warnN=0;
  for(const row of DATA.rows){const rd=document.createElement("div");rd.style.display="flex";rd.style.flexWrap="wrap";rd.style.gap="4px";rd.style.flexBasis="100%";
   for(const kc of row){if(!(kc in st))continue;const d=document.createElement("div");d.className="key"+(kc===selected?" sel":"");
+   if(hlCat&&catOf(kc)===hlCat){d.style.outline="2px solid "+CATCOL[hlCat];d.style.outlineOffset="1px";}
    const cv=document.createElement("canvas");cv.width=(OW+2*MARG)*SCALE;cv.height=(OH+2*MARG)*SCALE;
    cv.style.width=((OW+2*MARG)*SCALE/2)+"px";cv.style.height=((OH+2*MARG)*SCALE/2)+"px";d.appendChild(cv);
    const lab=document.createElement("div");lab.className="lab";lab.textContent=kc.replace("KC_","");d.appendChild(lab);
@@ -162,8 +168,9 @@ function offCtl(c,t){const o=OFF[c][t];
  return`<div class="offdpad"><span class="vn ${t}">${t}</span>
   <div class="offpad"><span class="sp"></span>${f('V',-1,'▲')}<span class="sp"></span>${f('H',-1,'◀')}<span class="sp"></span>${f('H',1,'▶')}<span class="sp"></span>${f('V',1,'▼')}<span class="sp"></span></div>
   <div class="offins">H${ip('H')} V${ip('V')}</div></div>`;}
-function buildOffPanel(){let h=`<div class="offhdr">layout offsets (whole ${LANG})</div><div class="offgroups">`;
- for(const c of['letter','num','sym']){h+=`<div class="offgroup"><span class="gname">${c}</span><div class="offrow">`;
+function buildOffPanel(){let h=`<div class="offhdr">layout offsets (whole ${LANG}) — click a category to frame its keys</div><div class="offgroups">`;
+ for(const c of['letter','num','sym']){const hl=hlCat===c?`box-shadow:0 0 0 2px ${CATCOL[c]} inset;`:'';
+  h+=`<div class="offgroup" style="border-color:${CATCOL[c]};${hl}"><span class="gname" style="color:${CATCOL[c]}" onclick="toggleCat('${c}')">${c}: <span class="ex">${CATEX[c]}</span></span><div class="offrow">`;
   for(const t of['small','shift','altgr'])h+=offCtl(c,t);h+='</div></div>';}
  document.getElementById("offctrl").innerHTML=h+'</div>';}
 function adjOff(c,t,ax,d){OFF[c][t][ax]+=d;document.getElementById(`o_${c}_${t}_${ax}`).value=OFF[c][t][ax];buildGrid();}

--- a/tools/keycap_tuner_template.html
+++ b/tools/keycap_tuner_template.html
@@ -118,7 +118,7 @@ function paintR(cv,kc){const r=renderKey(kc),ctx=cv.getContext("2d");ctx.fillSty
  return r;}
 let selected=null,activeEl=null;
 function buildGrid(){const g=document.getElementById("grid");g.innerHTML="";let warnN=0;
- for(const row of DATA.rows){const rd=document.createElement("div");rd.style.display="flex";rd.style.gap="4px";rd.style.flexBasis="100%";
+ for(const row of DATA.rows){const rd=document.createElement("div");rd.style.display="flex";rd.style.flexWrap="wrap";rd.style.gap="4px";rd.style.flexBasis="100%";
   for(const kc of row){if(!(kc in st))continue;const d=document.createElement("div");d.className="key"+(kc===selected?" sel":"");
    const cv=document.createElement("canvas");cv.width=(OW+2*MARG)*SCALE;cv.height=(OH+2*MARG)*SCALE;
    cv.style.width=((OW+2*MARG)*SCALE/2)+"px";cv.style.height=((OH+2*MARG)*SCALE/2)+"px";d.appendChild(cv);

--- a/tools/keycap_tuner_template.html
+++ b/tools/keycap_tuner_template.html
@@ -39,8 +39,10 @@
  .offdpad .vn{font-size:11px;color:#888} .offdpad .vn.small{color:#4f4}.offdpad .vn.shift{color:#6af}.offdpad .vn.altgr{color:#f66}
  .offpad{display:inline-grid;grid-template-columns:repeat(3,18px);grid-gap:1px}
  .offpad button{width:18px;height:15px;font-size:10px;padding:0} .offpad button:hover{background:#444} .offpad .sp{visibility:hidden}
+ .offpad .hbtn{font-weight:bold;color:#fa6} .offpad .hbtn.on{background:#a33;color:#fff;border-color:#c55}
  .offins{display:flex;align-items:center;gap:1px;font-size:10px;color:#888}
  .offins input{width:26px;background:#111;color:#dd9;border:1px solid #444;font-size:10px;text-align:center}
+ .offdpad.hidden .vn{text-decoration:line-through;opacity:.85} .offdpad.hidden .offins input{color:#f88;border-color:#a44}
  .top{display:flex;gap:10px;align-items:center;margin-bottom:6px;flex-wrap:wrap}
  button.act{background:#264;color:#cfc;border:1px solid #485;border-radius:4px;padding:5px 9px;cursor:pointer}
  #exp{width:100%;max-width:1150px;height:80px;background:#111;color:#9f9;font-family:monospace;font-size:11px;border:1px solid #444;margin-top:4px}
@@ -162,19 +164,31 @@ function buildKeyCtrl(){const p=document.getElementById("keyctrl");if(!selected)
  p.innerHTML=h;}
 // a category offset as a d-pad (▲▼ = V up/down, ◀▶ = H left/right) over two number
 // inputs, mirroring the per-key d-pad so both feel the same to operate.
-function offCtl(c,t){const o=OFF[c][t];
+function offCtl(c,t){const o=OFF[c][t];const hid=(o.H===HIDE||o.V===HIDE);
  const f=(ax,d,s)=>`<button onclick="adjOff('${c}','${t}','${ax}',${d})">${s}</button>`;
- const ip=(ax)=>`<input id="o_${c}_${t}_${ax}" type="number" value="${o[ax]}" onchange="setOffV('${c}','${t}','${ax}',this.value)">`;
- return`<div class="offdpad"><span class="vn ${t}">${t}</span>
-  <div class="offpad"><span class="sp"></span>${f('V',-1,'▲')}<span class="sp"></span>${f('H',-1,'◀')}<span class="sp"></span>${f('H',1,'▶')}<span class="sp"></span>${f('V',1,'▼')}<span class="sp"></span></div>
+ const ip=(ax)=>`<input id="o_${c}_${t}_${ax}" type="number" value="${o[ax]===HIDE?'':o[ax]}" placeholder="${o[ax]===HIDE?'hid':''}" onchange="setOffV('${c}','${t}','${ax}',this.value)">`;
+ const H=`<button class="hbtn${hid?' on':''}" title="hide this variation (both axes -> HIDE)" onclick="hideOff('${c}','${t}')">H</button>`;
+ return`<div class="offdpad${hid?' hidden':''}"><span class="vn ${t}">${t}</span>
+  <div class="offpad"><span class="sp"></span>${f('V',-1,'▲')}<span class="sp"></span>${f('H',-1,'◀')}${H}${f('H',1,'▶')}<span class="sp"></span>${f('V',1,'▼')}<span class="sp"></span></div>
   <div class="offins">H${ip('H')} V${ip('V')}</div></div>`;}
 function buildOffPanel(){let h=`<div class="offhdr">layout offsets (whole ${LANG}) — click a category to frame its keys</div><div class="offgroups">`;
  for(const c of['letter','num','sym']){const hl=hlCat===c?`box-shadow:0 0 0 2px ${CATCOL[c]} inset;`:'';
   h+=`<div class="offgroup" style="border-color:${CATCOL[c]};${hl}"><span class="gname" style="color:${CATCOL[c]}" onclick="toggleCat('${c}')">${c}: <span class="ex">${CATEX[c]}</span></span><div class="offrow">`;
   for(const t of['small','shift','altgr'])h+=offCtl(c,t);h+='</div></div>';}
  document.getElementById("offctrl").innerHTML=h+'</div>';}
-function adjOff(c,t,ax,d){OFF[c][t][ax]+=d;document.getElementById(`o_${c}_${t}_${ax}`).value=OFF[c][t][ax];buildGrid();}
-function setOffV(c,t,ax,v){OFF[c][t][ax]=parseInt(v,10)||0;buildGrid();}
+// HIDE_KEY (-128) is the firmware "do not show" sentinel; we treat any negative the
+// same. A step out of a hidden/negative state wakes both axes to 0; a step (or typed
+// value) into the negative hides both. The H button toggles hide directly.
+function adjOff(c,t,ax,d){const o=OFF[c][t];
+ if(o.H===HIDE||o.V===HIDE||o.H<0||o.V<0){o.H=0;o.V=0;}        // wake hidden/negative -> 0,0
+ else{o[ax]+=d;if(o[ax]<0){o.H=HIDE;o.V=HIDE;}}                // stepped below 0 -> hide both
+ buildOffPanel();buildGrid();}
+function setOffV(c,t,ax,v){const n=parseInt(v,10);const o=OFF[c][t];
+ if(isNaN(n)||n<0){o.H=HIDE;o.V=HIDE;}else{o[ax]=n;}           // blank or negative -> hide both
+ buildOffPanel();buildGrid();}
+function hideOff(c,t){const o=OFF[c][t];
+ if(o.H===HIDE||o.V===HIDE){o.H=0;o.V=0;}else{o.H=HIDE;o.V=HIDE;}   // toggle hide
+ buildOffPanel();buildGrid();}
 function nudge(kc,el,dx,dy){const E=st[kc][el];E.dx+=dx;E.dy+=dy;activeEl=el;buildGrid();buildKeyCtrl();}
 function reset1(kc,el){const E=st[kc][el];E.dx=E.odx;E.dy=E.ody;E.drop=E.odrop;buildGrid();buildKeyCtrl();}
 function setdrop(kc,el,v){st[kc][el].drop=v;buildGrid();buildKeyCtrl();}

--- a/tools/oled_preview.py
+++ b/tools/oled_preview.py
@@ -86,7 +86,8 @@ class Lang:
     def __init__(self, xlsx: str, named: dict):
         from openpyxl import load_workbook
         wb = load_workbook(xlsx, data_only=True, read_only=True)
-        ws = wb['key_lut']; self.named = named
+        ws = wb['key_lut']
+        self.named = named
         # Materialise the sheet once. A read_only worksheet streams forward, so random
         # `.cell(row, col)` access re-scans and is O(n) per call - fine for one layout,
         # but it made --all (every layout x ~49 keys) crawl. A single iter_rows pass
@@ -100,7 +101,8 @@ class Lang:
         self.langs = []
         i = 0
         while self.grid.get((1, 2 + i * 4)):
-            self.langs.append(self.grid[(1, 2 + i * 4)]); i += 1
+            self.langs.append(self.grid[(1, 2 + i * 4)])
+            i += 1
 
     def basecol(self, lang): return 2 + self.langs.index(lang) * 4
 

--- a/tools/oled_preview.py
+++ b/tools/oled_preview.py
@@ -86,17 +86,27 @@ class Lang:
     def __init__(self, xlsx: str, named: dict):
         from openpyxl import load_workbook
         wb = load_workbook(xlsx, data_only=True, read_only=True)
-        self.sh = wb['key_lut']; self.named = named
+        ws = wb['key_lut']; self.named = named
+        # Materialise the sheet once. A read_only worksheet streams forward, so random
+        # `.cell(row, col)` access re-scans and is O(n) per call - fine for one layout,
+        # but it made --all (every layout x ~49 keys) crawl. A single iter_rows pass
+        # into a {(row,col): value} grid makes every later lookup O(1).
+        self.grid = {}
+        for r, rowvals in enumerate(ws.iter_rows(values_only=True), start=1):
+            for c, v in enumerate(rowvals, start=1):
+                if v is not None and v != '':
+                    self.grid[(r, c)] = v
+        wb.close()
         self.langs = []
         i = 0
-        while self.sh.cell(row=1, column=2 + i * 4).value:
-            self.langs.append(self.sh.cell(row=1, column=2 + i * 4).value); i += 1
+        while self.grid.get((1, 2 + i * 4)):
+            self.langs.append(self.grid[(1, 2 + i * 4)]); i += 1
 
     def basecol(self, lang): return 2 + self.langs.index(lang) * 4
 
     def cell(self, lang_idx0, row, var):
         """raw cell value at language (0-based index), row, variation column."""
-        return self.sh.cell(row=row, column=2 + lang_idx0 * 4 + var).value
+        return self.grid.get((row, 2 + lang_idx0 * 4 + var))
 
     def resolve(self, val) -> list[int] | None:
         """cell value -> list of codepoints (the U'...' the firmware would build), or None."""


### PR DESCRIPTION
Extend the offline keycap tuner so every layout can be tuned from one file,
and close the manual copy-paste loop back into lang_lut.xlsx.

gen_keycap_tuner.py:
- add --all: bake every layout in lang_lut.xlsx into one self-contained HTML
  behind a Layout dropdown. Glyph bitmaps are stored once in a shared pool keyed
  by codepoint (Latin layouts reuse a/b/c), so all 160 layouts fit in ~1.7 MB.
- --lang X is now --all restricted to one layout; both feed the same template
  and JS render mirror (single source to keep in sync with the firmware).

keycap_tuner_template.html:
- dropdown switches layouts; per-layout edit state (st/offsets) is kept alive
  while switching so nothing is lost. Export emits one `=== code ===` block per
  edited layout.

apply_tuner.py (new):
- parse the tuner's export and write the changed key_lut + offset cells straight
  into lang_lut.xlsx. Edits ONLY xl/worksheets/sheet2.xml (set/clear cells) and
  copies every other zip entry byte-for-byte, so formula caches stay intact -
  same surgical approach as lang/_patch_xlsx.py, but editing existing cells.

oled_preview.py:
- Lang now materialises the key_lut sheet in one iter_rows pass instead of O(n)
  random read_only .cell() access. Identical values; turns --all from
  never-finishing into ~1 s.

Verified: JS render mirror matches oled_preview --check-bounds for te-IN both as
a single-layout file and inside the --all file; apply_tuner set/clear round-trips
land in the right cells and leave neighbours intact.

https://claude.ai/code/session_012DeueLR6WWSdBJitGtoDCd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Keycap tuner now generates multi-layout offline HTML files with a layout selector dropdown
  * Per-layout edits are preserved when switching between layouts
  * Glyph bitmaps are shared across layouts to minimize file size
  * New command-line tool to apply keycap tuner edits back to keyboard layout files

* **Documentation**
  * Updated keycap tuner documentation for multi-layout workflow and export/apply process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->