### PR TITLE
Installer: launch-on-finish + POLYKYBD_NO_LAUNCH opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ location up front without the prompt, set `POLYKYBD_DIR` first — e.g.
 `POLYKYBD_DIR=~/apps/polykybd` (bash) or `$env:POLYKYBD_DIR="C:\Tools\PolyKybd"`
 (PowerShell).
 
+When it finishes, the installer offers to start PolyKybd. If you ran it from a
+terminal it asks first (`Start PolyKybd now? [Y/n]`); if it was launched
+non-interactively it starts the app right away. Either way the app registers
+itself for autostart on its first run, so the manual `python -m polyhost`
+commands below are only needed for later/manual launches.
+
 **Linux / macOS**
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ location up front without the prompt, set `POLYKYBD_DIR` first — e.g.
 
 When it finishes, the installer offers to start PolyKybd. If you ran it from a
 terminal it asks first (`Start PolyKybd now? [Y/n]`); if it was launched
-non-interactively it starts the app right away. Either way the app registers
-itself for autostart on its first run, so the manual `python -m polyhost`
-commands below are only needed for later/manual launches.
+non-interactively it starts the app right away. Set `POLYKYBD_NO_LAUNCH=1` to
+skip starting the app altogether (useful for CI/headless installs). Either way
+the app registers itself for autostart on its first run, so the manual
+`python -m polyhost` commands below are only needed for later/manual launches.
 
 **Linux / macOS**
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -55,6 +55,25 @@ $venvPy = Join-Path (Get-Location) ".venv\Scripts\python.exe"
 & $venvPy -m pip install --upgrade pip
 & $venvPy -m pip install -r requirements.txt
 
+function Start-PolyKybd {
+    Write-Host ">> Starting PolyKybd..."
+    # Prefer pythonw.exe so the GUI/tray app launches without a console window.
+    $pyw = Join-Path (Get-Location) ".venv\Scripts\pythonw.exe"
+    if (-not (Test-Path $pyw)) { $pyw = $venvPy }
+    Start-Process -FilePath $pyw -ArgumentList "-m", "polyhost" -WorkingDirectory (Get-Location)
+    Write-Host ">> PolyKybd started; it also registers itself to autostart at login."
+}
+
 Write-Host ""
-Write-Host ">> Done. Start PolyKybdHost with:"
-Write-Host "       cd $(Get-Location); .venv\Scripts\python.exe -m polyhost"
+Write-Host ">> Done."
+if ([Environment]::UserInteractive -and -not [Console]::IsInputRedirected) {
+    $ans = Read-Host ">> Start PolyKybd now? [Y/n]"
+    if ($ans -match '^[Nn]') {
+        Write-Host ">> Not started. Launch it later with:  .venv\Scripts\python.exe -m polyhost"
+    } else {
+        Start-PolyKybd
+    }
+} else {
+    # Not started interactively - start right away.
+    Start-PolyKybd
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -66,7 +66,10 @@ function Start-PolyKybd {
 
 Write-Host ""
 Write-Host ">> Done."
-if ([Environment]::UserInteractive -and -not [Console]::IsInputRedirected) {
+if ($env:POLYKYBD_NO_LAUNCH) {
+    # Opt out of auto-launch (e.g. CI / headless). Don't start the app.
+    Write-Host ">> POLYKYBD_NO_LAUNCH set - not starting. Launch it later with:  .venv\Scripts\python.exe -m polyhost"
+} elseif ([Environment]::UserInteractive -and -not [Console]::IsInputRedirected) {
     $ans = Read-Host ">> Start PolyKybd now? [Y/n]"
     if ($ans -match '^[Nn]') {
         Write-Host ">> Not started. Launch it later with:  .venv\Scripts\python.exe -m polyhost"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -84,6 +84,22 @@ case "$(uname -s)" in
         ;;
 esac
 
+launch_app() {
+    echo ">> Starting PolyKybd..."
+    nohup .venv/bin/python -m polyhost >/dev/null 2>&1 &
+    echo ">> PolyKybd started (PID $!); it also registers itself to autostart at login."
+}
+
 echo ""
-echo ">> Done. Start PolyKybdHost with:"
-echo "       cd $(pwd) && .venv/bin/python -m polyhost"
+echo ">> Done."
+if [ -r /dev/tty ]; then
+    printf ">> Start PolyKybd now? [Y/n] " > /dev/tty
+    read -r ans < /dev/tty || ans=""
+    case "$ans" in
+        [Nn]*) echo ">> Not started. Launch it later with:  cd \"$(pwd)\" && .venv/bin/python -m polyhost" ;;
+        *)     launch_app ;;
+    esac
+else
+    # No terminal to ask on (not started interactively) - start right away.
+    launch_app
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -92,11 +92,15 @@ launch_app() {
 
 echo ""
 echo ">> Done."
-if [ -r /dev/tty ]; then
+RUN_HINT="cd \"$(pwd)\" && .venv/bin/python -m polyhost"
+if [ -n "${POLYKYBD_NO_LAUNCH:-}" ]; then
+    # Opt out of auto-launch (e.g. CI / headless). Don't start the app.
+    echo ">> POLYKYBD_NO_LAUNCH set - not starting. Launch it later with:  $RUN_HINT"
+elif [ -r /dev/tty ]; then
     printf ">> Start PolyKybd now? [Y/n] " > /dev/tty
     read -r ans < /dev/tty || ans=""
     case "$ans" in
-        [Nn]*) echo ">> Not started. Launch it later with:  cd \"$(pwd)\" && .venv/bin/python -m polyhost" ;;
+        [Nn]*) echo ">> Not started. Launch it later with:  $RUN_HINT" ;;
         *)     launch_app ;;
     esac
 else


### PR DESCRIPTION
Adds `POLYKYBD_NO_LAUNCH` to let users opt out of the installer auto-launching the app.

### Context
The "offer to launch when done" behaviour was added to the installers but did **not** make it into the #46 merge (that PR merged at the commit just before it), so this PR brings in both:

1. **Offer to launch when done** — after install, prompt `Start PolyKybd now? [Y/n]` when an interactive terminal is present; start the app right away when run non-interactively. Linux/macOS launch detached via `nohup`; Windows uses `pythonw.exe` so no console window flashes.
2. **`POLYKYBD_NO_LAUNCH` opt-out** — when set, the installer finishes without starting the app (no prompt, no auto-launch). This avoids the footgun where the non-interactive path would otherwise try to launch the GUI in CI/headless contexts.

### Files
- `scripts/install.sh`, `scripts/install.ps1`: launch-on-finish + `POLYKYBD_NO_LAUNCH` gate (checked before the interactive/auto branches).
- `README.md`: documents the launch prompt and the `POLYKYBD_NO_LAUNCH=1` opt-out.

### Testing notes
- `bash -n scripts/install.sh` passes. Not run end-to-end (no venv/display/hardware in the dev environment); the launch paths and env-var gate were reviewed by reading, not executed.

https://claude.ai/code/session_0191FLxQ7LceLUNBNAmzCMfj

---
_Generated by [Claude Code](https://claude.ai/code/session_0191FLxQ7LceLUNBNAmzCMfj)_