### PR TITLE
Fix spurious "firmware too old" warning + move language menu near top

### DIFF
--- a/polyhost/device/poly_kybd.py
+++ b/polyhost/device/poly_kybd.py
@@ -327,6 +327,13 @@ class PolyKybd:
         if not result:
             return False, msg
 
+        # enumerate_lang() can run during the initial menu build, before
+        # query_version_info() has populated protocol_version (it is otherwise
+        # only refreshed on a connection-state transition). Without this, a
+        # protocol-2 board is misreported as "too old" on the first pass.
+        if self.protocol_version is None:
+            self.query_version_info()
+
         # Protocol v2+ delivers the language list via GET_LANG_LIST_PACKED
         # (compact 2-byte ISO index pairs). The legacy ASCII GET_LANG_LIST
         # (cmd 8) has been retired — the firmware NACKs it — so there is no

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -565,7 +565,17 @@ class PolyHost(QApplication):
             self.current_lang = self.keeb.get_current_lang()
             title = f"Selected Language: {self.current_lang[:2]} {self.langcode_to_flag(self.current_lang[2:])}"
             if self.keeb_lang_menu is None:
-                self.keeb_lang_menu = menu.addMenu(get_icon("language.svg"), title)
+                # Place the language menu right under the first entry (the status
+                # action) instead of appending it last. It may be created lazily
+                # once the firmware version is known, by which point the rest of
+                # the menu already exists, so insert rather than add.
+                self.keeb_lang_menu = QMenu(title)
+                self.keeb_lang_menu.menuAction().setIcon(get_icon("language.svg"))
+                actions = menu.actions()
+                if len(actions) > 1:
+                    menu.insertMenu(actions[1], self.keeb_lang_menu)
+                else:
+                    menu.addMenu(self.keeb_lang_menu)
             else:
                 self.keeb_lang_menu.setTitle(title)
                 self.keeb_lang_menu.clear()


### PR DESCRIPTION
Fixes two related issues, both rooted in the language menu being built before the firmware version handshake has run.

### 1. Spurious "Firmware protocol too old" warning
`protocol_version` is only populated by `query_version_info()`, which the device loop calls **only on a connection-state transition** (`host.py:488`). But the initial menu build calls `enumerate_lang()` earlier, while `protocol_version` is still `None`. `enumerate_lang()` treats `None` the same as "too old", so a perfectly fine protocol-2 board logs:

```
Firmware protocol too old for the packed language list (need v2+). Please update the PolyKybd firmware.
```

…and then the next enumerate (after the handshake) succeeds. Fix: in `enumerate_lang()`, if `protocol_version` is `None`, call `query_version_info()` first so the version is known before judging it. A genuinely old board (P1 / no `P` field) still reports correctly.

### 2. Language menu appended last instead of near the top
Because that first `enumerate_lang()` failed, `keeb_lang_menu` wasn't created during the initial build (right after the status action); it was only created later by which point the rest of the menu existed, so `addMenu` appended it **last**. Fix: create the submenu and `insertMenu` it right after the first entry (the status action), so it sits near the top regardless of when it's first created.

### Testing
- `tests/device/poly_kybd_test.py` — all 5 tests pass (installed numpy/hid/libhidapi/PyQt5 in the dev env to run them). The "no protocol version → unsupported" test still passes: the on-demand `query_version_info()` uses a different HID method and, with the test's mock, the version string doesn't parse, so enumeration still fails cleanly with no list command sent.
- Menu-position change verified by reading (PyQt5 GUI not exercised headlessly); icon set via `menuAction().setIcon()` to avoid any `QMenu.setIcon` ambiguity.

https://claude.ai/code/session_0191FLxQ7LceLUNBNAmzCMfj

---
_Generated by [Claude Code](https://claude.ai/code/session_0191FLxQ7LceLUNBNAmzCMfj)_