### PR TITLE
H4c-2: unify the window matcher + route the TCP relay through report_window

### DIFF
--- a/docs/headless-h4-plan.md
+++ b/docs/headless-h4-plan.md
@@ -257,15 +257,21 @@ point: the `window.report` RPC → `PolyCore.report_window` → `RemoteHandler.r
 which writes the **same `connections` store** the TCP relay feeds, so the existing
 remote matcher picks it up unchanged.
 
-### H4c-2 — dedupe the matcher, route the TCP receiver through `report_window`
-- `RemoteHandler.try_to_match_window_remote` is a near-copy of
-  `OverlayHandler.try_to_match_window` (two matchers to keep in sync). Extract one
-  shared matcher both call.
-- Make `receive_from_forwarder` call `core.report_window(...)` (via a callback)
-  instead of stashing into the `connections` dict directly, so the TCP relay
-  becomes a thin transport over the single unified entry point.
-- Keeps the TCP wire; cross-machine behavior unchanged. Needs two machines to
-  validate.
+### H4c-2 — dedupe the matcher, route the TCP receiver through `report_window` ✅ DONE (2026-06-15)
+- The recursion is now the single `common.find_matching_entry(title, entry)` —
+  a **pure** function both `OverlayHandler.try_to_match_window` (which adds the
+  ENABLE/OFF_ON decision + current/last bookkeeping) and `RemoteHandler` (via
+  the new `_match_remote`) call. `try_to_match_window_remote` is gone. Being
+  pure + display-free, the matcher is unit-tested in CI
+  (`tests/handler/matcher_test.py`) instead of being buried in the
+  pywinctl-coupled `active_window.py`.
+- `receive_from_forwarder` now calls `on_report(handle, name, title)` —
+  `RemoteHandler.report_window`, the same entry point the `window.report` RPC
+  uses — instead of writing the `connections` dict directly. One entry point for
+  local and remote; the read path (`remote_changed` → latest report) is
+  unchanged, so the TCP wire and cross-machine behavior are preserved.
+- Validated: full suite + the xvfb `active_window_test` (OverlayHandler matching
+  still behaves). Cross-machine still wants a two-machine smoke.
 
 ### H4d — networked control endpoint (retire the bespoke TCP relay)
 Make the forwarder a **real control-protocol client over the network** that calls

--- a/polyhost/handler/active_window.py
+++ b/polyhost/handler/active_window.py
@@ -3,7 +3,10 @@ import os
 import platform
 import re
 
-from polyhost.handler.common import OverlayCommand, Flags
+from polyhost.handler.common import (
+    OverlayCommand, Flags, find_matching_entry,
+    TITLE, TITLE_SW, TITLE_EW, TITLE_HAS, FLAGS,
+)
 from polyhost.handler.remote_window import RemoteHandler
 
 IS_PLASMA = os.getenv("XDG_CURRENT_DESKTOP") == "KDE"
@@ -19,12 +22,9 @@ else:
     import pywinctl as pwc
 
 
-TITLE_SW = "titles-startswith"
-TITLE_EW = "titles-endswith"
-TITLE_HAS = "titles-contains"
-TITLE = "title"
+# TITLE/TITLE_SW/TITLE_EW/TITLE_HAS/FLAGS are imported from common (shared with
+# the matcher and RemoteHandler).
 INDEX = "index"
-FLAGS = "flags"
 OVERLAY = "overlay"
 REMOTE = "remote"
 
@@ -98,65 +98,27 @@ class OverlayHandler:
         self.handle = handle
 
     def try_to_match_window(self, name, entry):
-        (
-            has_overlay,
-            has_remote,
-            has_title,
-            has_starts_with,
-            has_ends_with,
-            has_contains,
-        ) = entry[FLAGS]
-        match = has_overlay or has_remote
+        # The recursion lives in common.find_matching_entry (shared with the
+        # remote path); here we add the ENABLE-vs-OFF_ON decision and the
+        # current/last-entry bookkeeping. A re-enter of the same matched entry
+        # is ENABLE (overlays already mapped); a different one is a full OFF_ON.
         try:
-            if match:
-                words = self.title.split() if (self.title and (has_starts_with or has_ends_with)) else []
-                if len(words) > 0:
-                    if (
-                        has_starts_with
-                        and words[0] in entry[TITLE_SW].keys()
-                    ):
-                        found, cmd = self.try_to_match_window(
-                            name, entry[TITLE_SW][words[0]]
-                        )
-                        if found:
-                            return True, cmd
-                    if (
-                        has_ends_with
-                        and words[-1] in entry[TITLE_EW].keys()
-                    ):
-                        found, cmd = self.try_to_match_window(
-                            name, entry[TITLE_EW][words[-1]]
-                        )
-                        if found:
-                            return True, cmd
-                    if has_contains:
-                        contains = entry[TITLE_HAS]
-                        for word in words:
-                            if word in contains.keys():
-                                found, cmd = self.try_to_match_window(name, contains[word])
-                                if found:
-                                    return True, cmd
-                if self.title and has_title:
-                    match = match and re.search(entry[TITLE], self.title)
+            matched = find_matching_entry(self.title, entry)
         except re.error as e:
             self.log.warning(
                 "Cannot match entry '%s': %s, because '%s'@%d with '%s'",
-                name,
-                entry,
-                e.msg,
-                e.pos,
-                e.pattern,
+                name, entry, e.msg, e.pos, e.pattern,
             )
             return False, OverlayCommand.NONE
 
-        if match:
-            if self.last_entry == entry:
-                self.current_entry = entry
-                return True, OverlayCommand.ENABLE
-            self.current_entry = entry
-            self.last_entry = entry
-            return True, OverlayCommand.OFF_ON
-        return False, OverlayCommand.NONE
+        if matched is None:
+            return False, OverlayCommand.NONE
+        if self.last_entry == matched:
+            self.current_entry = matched
+            return True, OverlayCommand.ENABLE
+        self.current_entry = matched
+        self.last_entry = matched
+        return True, OverlayCommand.OFF_ON
 
     def log_win(self, raw_app_name):
         """Log active window"""

--- a/polyhost/handler/common.py
+++ b/polyhost/handler/common.py
@@ -1,4 +1,13 @@
+import re
 from enum import Enum
+
+
+# Keys in the *annotated* overlay mapping produced by OverlayHandler.annotate().
+TITLE = "title"
+TITLE_SW = "titles-startswith"
+TITLE_EW = "titles-endswith"
+TITLE_HAS = "titles-contains"
+FLAGS = "flags"
 
 
 class OverlayCommand(Enum):
@@ -19,3 +28,48 @@ class Flags(Enum):
     HAS_TITLES_STARTS_W = 3
     HAS_TITLES_ENDS_W = 4
     HAS_TITLES_CONTAINS = 5
+
+
+def find_matching_entry(title, entry):
+    """Return the deepest mapping entry that matches ``title``, or ``None``.
+
+    The single window-matcher shared by local (`OverlayHandler`) and remote
+    (`RemoteHandler`) tracking — previously two near-identical copies that could
+    drift. Pure (no side effects), so it is unit-testable without a display;
+    callers add the ENABLE/OFF_ON decision and the current/last bookkeeping.
+
+    ``entry[FLAGS]`` is the 6-bool list
+    ``[has_overlay, has_remote, has_title, has_starts_with, has_ends_with,
+    has_contains]`` from ``annotate()``; the title sub-maps hold further
+    annotated entries. An entry matches when it carries an overlay/remote and,
+    if it has a title constraint, the title satisfies it — recursing into the
+    starts-with / ends-with / contains sub-maps first (first match wins).
+
+    Raises ``re.error`` if an entry's ``title`` regex is invalid; callers log it
+    and treat it as no match (mirrors the previous behaviour)."""
+    (has_overlay, has_remote, has_title,
+     has_starts_with, has_ends_with, has_contains) = entry[FLAGS]
+
+    if not (has_overlay or has_remote):
+        return None
+
+    words = title.split() if (title and (has_starts_with or has_ends_with)) else []
+    if words:
+        if has_starts_with and words[0] in entry[TITLE_SW]:
+            m = find_matching_entry(title, entry[TITLE_SW][words[0]])
+            if m is not None:
+                return m
+        if has_ends_with and words[-1] in entry[TITLE_EW]:
+            m = find_matching_entry(title, entry[TITLE_EW][words[-1]])
+            if m is not None:
+                return m
+        if has_contains:
+            for word in words:
+                if word in entry[TITLE_HAS]:
+                    m = find_matching_entry(title, entry[TITLE_HAS][word])
+                    if m is not None:
+                        return m
+
+    if title and has_title and not re.search(entry[TITLE], title):
+        return None
+    return entry

--- a/polyhost/handler/remote_window.py
+++ b/polyhost/handler/remote_window.py
@@ -3,14 +3,18 @@ import re
 import socket
 import threading
 
-from polyhost.handler.common import Flags
+from polyhost.handler.common import Flags, find_matching_entry
 
 TCP_PORT = 50162
 BUFFER_SIZE = 1024
 
 
 # Needs to be started as thread
-def receive_from_forwarder(log, connections, stop_event):
+def receive_from_forwarder(log, on_report, stop_event):
+    """Accept ``handle;name;title`` reports from a forwarder and hand each to
+    ``on_report(handle, name, title)`` — the same entry point the window.report
+    RPC uses (RemoteHandler.report_window), so the TCP relay is now just a
+    transport over the unified path rather than poking a separate store."""
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
@@ -33,12 +37,7 @@ def receive_from_forwarder(log, connections, stop_event):
                 data = data.decode("utf-8")
                 entries = [0, "", ""] if not data else data.split(";")
                 if len(entries) > 2:
-                    connections[addr] = {
-                        "handle": entries[0],
-                        "name": entries[1],
-                        "title": entries[2],
-                    }
-                    connections["_latest"] = addr
+                    on_report(entries[0], entries[1], entries[2])
                     log.debug_detailed("Remote data from %s: handle=%s name=%s", addr, entries[0], entries[1])
             finally:
                 conn.close()
@@ -77,20 +76,18 @@ class RemoteHandler:
         self.forwarder = threading.Thread(
             target=receive_from_forwarder,
             name="PolyKybd Remote Handler",
-            args=(self.log, self.connections, self.stop_event),
+            args=(self.log, self.report_window, self.stop_event),
         )
         self.forwarder.daemon = True
         self.forwarder.start()
 
     def report_window(self, handle, name, title):
-        """Inject an active-window report from a non-TCP source (the
-        ``window.report`` control-socket RPC / ``polyctl window report``).
+        """Single entry point for an active-window report, from either source:
+        the cross-machine TCP relay (`receive_from_forwarder`) or the
+        ``window.report`` control-socket RPC / ``polyctl window report``.
 
-        Writes the same ``connections`` store the TCP relay (`receive_from_forwarder`)
-        feeds, under a synthetic key, and marks it latest — so ``remote_changed``
-        picks it up through the existing matching with no change to that path.
-        Unifying the matcher and routing the TCP receiver through here too is a
-        deferred follow-up (the cross-machine wire stays untouched for now)."""
+        Stores the latest report; ``remote_changed`` reads it and runs the
+        shared matcher (`common.find_matching_entry`)."""
         self.connections["_report"] = {
             "handle": str(handle),
             "name": str(name),
@@ -100,67 +97,24 @@ class RemoteHandler:
         self.log.debug_detailed(
             "report_window: handle=%s name=%s title=%s", handle, name, title)
 
-    def try_to_match_window_remote(self, name, entry):
-        (
-            has_overlay,
-            has_remote,
-            has_title,
-            has_starts_with,
-            has_ends_with,
-            has_contains,
-        ) = entry["flags"]
-        match = has_overlay or has_remote
+    def _match_remote(self):
+        """Match the current remote window's app/title against the mapping using
+        the shared matcher, updating current/last_entry. Returns True on match."""
+        if self.name not in self.mapping:
+            return False
         try:
-            if match:
-                title_elements = (
-                    self.title.split() if has_starts_with or has_ends_with else []
-                )
-                if len(title_elements) > 0:
-                    if (
-                        has_starts_with
-                        and title_elements[0] in entry["titles-startswith"].keys()
-                    ):
-                        found = self.try_to_match_window_remote(
-                            name, entry["titles-startswith"][title_elements[0]]
-                        )
-                        if found:
-                            return True
-                    if (
-                        has_ends_with
-                        and title_elements[-1] in entry["titles-endswith"].keys()
-                    ):
-                        found = self.try_to_match_window_remote(
-                            name, entry["titles-endswith"][title_elements[-1]]
-                        )
-                        if found:
-                            return True
-                    if has_contains:
-                        contains = entry["titles-contains"]
-                        for elem in title_elements:
-                            if elem in contains.keys():
-                                found = self.try_to_match_window_remote(
-                                    name, contains[elem]
-                                )
-                                if found:
-                                    return True
-                if self.title and has_title:
-                    match = match and re.search(entry["title"], self.title)
+            matched = find_matching_entry(self.title, self.mapping[self.name])
         except re.error as e:
             self.log.warning(
                 "Cannot match entry '%s': %s, because '%s'@%d with '%s'",
-                name,
-                entry,
-                e.msg,
-                e.pos,
-                e.pattern,
+                self.name, self.mapping[self.name], e.msg, e.pos, e.pattern,
             )
             return False
-
-        if match:
-            self.current_entry = entry
-            self.last_entry = entry
-            return True
-        return False
+        if matched is None:
+            return False
+        self.current_entry = matched
+        self.last_entry = matched
+        return True
 
     def remote_changed(self, remote_entry: dict):
         self.listen_to_forwarder()  # restart listener if it died (e.g. bind failed on first try)
@@ -189,10 +143,7 @@ class RemoteHandler:
                 self.handle,
             )
 
-            found = False
-            if self.name in self.mapping.keys():
-                found = self.try_to_match_window_remote(self.name, self.mapping[self.name])
-            if self.current_entry and not found:
+            if not self._match_remote() and self.current_entry:
                 self.current_entry = None
             return True
         self.log.debug_detailed(

--- a/tests/handler/matcher_test.py
+++ b/tests/handler/matcher_test.py
@@ -1,0 +1,76 @@
+"""common.find_matching_entry — the shared window matcher (H4c-2).
+
+Pulled out of OverlayHandler so the local and remote paths share one matcher,
+and so the recursion is unit-testable without a display (active_window imports
+pywinctl). Entries here are built in the *annotated* shape annotate() produces:
+a `flags` list [overlay, remote, title, starts_with, ends_with, contains] plus
+the matching sub-maps.
+"""
+import unittest
+
+from polyhost.handler.common import find_matching_entry
+
+
+def entry(overlay=True, remote=False, title=None, sw=None, ew=None, contains=None):
+    e = {"flags": [overlay, remote, title is not None, bool(sw), bool(ew), bool(contains)]}
+    if overlay:
+        e["overlay"] = "ov"
+    if remote:
+        e["remote"] = "1.2.3.4"
+    if title is not None:
+        e["title"] = title
+    if sw:
+        e["titles-startswith"] = sw
+    if ew:
+        e["titles-endswith"] = ew
+    if contains:
+        e["titles-contains"] = contains
+    return e
+
+
+class TestFindMatchingEntry(unittest.TestCase):
+    def test_plain_overlay_matches_any_title(self):
+        e = entry()
+        self.assertIs(find_matching_entry("anything", e), e)
+        self.assertIs(find_matching_entry("", e), e)
+
+    def test_no_overlay_or_remote_never_matches(self):
+        self.assertIsNone(find_matching_entry("x", entry(overlay=False)))
+
+    def test_remote_only_matches(self):
+        e = entry(overlay=False, remote=True)
+        self.assertIs(find_matching_entry("x", e), e)
+
+    def test_title_regex_gates_the_match(self):
+        e = entry(title=r"- Editor$")
+        self.assertIs(find_matching_entry("main.py - Editor", e), e)
+        self.assertIsNone(find_matching_entry("notes.txt", e))
+
+    def test_starts_with_recurses_to_subentry(self):
+        leaf = entry(title=None)
+        e = entry(sw={"Word0": leaf})
+        self.assertIs(find_matching_entry("Word0 and the rest", e), leaf)
+        # First word differs -> the sub-map isn't entered; the parent has no
+        # title constraint, so it matches itself.
+        self.assertIs(find_matching_entry("Other start", e), e)
+
+    def test_ends_with_recurses(self):
+        leaf = entry()
+        e = entry(ew={"END": leaf})
+        self.assertIs(find_matching_entry("foo bar END", e), leaf)
+
+    def test_contains_recurses_on_any_word(self):
+        leaf = entry()
+        e = entry(sw={"x": {}}, contains={"NEEDLE": leaf})
+        # has both starts_with and contains so the title is split into words.
+        self.assertIs(find_matching_entry("a NEEDLE b", e), leaf)
+        self.assertIs(find_matching_entry("no match words", e), e)  # parent, no title gate
+
+    def test_bad_regex_raises(self):
+        import re as _re
+        with self.assertRaises(_re.error):
+            find_matching_entry("x", entry(title="("))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Unifies the local and remote window matchers (the documented H4c-2 follow-up) and routes the forwarder's TCP relay through the same entry point as the `window.report` RPC.

- **One matcher.** The local (`OverlayHandler.try_to_match_window`) and remote (`RemoteHandler.try_to_match_window_remote`) matchers were near-identical copies of the same recursion that could drift. Extracted into one pure function `common.find_matching_entry(title, entry)`. `OverlayHandler` now calls it and adds only the ENABLE/OFF_ON decision + current/last bookkeeping (behavior unchanged); `RemoteHandler` drops `try_to_match_window_remote` for a small `_match_remote()`.
- **CI-testable.** Being pure + display-free, the matcher is unit-tested directly (`tests/handler/matcher_test.py`) instead of being buried in the pywinctl-coupled `active_window.py`.
- **One entry point.** `receive_from_forwarder` now feeds `RemoteHandler.report_window` (same as the `window.report` RPC) instead of writing the `connections` dict directly. The read path (`remote_changed` → latest report) is unchanged, so the **TCP wire and cross-machine behavior are preserved**.

Shared title-key constants (TITLE/TITLE_SW/…) moved to `common.py`.

Validated: full suite **755 OK**; under xvfb the `active_window_test` (OverlayHandler matching/suppression) + the host GUI harness pass. The cross-machine forwarder path is behavior-preserving by construction but still wants a two-machine smoke.

Doc: `docs/headless-h4-plan.md` H4c-2 marked done.

https://claude.ai/code/session_01Lz99SUyH77gyGN3ooAPk3X

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lz99SUyH77gyGN3ooAPk3X)_

## Summary by Sourcery

Unify local and remote window matching logic and route all remote window reports through a single entry point.

Enhancements:
- Introduce a shared pure matcher function in common that both OverlayHandler and RemoteHandler use to resolve window-to-entry mappings.
- Refactor RemoteHandler to consume active-window updates from the forwarder via the same report_window path used by the window.report RPC, while preserving existing behavior.
- Centralize shared title/flag constants in common and simplify local/remote matching bookkeeping around current/last entries.

Documentation:
- Mark H4c-2 as completed in the headless plan and document the unified matcher and TCP relay routing.

Tests:
- Add unit tests for the shared window matcher to validate recursive matching behavior and regex handling independently of the GUI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for window matching functionality to ensure reliable behavior across overlay and remote scenarios.

* **Documentation**
  * Updated development plan documentation with execution status and design notes for current and upcoming improvements.

* **Refactor**
  * Centralized window matching logic for improved consistency and maintainability across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->