### PR TITLE
device: clamp hid_reconnect_retries to >= 1 so a 0 value can't spin HID re-enumeration

### DIFF
--- a/polyhost/device/poly_kybd.py
+++ b/polyhost/device/poly_kybd.py
@@ -87,7 +87,12 @@ class PolyKybd:
             self.log.debug("Connecting to PolyKybd for the first time...")
             return self._open_interfaces()
         else:
-            retries = self.poly_settings.get("hid_reconnect_retries")
+            # Always probe the live handle at least once before re-enumerating.
+            # A misconfigured hid_reconnect_retries <= 0 would otherwise skip the
+            # GET_ID loop entirely and blindly tear down/re-open the HID interface
+            # on every reconnect probe (~1 Hz) — log spam plus disruptive handle
+            # churn that can clip in-flight overlay transfers.
+            retries = max(1, self.poly_settings.get("hid_reconnect_retries"))
             for attempt in range(retries):
                 result, msg = self.query_id()
                 if result:

--- a/tests/device/poly_kybd_cmd_test.py
+++ b/tests/device/poly_kybd_cmd_test.py
@@ -697,6 +697,16 @@ class TestConnect(unittest.TestCase):
         self.assertEqual(len(device.writes), 1)  # exactly one probe, not zero
         keeb._open_interfaces.assert_not_called()  # no re-enumeration needed
 
+    def test_reconnect_retries_clamped_when_negative(self):
+        # A mis-edited negative value must clamp the same way as 0 — one probe,
+        # never a per-cycle blind re-enumeration.
+        keeb, device = make_keeb(
+            auto_ack=True, settings=StubPolySettings(hid_reconnect_retries=-1))
+        keeb._open_interfaces = MagicMock(return_value=False)
+        self.assertTrue(keeb.connect())
+        self.assertEqual(len(device.writes), 1)
+        keeb._open_interfaces.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Command file execution & console

--- a/tests/device/poly_kybd_cmd_test.py
+++ b/tests/device/poly_kybd_cmd_test.py
@@ -686,6 +686,17 @@ class TestConnect(unittest.TestCase):
         self.assertEqual(len(device.writes), 2)
         keeb._open_interfaces.assert_called_once()
 
+    def test_reconnect_retries_clamped_to_at_least_one(self):
+        # A misconfigured hid_reconnect_retries=0 must still probe the live
+        # handle once (single GET_ID) before re-enumerating, never skip straight
+        # to a blind re-open on every probe cycle.
+        keeb, device = make_keeb(
+            auto_ack=True, settings=StubPolySettings(hid_reconnect_retries=0))
+        keeb._open_interfaces = MagicMock(return_value=False)
+        self.assertTrue(keeb.connect())          # GET_ID answered → connected
+        self.assertEqual(len(device.writes), 1)  # exactly one probe, not zero
+        keeb._open_interfaces.assert_not_called()  # no re-enumeration needed
+
 
 # ---------------------------------------------------------------------------
 # Command file execution & console


### PR DESCRIPTION
## Symptom

The host log spammed:

```
WARNING Re-enumerating HID after 0 failed attempts...
```

repeating roughly once a second.

## Root cause

`PolyKybd.connect()` is called on every reconnect probe (~1 Hz, `poly_core.py:474`). When the HID handle already exists, it probes the live handle with up to `hid_reconnect_retries` `GET_ID` attempts and only re-enumerates if all of them fail. The warning prints the **configured** retry count, not a running tally — so `0` means the setting was `hid_reconnect_retries: 0` (default is `5`).

With `retries == 0`:

- `for attempt in range(0)` never executes → **no `GET_ID` is sent**, the live handle is never verified;
- `connect()` falls straight through to tearing down and re-opening the HID interface **on every probe cycle** — the log spam, plus disruptive handle churn that can clip in-flight overlay transfers.

How the config reached `0` is unknown (no code path writes the key — most likely a hand-edit or stale config), so this adds a defensive clamp rather than relying on the value being sane.

## Fix

`polyhost/device/poly_kybd.py` — clamp the loop bound:

```python
retries = max(1, self.poly_settings.get("hid_reconnect_retries"))
```

The live handle is now always probed at least once before re-enumerating, regardless of a misconfigured (zero/negative) setting.

`tests/device/poly_kybd_cmd_test.py` — regression test `test_reconnect_retries_clamped_to_at_least_one`: with `hid_reconnect_retries=0` and a device that answers, `connect()` issues exactly one `GET_ID` and does **not** re-enumerate.

## Verification

Full module run (numpy/pyserial/hid/pillow + libhidapi installed in the build env): **72 tests, all OK**, including the new one.

## Note for deployment

This is a code-level backstop. A running host with `hid_reconnect_retries: 0` still needs the value corrected to stop the warnings until this lands:

```bash
polyctl settings set hid_reconnect_retries 5
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XQ1kfG2WuuYJo5vr1pYRM

---
_Generated by [Claude Code](https://claude.ai/code/session_014XQ1kfG2WuuYJo5vr1pYRM)_

## Summary by Sourcery

Tests:
- Add a regression test ensuring a misconfigured hid_reconnect_retries=0 still performs a single GET_ID probe and avoids unnecessary HID re-enumeration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device reconnection reliability by ensuring at least one retry/probe attempt even when retry settings are configured to zero.

* **Tests**
  * Added automated coverage to verify reconnect succeeds with zero configured retries and avoids unnecessary re-enumeration when the first probe succeeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->