### PR TITLE
Windows launcher: use pythonw so the tray GUI has no console window

### DIFF
--- a/polyhost/services/add_to_startup.py
+++ b/polyhost/services/add_to_startup.py
@@ -186,10 +186,18 @@ def create_windows_bat_wrapper(venv_path, script_path, args="", wrapper_path=Non
 
     activate_bat = venv_path / "Scripts" / "activate.bat"
 
+    # Use pythonw (no console subsystem) for the tray GUI so it never opens or
+    # owns a console window — `python.exe` allocates one, and closing that window
+    # kills the app (the user-reported "console opens, closing it drops the
+    # connection"). The `call activate.bat` above keeps the venv Scripts dir on
+    # PATH, so pythonw resolves — the documented "don't call pythonw WITHOUT
+    # activation" regression doesn't apply here (we activate first).
+    interp = "pythonw" if (venv_path / "Scripts" / "pythonw.exe").exists() else "python"
+
     bat_content = f"""@echo off
 call "{activate_bat}"
 cd "{script_path.parent.parent}"
-python -m polyhost {args}
+{interp} -m polyhost {args}
 """
 
     wrapper_path.write_text(bat_content, encoding="utf-8")
@@ -257,8 +265,13 @@ def _windows_launch_target(script_path, args):
     # (`-m polyhost`, not the script by path — the latter breaks `polyhost.*`
     # imports because the package dir, not its parent, lands on sys.path).
     python_exe = Path(sys.executable).resolve()
+    # Prefer pythonw.exe (no console window) for the tray GUI; fall back to
+    # python.exe if it's somehow absent.
+    launcher = python_exe.with_name("pythonw.exe")
+    if not launcher.exists():
+        launcher = python_exe
     wrapper = script_path.parent / "start_polyhost.bat"
-    content = f'@echo off\ncd "{repo_root}"\n"{python_exe}" -m polyhost {win_args}\n'
+    content = f'@echo off\ncd "{repo_root}"\n"{launcher}" -m polyhost {win_args}\n'
     wrapper.write_text(content, encoding="utf-8")
     print(f"Windows simple wrapper created at: {wrapper}")
     return str(wrapper), "", repo_root

--- a/tests/services/add_to_startup_test.py
+++ b/tests/services/add_to_startup_test.py
@@ -67,6 +67,41 @@ class WindowsAutostartFallbackTest(unittest.TestCase):
         self.assertEqual(mk_lnk.call_count, 1)
 
 
+class BatWrapperTest(unittest.TestCase):
+    """The venv launcher .bat must activate the venv and run the GUI windowless
+    (pythonw, no console) — a console window would otherwise open and closing it
+    would kill the app."""
+
+    def test_uses_pythonw_when_available_and_activates(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            venv = Path(tmp) / "venv"
+            (venv / "Scripts").mkdir(parents=True)
+            (venv / "Scripts" / "pythonw.exe").write_text("")   # pythonw present
+            (venv / "Scripts" / "activate.bat").write_text("")
+            script = Path(tmp) / "polyhost" / "__main__.py"
+            script.parent.mkdir(parents=True)
+            wrapper = Path(tmp) / "start_polyhost.bat"
+            add_to_startup.create_windows_bat_wrapper(venv, script, "", wrapper)
+            content = wrapper.read_text()
+        self.assertIn("activate.bat", content)          # venv activated first
+        self.assertIn("pythonw -m polyhost", content)   # console-free interpreter
+        self.assertNotIn("\npython -m polyhost", content)
+
+    def test_falls_back_to_python_without_pythonw(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            venv = Path(tmp) / "venv"
+            (venv / "Scripts").mkdir(parents=True)         # no pythonw.exe
+            (venv / "Scripts" / "activate.bat").write_text("")
+            script = Path(tmp) / "polyhost" / "__main__.py"
+            script.parent.mkdir(parents=True)
+            wrapper = Path(tmp) / "start_polyhost.bat"
+            add_to_startup.create_windows_bat_wrapper(venv, script, "", wrapper)
+            content = wrapper.read_text()
+        self.assertIn("python -m polyhost", content)
+
+
 class HiddenInvocationTest(unittest.TestCase):
     """A .bat launcher must be wrapped in wscript + hidden .vbs (no console
     flash); a frozen exe is windowless and passed through unchanged."""


### PR DESCRIPTION
Fixes the user-reported Windows issue: launching from the Start menu opens a **console window**, and closing it drops the connection.

`python.exe` is a *console* interpreter, so the tray GUI gets a console window; closing it kills the app. For a GUI app the launcher should use **`pythonw.exe`** (no console subsystem).

- `create_windows_bat_wrapper` now runs `pythonw -m polyhost` (falling back to `python` only if `pythonw.exe` is absent); the system-Python wrapper prefers `pythonw.exe` next to the interpreter.
- The `call activate.bat` still runs first, so the venv `Scripts` dir is on PATH and `pythonw` resolves — this is **not** the documented "pythonw without activation drops Scripts from PATH" regression (that was a direct scheduled-task call with no `.bat`).
- The Start-menu shortcut already launches windowless via `wscript` + a hidden `.vbs`; this hardens the interpreter itself. A pre-existing stale shortcut from an older build can still show a console until recreated — re-running the app regenerates both the `.bat` (now `pythonw`) and the windowless shortcut.

Tests: `add_to_startup_test` asserts the venv `.bat` activates then runs `pythonw -m polyhost`, and falls back to `python` when `pythonw` is absent. Full suite 749 OK.

⚠️ Not tested on Windows itself — needs a desktop check. (Re-opened against `main` — the original PR #58 targeted `feature/headless-core`, which was merged + removed.)

https://claude.ai/code/session_01Lz99SUyH77gyGN3ooAPk3X

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lz99SUyH77gyGN3ooAPk3X)_