### PR TITLE
gui: place host-update & firmware-release progress dialogs in the tray corner

### DIFF
--- a/polyhost/gui/dialog_util.py
+++ b/polyhost/gui/dialog_util.py
@@ -1,0 +1,41 @@
+"""Shared GUI dialog helpers (Qt)."""
+
+from PyQt5.QtWidgets import QApplication
+
+
+def position_near_tray(widget, tray_icon, margin: int = 12):
+    """Move ``widget`` to the screen corner nearest the system-tray icon.
+
+    Picks the screen that contains the tray icon (falling back to primary) and
+    snaps the widget to whichever corner of that screen's available area the
+    tray icon sits in. With no usable tray geometry it lands bottom-right.
+
+    Call after the widget is shown so its frame size is finalised (defer one
+    event-loop tick via ``QTimer.singleShot(0, ...)`` if needed).
+    """
+    tray_geom = tray_icon.geometry() if tray_icon else None
+
+    # Find the screen that contains the tray icon, fall back to primary.
+    screen = None
+    if tray_geom and not tray_geom.isEmpty():
+        screen = QApplication.screenAt(tray_geom.center())
+    if screen is None:
+        screen = QApplication.primaryScreen()
+    if screen is None:
+        return
+
+    avail = screen.availableGeometry()
+    dw    = widget.frameGeometry().width()
+    dh    = widget.frameGeometry().height()
+
+    if tray_geom and not tray_geom.isEmpty():
+        # Snap to whichever corner of the available area the tray icon is in.
+        right  = tray_geom.center().x() >= avail.center().x()
+        bottom = tray_geom.center().y() >= avail.center().y()
+        x = avail.right()  - dw - margin if right  else avail.left() + margin
+        y = avail.bottom() - dh - margin if bottom else avail.top()  + margin
+    else:
+        x = avail.right()  - dw - margin
+        y = avail.bottom() - dh - margin
+
+    widget.move(x, y)

--- a/polyhost/gui/hid_fw_up_dialog.py
+++ b/polyhost/gui/hid_fw_up_dialog.py
@@ -7,6 +7,7 @@ from PyQt5.QtWidgets import (
 )
 
 from polyhost.device.hid_fw_up import flash_firmware, apply_staged_firmware
+from polyhost.gui.dialog_util import position_near_tray
 
 
 class _HidFwUpWorker(QThread):
@@ -218,33 +219,7 @@ class HidFwUpDialog(QDialog):
 
     def _position_near_tray(self):
         """Move the dialog to the screen corner nearest the system-tray icon."""
-        tray_geom = self._tray_icon.geometry() if self._tray_icon else None
-
-        # Find the screen that contains the tray icon, fall back to primary.
-        screen = None
-        if tray_geom and not tray_geom.isEmpty():
-            screen = QApplication.screenAt(tray_geom.center())
-        if screen is None:
-            screen = QApplication.primaryScreen()
-        if screen is None:
-            return
-
-        avail   = screen.availableGeometry()
-        dw      = self.frameGeometry().width()
-        dh      = self.frameGeometry().height()
-        margin  = 12
-
-        if tray_geom and not tray_geom.isEmpty():
-            # Snap to whichever corner of the available area the tray icon is in.
-            right  = tray_geom.center().x() >= avail.center().x()
-            bottom = tray_geom.center().y() >= avail.center().y()
-            x = avail.right()  - dw - margin if right  else avail.left()  + margin
-            y = avail.bottom() - dh - margin if bottom else avail.top()   + margin
-        else:
-            x = avail.right()  - dw - margin
-            y = avail.bottom() - dh - margin
-
-        self.move(x, y)
+        position_near_tray(self, self._tray_icon)
 
     # ------------------------------------------------------------------
     def _update_eta(self):

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -44,6 +44,7 @@ from polyhost._version import __version__
 from polyhost.input.unicode_input import get_input_method
 from polyhost.services.updater import UpdateChecker, UpdateInstaller, FwUpDownloader, restart_app
 from polyhost.gui.hid_fw_up_dialog import HidFwUpDialog
