### PR TITLE
Reorder VS Code debug configurations

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,14 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Start PolyHost",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "polyhost",
+            "console": "integratedTerminal"
+        },
+        {
+            // Requires scalene in the venv: `pip install scalene`
             "name": "[WIN] Profile PolyHost",
             "type": "python",
             "request": "launch",
@@ -9,13 +17,6 @@
             "args": [ "-m", "polyhost" ],
             "console": "integratedTerminal",
             "justMyCode": false
-        },
-        {
-            "name": "Start PolyHost",
-            "type": "debugpy",
-            "request": "launch",
-            "module": "polyhost",
-            "console": "integratedTerminal"
         },
         {
             "name": "Debug PolyHost",


### PR DESCRIPTION
## Summary
Reordered the VS Code debug launch configurations in `.vscode/launch.json` to place "Start PolyHost" before "[WIN] Profile PolyHost". This improves the logical flow by grouping the standard debug launcher first, followed by profiling and other specialized configurations. Also added a clarifying comment to the profiling configuration noting the scalene dependency requirement.

## Version bump label
*(none)* — configuration-only change

## Testing
N/A — configuration file change with no functional impact on the application.

https://claude.ai/code/session_0191FLxQ7LceLUNBNAmzCMfj

## Summary by Sourcery

Reorder VS Code debug launch configurations to prioritize the standard PolyHost launcher ahead of profiling and specialized configurations.

Enhancements:
- Reorganize VS Code launch configurations in .vscode/launch.json to present the standard PolyHost debug configuration before the profiling configuration.
- Document the profiling configuration's dependency on scalene via an inline comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated VS Code debug configurations for improved development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->