+from polyhost.gui.dialog_util import position_near_tray
 from polyhost.gui.worker_bridge import WorkerBridge
 from polyhost.core.poly_core import PolyCore
 from polyhost.server.control_server import ControlServer
@@ -156,7 +157,7 @@ def _msgbox(icon, title: str, text: str,
         return QMessageBox.Cancel
 
 
-def _progress_dlg(label: str, title: str) -> QProgressDialog:
+def _progress_dlg(label: str, title: str, tray_icon=None) -> QProgressDialog:
     dlg = QProgressDialog(label, None, 0, 100, None)
     dlg.setWindowTitle(title)
     dlg.setWindowFlag(Qt.WindowStaysOnTopHint, True)
@@ -174,6 +175,9 @@ def _progress_dlg(label: str, title: str) -> QProgressDialog:
         layout.setContentsMargins(m.left(), m.top(), m.right(),
                                   m.bottom() + _UPD_DLG_H // 10)
     dlg.show()
+    # Snap to the tray corner like HidFwUpDialog (defer a tick so the WM has
+    # finalised the frame size); harmless when no tray icon is available.
+    QTimer.singleShot(0, lambda: position_near_tray(dlg, tray_icon))
     return dlg
 
 
@@ -1164,7 +1168,8 @@ class PolyHost(QApplication):
 
         self.update_action.setEnabled(False)
         self._update_progress = _progress_dlg(
-            f"Downloading v{release.version}…", "PolyKybdHost Update")
+            f"Downloading v{release.version}…", "PolyKybdHost Update",
+            tray_icon=self.tray)
 
         b = self.bridge
         self._update_installer = UpdateInstaller(
@@ -1303,7 +1308,8 @@ class PolyHost(QApplication):
 
         self.firmware_update_action.setEnabled(False)
         self._fw_up_progress = _progress_dlg(
-            f"Downloading firmware v{release.version}…", "Firmware Update")
+            f"Downloading firmware v{release.version}…", "Firmware Update",
+            tray_icon=self.tray)
 
         b = self.bridge
         self._fw_up_downloader = FwUpDownloader(

--- a/tests/gui/dialog_util_test.py
+++ b/tests/gui/dialog_util_test.py
@@ -1,0 +1,85 @@
+"""position_near_tray — shared corner-snapping helper.
+
+The host-update / firmware-release progress dialogs and HidFwUpDialog all snap
+to the screen corner nearest the tray icon through this one helper. Verifies the
+corner math against a synthetic screen, and the no-tray fallback (bottom-right).
+Construction needs only PyQt5, so it runs under the offscreen Qt platform.
+"""
+import os
+import unittest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+try:
+    from PyQt5.QtCore import QRect, QPoint
+    from PyQt5.QtWidgets import QApplication, QWidget
+    from polyhost.gui import dialog_util
+    _APP = QApplication.instance() or QApplication([])
+    _IMPORT_ERR = None
+except Exception as e:  # pragma: no cover - no Qt platform available
+    _IMPORT_ERR = e
+
+
+class _FakeTray:
+    def __init__(self, rect):
+        self._rect = rect
+
+    def geometry(self):
+        return self._rect
+
+
+@unittest.skipIf(_IMPORT_ERR is not None, f"Qt unavailable: {_IMPORT_ERR}")
+class TestPositionNearTray(unittest.TestCase):
+
+    def setUp(self):
+        self.w = QWidget()
+        self.addCleanup(self.w.deleteLater)
+        # Pin the frame size so the corner math is exact (offscreen frame
+        # geometry is otherwise unstable by a pixel after move()).
+        self.w.frameGeometry = lambda: QRect(0, 0, 200, 100)
+        # Drive the screen geometry deterministically rather than depending on
+        # whatever offscreen reports.
+        self._avail = QRect(0, 0, 1000, 800)
+        self._patch_screen()
+
+    def _patch_screen(self):
+        screen = _APP.primaryScreen()
+        self._orig_screen_at = QApplication.screenAt
+        self._orig_avail = screen.availableGeometry
+        avail = self._avail
+        QApplication.screenAt = staticmethod(lambda pt: screen)
+        screen.availableGeometry = lambda: avail
+        self.addCleanup(setattr, QApplication, "screenAt", self._orig_screen_at)
+        self.addCleanup(setattr, screen, "availableGeometry", self._orig_avail)
+
+    def _move_pos(self):
+        moved = {}
+        self.w.move = lambda x, y: moved.update(x=x, y=y)
+        return moved
+
+    def test_bottom_right_tray(self):
+        moved = self._move_pos()
+        # tray near bottom-right of the available area
+        tray = _FakeTray(QRect(960, 770, 16, 16))
+        dialog_util.position_near_tray(self.w, tray, margin=12)
+        # QRect.right()/bottom() are inclusive (x + w - 1), so 999/799 here.
+        self.assertEqual(moved["x"], 999 - 200 - 12)
+        self.assertEqual(moved["y"], 799 - 100 - 12)
+
+    def test_top_left_tray(self):
+        moved = self._move_pos()
+        tray = _FakeTray(QRect(0, 0, 16, 16))
+        dialog_util.position_near_tray(self.w, tray, margin=12)
+        self.assertEqual(moved["x"], 12)
+        self.assertEqual(moved["y"], 12)
+
+    def test_no_tray_falls_back_bottom_right(self):
+        moved = self._move_pos()
+        dialog_util.position_near_tray(self.w, None, margin=12)
+        # QRect.right()/bottom() are inclusive (x + w - 1), so 999/799 here.
+        self.assertEqual(moved["x"], 999 - 200 - 12)
+        self.assertEqual(moved["y"], 799 - 100 - 12)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Makes the **host self-update download** and the **in-process firmware-release download** progress dialogs match the polished firmware-flash dialog: snapped to the screen corner nearest the tray icon, instead of a bare `QProgressDialog` anchored at screen centre.

## Why

The client/daemon-mode firmware flash already uses `HidFwUpDialog` (tray-corner placement + ETA), but `_progress_dlg()` — used by the host self-update and firmware-release downloads — still produced a centred, plain dialog. This was the visual inconsistency that showed up in testing ("a very bare looking one"). This unifies the placement so every long-running progress dialog lands in the same spot.

## How

- New `polyhost/gui/dialog_util.py` — `position_near_tray(widget, tray_icon)`, extracted verbatim from `HidFwUpDialog._position_near_tray` (finds the screen containing the tray icon, snaps to the nearest corner, bottom-right fallback when no tray geometry).
- `HidFwUpDialog._position_near_tray` now delegates to the shared helper (no behaviour change).
- `_progress_dlg()` takes a `tray_icon` arg and snaps to the tray corner one event-loop tick after `show()` (so the WM has finalised the frame size); both call sites (`_run_update_installer`, `_fw_up_progress`) pass `self.tray`.

## Tests

- New `tests/gui/dialog_util_test.py` — corner math (top-left, bottom-right) + no-tray bottom-right fallback.
- GUI segment: 66 tests OK (incl. the existing `HidFwUpDialog` external-mode tests).
- `tests/gui/host_client_test.py` (default + `--connect` client mode) passes under xvfb.

https://claude.ai/code/session_01Lz99SUyH77gyGN3ooAPk3X

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lz99SUyH77gyGN3ooAPk3X)_

## Summary by Sourcery

Unify host update and firmware-release progress dialogs with the existing firmware flash UI by reusing a shared helper to position dialogs near the system tray icon.

Enhancements:
- Introduce a shared dialog utility to position windows near the tray icon and reuse it in the firmware flash dialog implementation.
- Update generic progress dialogs used for host self-update and firmware-release downloads to appear in the tray-adjacent screen corner for consistent UX.

Tests:
- Add dialog utility tests to validate tray-corner positioning logic and fallback behavior under an offscreen Qt platform.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Dialog windows now intelligently position themselves near the system tray, improving visibility and accessibility during firmware updates and file downloads. Smart positioning automatically adapts based on screen and tray layout.

## Tests
- Added comprehensive unit tests validating tray-positioning behavior across various screen and tray geometry configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->