### PR TITLE
Daylight brightness: diagnostics, gamma, immediate retransmit + host-auto mode (protocol v5)

### DIFF
--- a/polyhost/core/poly_core.py
+++ b/polyhost/core/poly_core.py
@@ -665,6 +665,17 @@ class PolyCore:
             max_val = self.poly_settings.get("irradiance_max")
             prescaler = self.poly_settings.get("irradiance_prescaler")
             brightness = self.sunlight.get_brightness_now(min_val, max_val, prescaler)
+            # Perceptual gamma on the output. The keycap OLEDs are driven near
+            # the bottom of their contrast range (the firmware caps at 49/50 to
+            # limit current/burn-in), where the eye's response is steepest
+            # (perceived brightness ~ luminance^1/3), so a linear value feels
+            # uneven. Raising the normalized 0..1 to a gamma before scaling to
+            # the device's 2..50 range evens out the perceived steps as the
+            # daylight changes. gamma=1.0 reproduces the old linear behaviour;
+            # >1 dims the mid-range. Endpoints (0->2, 1->50) are preserved.
+            gamma = self.poly_settings.get("brightness_gamma")
+            if gamma and gamma > 0:
+                brightness = brightness ** gamma
             self.keeb.set_brightness(2 + brightness * 48)
 
     # ------------------------------------------------------------------

--- a/polyhost/core/poly_core.py
+++ b/polyhost/core/poly_core.py
@@ -599,6 +599,11 @@ class PolyCore:
                     self.overlay_handler.force_resend()
                 self.needs_overlay_reset = True
                 self.log.info("Connected: active window resend queued.")
+                # Re-assert the host's brightness mode on the freshly-connected
+                # keyboard (its auto mode is RAM-only and defaults off on boot):
+                # engage daylight-auto + push the current value, or send AUTO_OFF
+                # so it uses its stored manual brightness. Queued on the worker.
+                self.refresh_daylight_brightness()
 
         # The applying client owns the applied-connection state the worker reads.
         self.last_applied_connected = self.connected
@@ -657,26 +662,61 @@ class PolyCore:
         if kb_serial or kb_log:
             self.emit("console", (kb_serial, kb_log))
 
+    # HID SET_BRIGHTNESS flag bits — mirror firmware base/com.h (protocol >= 5).
+    # On older firmware the flags byte is ignored (plain persisted set), so we
+    # only send flags when the device advertises support.
+    _BR_FLAG_VOLATILE = 1 << 0   # daylight value: applied only in auto mode, never persisted
+    _BR_FLAG_AUTO_ON  = 1 << 1   # engage host-driven (auto) brightness
+    _BR_FLAG_AUTO_OFF = 1 << 2   # leave auto mode, revert to the keyboard's stored manual level
+    _BRIGHTNESS_FLAGS_PROTOCOL = 5
+
+    def _brightness_flags_supported(self):
+        return (self.keeb.get_protocol_version() or 0) >= self._BRIGHTNESS_FLAGS_PROTOCOL
+
+    def _compute_daylight_value(self):
+        """Map the current daylight irradiance to a device value (2..50),
+        applying the perceptual gamma. The keycap OLEDs are driven near the
+        bottom of their contrast range (firmware caps at 49/50 for current/
+        burn-in), where perceived brightness ~ luminance^(1/3), so a linear
+        value feels uneven; gamma>1 evens out the perceived steps (1.0 = the
+        old linear behaviour). Endpoints (0->2, 1->50) are preserved."""
+        min_val = self.poly_settings.get("irradiance_min")
+        max_val = self.poly_settings.get("irradiance_max")
+        prescaler = self.poly_settings.get("irradiance_prescaler")
+        brightness = self.sunlight.get_brightness_now(min_val, max_val, prescaler)
+        gamma = self.poly_settings.get("brightness_gamma")
+        if gamma and gamma > 0:
+            brightness = brightness ** gamma
+        return 2 + brightness * 48
+
     def _brightness_periodic(self, cancel):
         """Worker periodic (10 min): daylight-dependent brightness incl. the
-        network lookups — kept entirely off any client thread."""
+        network lookups — kept entirely off any client thread. Sends a VOLATILE
+        update only (never AUTO_ON): if the user has taken manual control on the
+        keyboard the firmware ignores it, so a background tick can't override a
+        deliberate choice. Engaging auto is a deliberate act (see _engage)."""
         if self.poly_settings.get("brightness_set_daylight_dependent"):
-            min_val = self.poly_settings.get("irradiance_min")
-            max_val = self.poly_settings.get("irradiance_max")
-            prescaler = self.poly_settings.get("irradiance_prescaler")
-            brightness = self.sunlight.get_brightness_now(min_val, max_val, prescaler)
-            # Perceptual gamma on the output. The keycap OLEDs are driven near
-            # the bottom of their contrast range (the firmware caps at 49/50 to
-            # limit current/burn-in), where the eye's response is steepest
-            # (perceived brightness ~ luminance^1/3), so a linear value feels
-            # uneven. Raising the normalized 0..1 to a gamma before scaling to
-            # the device's 2..50 range evens out the perceived steps as the
-            # daylight changes. gamma=1.0 reproduces the old linear behaviour;
-            # >1 dims the mid-range. Endpoints (0->2, 1->50) are preserved.
-            gamma = self.poly_settings.get("brightness_gamma")
-            if gamma and gamma > 0:
-                brightness = brightness ** gamma
-            self.keeb.set_brightness(2 + brightness * 48)
+            val = self._compute_daylight_value()
+            flags = self._BR_FLAG_VOLATILE if self._brightness_flags_supported() else 0
+            self.keeb.set_brightness(val, flags)
+
+    def _engage_brightness(self, cancel):
+        """Deliberate (re-)assert of the host's brightness mode — runs on a
+        settings change or on connect. Daylight on -> engage auto mode and push
+        the current value (VOLATILE|AUTO_ON); daylight off -> tell the keyboard
+        to leave auto mode and fall back to its stored manual brightness
+        (AUTO_OFF). Both clear any prior keyboard manual override, which is the
+        intended 'the host re-takes control' semantics."""
+        supported = self._brightness_flags_supported()
+        if self.poly_settings.get("brightness_set_daylight_dependent"):
+            val = self._compute_daylight_value()
+            flags = (self._BR_FLAG_VOLATILE | self._BR_FLAG_AUTO_ON) if supported else 0
+            self.keeb.set_brightness(val, flags)
+        elif supported:
+            # Daylight disabled: leave auto mode; the keyboard restores its own
+            # persisted manual brightness (level byte ignored on AUTO_OFF). On
+            # pre-v5 firmware there is no auto mode, so there is nothing to do.
+            self.keeb.set_brightness(0, self._BR_FLAG_AUTO_OFF)
 
     # Settings whose change should immediately recompute + retransmit the
     # daylight brightness rather than waiting for the next 10-min periodic.
@@ -689,18 +729,17 @@ class PolyCore:
     })
 
     def refresh_daylight_brightness(self):
-        """Recompute the daylight brightness now and push it to the device,
-        instead of waiting for the next 10-min periodic. Runs on the worker so
-        it never blocks the caller; coalesces so a burst of setting changes
-        results in a single recompute. No-ops without a network hit when
-        daylight dependence is off (the periodic checks the flag first)."""
+        """(Re-)assert the host brightness mode on the device now, instead of
+        waiting for the next 10-min periodic — used on a settings change and on
+        connect. Runs on the worker so it never blocks the caller; coalesces so
+        a burst of setting changes results in a single push."""
         # Keep the Sunlight lookup permissions in sync with the live settings,
         # so toggling the online-lookup options takes effect immediately too.
         self.sunlight.allow_online_lookup(
             bool(self.poly_settings.get("brightness_allow_online_irradiance_request")))
         self.sunlight.allow_location_lookup(
             bool(self.poly_settings.get("brightness_allow_online_location_lookup")))
-        self.worker.submit("brightness_now", self._brightness_periodic,
+        self.worker.submit("brightness_now", self._engage_brightness,
                            coalesce_key="brightness_now")
 
     # ------------------------------------------------------------------

--- a/polyhost/core/poly_core.py
+++ b/polyhost/core/poly_core.py
@@ -678,6 +678,31 @@ class PolyCore:
                 brightness = brightness ** gamma
             self.keeb.set_brightness(2 + brightness * 48)
 
+    # Settings whose change should immediately recompute + retransmit the
+    # daylight brightness rather than waiting for the next 10-min periodic.
+    _BRIGHTNESS_SETTING_KEYS = frozenset({
+        "brightness_set_daylight_dependent",
+        "irradiance_min", "irradiance_max", "irradiance_prescaler",
+        "brightness_gamma",
+        "brightness_allow_online_irradiance_request",
+        "brightness_allow_online_location_lookup",
+    })
+
+    def refresh_daylight_brightness(self):
+        """Recompute the daylight brightness now and push it to the device,
+        instead of waiting for the next 10-min periodic. Runs on the worker so
+        it never blocks the caller; coalesces so a burst of setting changes
+        results in a single recompute. No-ops without a network hit when
+        daylight dependence is off (the periodic checks the flag first)."""
+        # Keep the Sunlight lookup permissions in sync with the live settings,
+        # so toggling the online-lookup options takes effect immediately too.
+        self.sunlight.allow_online_lookup(
+            bool(self.poly_settings.get("brightness_allow_online_irradiance_request")))
+        self.sunlight.allow_location_lookup(
+            bool(self.poly_settings.get("brightness_allow_online_location_lookup")))
+        self.worker.submit("brightness_now", self._brightness_periodic,
+                           coalesce_key="brightness_now")
+
     # ------------------------------------------------------------------
     # Command API — the surface clients (CLI / RPC / GUI) drive (H2).
     #
@@ -810,6 +835,10 @@ class PolyCore:
             return False, f"Unknown setting '{key}'"
         alls[key] = value
         self.poly_settings.set_all(alls)
+        # A brightness/daylight setting change takes effect immediately instead
+        # of on the next 10-min cycle (covers polyctl + the client-mode dialog).
+        if key in self._BRIGHTNESS_SETTING_KEYS:
+            self.refresh_daylight_brightness()
         return True, key
 
     # ------------------------------------------------------------------

--- a/polyhost/device/poly_kybd.py
+++ b/polyhost/device/poly_kybd.py
@@ -248,9 +248,13 @@ class PolyKybd:
         self.log.info("Setting unicode mode to %d", mode.value)
         return self.hid.send_and_read_validate(compose_cmd(Cmd.SET_UNICODE_MODE, mode.value))
 
-    def set_brightness(self, brightness: int) -> tuple[bool, Any]:
-        self.log.info("Setting Display Brightness to %d...", brightness)
-        return self.hid.send_and_read_validate(compose_cmd(Cmd.SET_BRIGHTNESS, int(np.clip(brightness, 0, 50))))
+    def set_brightness(self, brightness: int, flags: int = 0) -> tuple[bool, Any]:
+        # flags (protocol >= 5, firmware base/com.h): bit0 VOLATILE (daylight,
+        # not persisted), bit1 AUTO_ON, bit2 AUTO_OFF. flags=0 is the legacy
+        # persisted set; pre-v5 firmware ignores the extra byte.
+        self.log.info("Setting Display Brightness to %d (flags 0x%x)...", brightness, flags)
+        return self.hid.send_and_read_validate(
+            compose_cmd(Cmd.SET_BRIGHTNESS, int(np.clip(brightness, 0, 50)), flags & 0xFF))
 
     def press_and_release_key(self, keycode: int, duration: int,
                               cancel: threading.Event | None = None) -> tuple[bool, Any]:

--- a/polyhost/device/poly_kybd_mock.py
+++ b/polyhost/device/poly_kybd_mock.py
@@ -191,8 +191,8 @@ class PolyKybdMock:
     # Device settings
     # -------------------------------------------------------------------------
 
-    def set_brightness(self, brightness: int) -> tuple[bool, str]:
-        self._log_call("set_brightness", brightness)
+    def set_brightness(self, brightness: int, flags: int = 0) -> tuple[bool, str]:
+        self._log_call("set_brightness", brightness, flags)
         max_brightness = getattr(self.device_settings, "MAX_BRIGHTNESS", 50)
         self._brightness = max(0, min(brightness, max_brightness))
         return True, ""

--- a/polyhost/gui/settings_dialog.py
+++ b/polyhost/gui/settings_dialog.py
@@ -25,6 +25,10 @@ def create_editor(value):
         doublebox = QDoubleSpinBox()
         doublebox.setDecimals(3)
         doublebox.setMaximum(1_000.0)
+        # Default step is 1.0, which silently clamps fine-grained float settings
+        # (e.g. the 0.75 brightness prescaler) to 0.0 on a single scroll/click —
+        # use a small step so these stay editable to their real precision.
+        doublebox.setSingleStep(0.05)
         doublebox.setValue(value)
         return doublebox
     else:  # string fallback

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -883,6 +883,10 @@ class PolyHost(QApplication):
                         self.core.settings_set(key, value)
             else:
                 self.poly_settings.set_all(updated)
+                # In-process mode writes settings directly (bypassing
+                # core.settings_set), so nudge the core to recompute + push the
+                # daylight brightness now rather than waiting for the next cycle.
+                self.core.refresh_daylight_brightness()
         dlg.close()
 
     def open_log(self):

--- a/polyhost/services/brightness_diag.py
+++ b/polyhost/services/brightness_diag.py
@@ -21,8 +21,13 @@ from polyhost.settings import PolySettings
 from polyhost.services.sunlight_helper import Sunlight
 
 
-def device_value(normalized):
-    """The mapping PolyCore applies: normalized 0..1 -> device 2..50."""
+def device_value(normalized, gamma=1.0):
+    """The mapping PolyCore applies: normalized 0..1 -> device 2..50, with the
+    perceptual gamma applied first (gamma=1.0 is the legacy linear behaviour).
+    The firmware then writes (value-1) straight to the SSD1306 contrast register
+    (linear, capped at 49) — so the perceptual shaping lives entirely here."""
+    if gamma and gamma > 0:
+        normalized = normalized ** gamma
     return 2 + normalized * 48
 
 
@@ -36,15 +41,17 @@ def normalize(irradiance, min_val, max_val, pre_scale):
     return perceived, normalized
 
 
-def curve_analysis(min_val, max_val, pre_scale):
+def curve_analysis(min_val, max_val, pre_scale, gamma=1.0):
     print("=" * 72)
     print("1. CALIBRATION — irradiance -> device brightness curve")
     print("=" * 72)
     print(f"   settings: irradiance_min={min_val}  irradiance_max={max_val}  "
-          f"prescaler={pre_scale}")
+          f"prescaler={pre_scale}  brightness_gamma={gamma}")
     print(f"   formula : perceived = ln(1+irr) * {pre_scale}")
     print( "             normalized = clamp(perceived, min, max) mapped to 0..1")
-    print( "             device    = 2 + normalized * 48   (then int-clipped 0..50)\n")
+    print(f"             device    = 2 + normalized**{gamma} * 48   (int-clipped 0..50)")
+    print( "             firmware writes (device-1) straight to the OLED contrast")
+    print( "             register, linear and capped at 49 (burn-in headroom).\n")
 
     # Detect degenerate configs that pin the output before computing the
     # physical break-points (which would divide by a zero prescaler).
@@ -74,8 +81,9 @@ def curve_analysis(min_val, max_val, pre_scale):
     print("   irr(W/m^2)  perceived  normalized  device")
     for irr in (0, 5, 10, 25, 50, 100, 200, 400, 600, 800, 1000):
         perceived, n = normalize(irr, min_val, max_val, pre_scale)
-        print(f"   {irr:>8}    {perceived:8.3f}   {n:8.3f}   {device_value(n):6.1f}"
-              f"  (int {int(max(0, min(50, device_value(n))))})")
+        dv = device_value(n, gamma)
+        print(f"   {irr:>8}    {perceived:8.3f}   {n:8.3f}   {dv:6.1f}"
+              f"  (int {int(max(0, min(50, dv)))})")
 
     if floor_irr > 50:
         print(f"\n   [!] irradiance_min is high: anything below {floor_irr:.0f} W/m^2")
@@ -87,7 +95,7 @@ def curve_analysis(min_val, max_val, pre_scale):
     print()
 
 
-def live_paths(s, min_val, max_val, pre_scale):
+def live_paths(s, min_val, max_val, pre_scale, gamma=1.0):
     print("=" * 72)
     print("2. LIVE — what each irradiance source returns right now")
     print("=" * 72)
@@ -102,7 +110,7 @@ def live_paths(s, min_val, max_val, pre_scale):
         print("   [!] location UNKNOWN (IP geolocation failed / disabled).")
         print("       get_irradiance_now() returns the crude hour-of-day fallback:")
         irr = min(19 - 7, max(0, now.hour - 7)) / 12
-        _report_value("hour-of-day fallback", irr, min_val, max_val, pre_scale)
+        _report_value("hour-of-day fallback", irr, min_val, max_val, pre_scale, gamma)
         return
     print(f"   location: lat {s.latitude:.4f}  lon {s.longitude:.4f}")
     print(f"   pvlib Location.tz = {getattr(s.site, 'tz', '?')!r} "
@@ -112,7 +120,7 @@ def live_paths(s, min_val, max_val, pre_scale):
     try:
         irr = s.get_irradiance_now()
         _report_value("get_irradiance_now() [the value actually used]", irr,
-                      min_val, max_val, pre_scale)
+                      min_val, max_val, pre_scale, gamma)
     except Exception as e:
         print(f"   get_irradiance_now() raised {type(e).__name__}: {e}")
         print("   (the worker periodic swallows this -> brightness is NOT updated)\n")
@@ -122,12 +130,13 @@ def live_paths(s, min_val, max_val, pre_scale):
     _clearsky_timezone_probe(s)
 
 
-def _report_value(label, irr, min_val, max_val, pre_scale):
+def _report_value(label, irr, min_val, max_val, pre_scale, gamma=1.0):
     perceived, n = normalize(irr, min_val, max_val, pre_scale)
+    dv = device_value(n, gamma)
     print(f"   {label}")
     print(f"      irradiance = {irr:.2f} W/m^2  -> device value "
-          f"{device_value(n):.1f} (int {int(max(0, min(50, device_value(n))))})")
-    if device_value(n) <= 2.5:
+          f"{dv:.1f} (int {int(max(0, min(50, dv)))})")
+    if dv <= 2.5:
         print("      => this is the FLOOR (2). Cause: irradiance read as "
               f"<= {math.exp(min_val/pre_scale)-1:.1f} W/m^2.\n")
     else:
@@ -187,17 +196,18 @@ def main():
     min_val = settings.get("irradiance_min")
     max_val = settings.get("irradiance_max")
     pre_scale = settings.get("irradiance_prescaler")
+    gamma = settings.get("brightness_gamma")
 
     print("\nPolyKybd daylight-brightness diagnostics\n")
     if not settings.get("brightness_set_daylight_dependent"):
         print("[note] brightness_set_daylight_dependent is OFF — the periodic does "
               "nothing; the keyboard keeps whatever brightness was last set.\n")
 
-    curve_analysis(min_val, max_val, pre_scale)
+    curve_analysis(min_val, max_val, pre_scale, gamma)
 
     s = Sunlight(settings.get("brightness_allow_online_location_lookup"),
                  settings.get("brightness_allow_online_irradiance_request"))
-    live_paths(s, min_val, max_val, pre_scale)
+    live_paths(s, min_val, max_val, pre_scale, gamma)
 
 
 if __name__ == "__main__":

--- a/polyhost/services/brightness_diag.py
+++ b/polyhost/services/brightness_diag.py
@@ -85,7 +85,7 @@ def live_paths(s, min_val, max_val, pre_scale):
         return
     print(f"   location: lat {s.latitude:.4f}  lon {s.longitude:.4f}")
     print(f"   pvlib Location.tz = {getattr(s.site, 'tz', '?')!r} "
-          "(constructed without a tz -> defaults to 'UTC')\n")
+          "(now built with tz='UTC' and fed a UTC-aware 'now')\n")
 
     # (a) The actual call the firmware-facing code makes.
     try:
@@ -114,56 +114,50 @@ def _report_value(label, irr, min_val, max_val, pre_scale):
 
 
 def _clearsky_timezone_probe(s):
-    """Show the modelled clear-sky GHI across today, the buggy (naive-local,
-    treated-as-UTC) way and the timezone-correct way, so the offset is visible."""
+    """Compare the clear-sky model the OLD (buggy) way — naive host-local time,
+    Location default tz='UTC' — against the CURRENT fix (UTC-aware now,
+    Location tz='UTC'), so the timezone correction is visible and verifiable."""
     try:
         import pandas as pd
+        import pytz
         from pvlib.location import Location
     except Exception as e:
         print(f"   (skipping clear-sky timezone probe: {e})")
         return
 
     print("   clear-sky timezone probe (fallback path):")
-    print("   The code calls Location(lat, lon).get_clearsky(pd.Timestamp.now()).")
-    print("   pd.Timestamp.now() is timezone-NAIVE host-local time, and the")
-    print("   Location was built with no tz (default 'UTC'), so pvlib models the")
-    print("   sun as if your wall clock were UTC. If you are far from UTC in")
-    print("   longitude that puts the modelled sun hours away from reality.\n")
+    print("   OLD bug: Location(lat,lon).get_clearsky(pd.Timestamp.now()) fed a")
+    print("   timezone-NAIVE host-local time to a UTC-default Location, so pvlib")
+    print("   modelled the sun as if your wall clock were UTC — shifting it by")
+    print("   your whole UTC offset and reading ~0 W/m^2 during real daylight.")
+    print("   FIX: tz-aware UTC 'now' + Location(tz='UTC') -> correct sun.\n")
 
     today = date.today()
-    hours = pd.date_range(datetime(today.year, today.month, today.day),
-                          periods=24, freq="h")
+    midnight = datetime(today.year, today.month, today.day)
 
-    # Buggy: naive local time, Location default tz='UTC'.
-    site_utc = Location(s.latitude, s.longitude)
-    ghi_buggy = site_utc.get_clearsky(hours)["ghi"]
+    # OLD (buggy): naive local time, Location default tz='UTC'.
+    site_buggy = Location(s.latitude, s.longitude)
+    hours_naive = pd.date_range(midnight, periods=24, freq="h")
+    ghi_buggy = site_buggy.get_clearsky(hours_naive)["ghi"].values
 
-    # Correct: localize the times to the location's own timezone.
-    try:
-        from timezonefinder import TimezoneFinder
-        tz = TimezoneFinder().timezone_at(lat=s.latitude, lng=s.longitude)
-    except Exception:
-        tz = None
-    correct_line = ""
-    if tz:
-        site_local = Location(s.latitude, s.longitude, tz=tz)
-        local_hours = hours.tz_localize(tz)
-        ghi_correct = site_local.get_clearsky(local_hours)["ghi"].values
-        peak_correct = int(local_hours[ghi_correct.argmax()].hour)
-        correct_line = (f"   tz-correct ({tz}): modelled solar peak at "
-                        f"~{peak_correct:02d}:00 local")
+    # CURRENT (fixed): the real UTC instants for each local hour today, against
+    # a tz='UTC' Location — exactly what get_irradiance_now now does per-tick.
+    site_fixed = Location(s.latitude, s.longitude, tz="UTC")
+    local_tz = datetime.now().astimezone().tzinfo
+    hours_local = pd.date_range(midnight, periods=24, freq="h").tz_localize(local_tz)
+    ghi_fixed = site_fixed.get_clearsky(hours_local.tz_convert("UTC"))["ghi"].values
 
-    peak_buggy = int(hours[ghi_buggy.values.argmax()].hour)
-    print(f"   as-coded (naive->UTC): modelled solar peak at ~{peak_buggy:02d}:00 "
-          "of your wall clock")
-    if correct_line:
-        print(correct_line)
+    peak_buggy = int(hours_naive[ghi_buggy.argmax()].hour)
+    peak_fixed = int(hours_local[ghi_fixed.argmax()].hour)
     cur = int(datetime.now().hour)
-    print(f"   modelled GHI at your current hour ({cur:02d}:00) via the as-coded "
-          f"path: {ghi_buggy.values[cur]:.1f} W/m^2")
-    if correct_line and ghi_buggy.values[cur] < 10 <= max(ghi_correct):
-        print("   [!] the as-coded path reads ~0 now while the tz-correct model has "
-              "real daylight\n       -> THIS is the 'stuck at 2' cause on this path.")
+    print(f"   OLD model solar peak : ~{peak_buggy:02d}:00 wall clock   "
+          f"(GHI now {ghi_buggy[cur]:.1f} W/m^2)")
+    print(f"   FIXED model solar peak: ~{peak_fixed:02d}:00 local time  "
+          f"(GHI now {ghi_fixed[cur]:.1f} W/m^2)")
+    if ghi_buggy[cur] < 10 <= ghi_fixed[cur]:
+        print("   [!] the OLD path read ~0 now while the FIXED model has real "
+              "daylight\n       -> the timezone fix resolves the 'stuck at 2' on "
+              "this path.")
     print()
 
 

--- a/polyhost/services/brightness_diag.py
+++ b/polyhost/services/brightness_diag.py
@@ -29,7 +29,10 @@ def device_value(normalized):
 def normalize(irradiance, min_val, max_val, pre_scale):
     """Mirror of Sunlight.get_brightness_now's normalization (no logging)."""
     perceived = math.log(1 + irradiance) * pre_scale
-    normalized = (max(min_val, min(max_val, perceived)) - min_val) / (max_val - min_val)
+    span = max_val - min_val
+    if span <= 0:                      # degenerate config — avoid div-by-zero
+        return perceived, 0.0
+    normalized = (max(min_val, min(max_val, perceived)) - min_val) / span
     return perceived, normalized
 
 
@@ -42,6 +45,21 @@ def curve_analysis(min_val, max_val, pre_scale):
     print(f"   formula : perceived = ln(1+irr) * {pre_scale}")
     print( "             normalized = clamp(perceived, min, max) mapped to 0..1")
     print( "             device    = 2 + normalized * 48   (then int-clipped 0..50)\n")
+
+    # Detect degenerate configs that pin the output before computing the
+    # physical break-points (which would divide by a zero prescaler).
+    if pre_scale <= 0:
+        print("   [!!] prescaler is <= 0  ->  perceived = ln(1+irr) * 0 = 0 for")
+        print("        EVERY irradiance, so brightness is ALWAYS pinned to the")
+        print("        floor (device value 2) no matter how bright it is outside.")
+        print("        THIS is almost certainly your 'stuck at 2' cause.")
+        print("        Fix: polyctl settings set irradiance_prescaler 0.75\n")
+        return
+    if max_val <= min_val:
+        print("   [!!] irradiance_max <= irradiance_min  ->  the normalization")
+        print("        collapses (or divides by zero) and the curve is unusable.")
+        print("        Fix: set irradiance_min ~1.8 and irradiance_max ~5.2\n")
+        return
 
     # The two physically meaningful break-points of the curve.
     floor_irr = math.exp(min_val / pre_scale) - 1   # below this -> value 2
@@ -59,6 +77,9 @@ def curve_analysis(min_val, max_val, pre_scale):
         print(f"   {irr:>8}    {perceived:8.3f}   {n:8.3f}   {device_value(n):6.1f}"
               f"  (int {int(max(0, min(50, device_value(n))))})")
 
+    if floor_irr > 50:
+        print(f"\n   [!] irradiance_min is high: anything below {floor_irr:.0f} W/m^2")
+        print("       floors to 2, so dim/overcast daylight reads as 'off'.")
     if full_irr > 1361:
         print("\n   [!] max_val is set so high that FULL brightness is physically")
         print("       unreachable — the keyboard tops out well below 50 even in")

--- a/polyhost/services/brightness_diag.py
+++ b/polyhost/services/brightness_diag.py
@@ -131,14 +131,21 @@ def live_paths(s, min_val, max_val, pre_scale, gamma=1.0):
 
 
 def _report_value(label, irr, min_val, max_val, pre_scale, gamma=1.0):
-    perceived, n = normalize(irr, min_val, max_val, pre_scale)
+    _perceived, n = normalize(irr, min_val, max_val, pre_scale)
     dv = device_value(n, gamma)
     print(f"   {label}")
     print(f"      irradiance = {irr:.2f} W/m^2  -> device value "
           f"{dv:.1f} (int {int(max(0, min(50, dv)))})")
     if dv <= 2.5:
-        print("      => this is the FLOOR (2). Cause: irradiance read as "
-              f"<= {math.exp(min_val/pre_scale)-1:.1f} W/m^2.\n")
+        if pre_scale > 0:
+            floor_irr = math.exp(min_val / pre_scale) - 1
+            print("      => this is the FLOOR (2). Cause: irradiance read as "
+                  f"<= {floor_irr:.1f} W/m^2.\n")
+        else:
+            # The tool exists to explain degenerate configs; a 0/negative
+            # prescaler pins normalization at the floor, so don't divide by it.
+            print("      => this is the FLOOR (2). Cause: irradiance_prescaler "
+                  "<= 0 pins normalization at the minimum.\n")
     else:
         print()
 

--- a/polyhost/services/brightness_diag.py
+++ b/polyhost/services/brightness_diag.py
@@ -1,0 +1,189 @@
+"""Diagnostics for the daylight-dependent keycap brightness.
+
+Run on the machine the keyboard is attached to:
+
+    python -m polyhost.services.brightness_diag
+
+It reproduces the exact pipeline that the 10-min worker periodic
+(`PolyCore._brightness_periodic`) drives — `Sunlight.get_brightness_now()`
+→ device value `2 + normalized * 48` — and prints, path by path, *why* a
+given device value comes out, so a "stuck at 2" report can be traced to a
+concrete cause (night, a mis-scaled curve, a failed online lookup, or the
+clear-sky timezone bug) instead of guessed at.
+
+It only reads — it never talks to the keyboard and changes no settings.
+"""
+
+import math
+from datetime import datetime, date, timedelta
+
+from polyhost.settings import PolySettings
+from polyhost.services.sunlight_helper import Sunlight
+
+
+def device_value(normalized):
+    """The mapping PolyCore applies: normalized 0..1 -> device 2..50."""
+    return 2 + normalized * 48
+
+
+def normalize(irradiance, min_val, max_val, pre_scale):
+    """Mirror of Sunlight.get_brightness_now's normalization (no logging)."""
+    perceived = math.log(1 + irradiance) * pre_scale
+    normalized = (max(min_val, min(max_val, perceived)) - min_val) / (max_val - min_val)
+    return perceived, normalized
+
+
+def curve_analysis(min_val, max_val, pre_scale):
+    print("=" * 72)
+    print("1. CALIBRATION — irradiance -> device brightness curve")
+    print("=" * 72)
+    print(f"   settings: irradiance_min={min_val}  irradiance_max={max_val}  "
+          f"prescaler={pre_scale}")
+    print(f"   formula : perceived = ln(1+irr) * {pre_scale}")
+    print( "             normalized = clamp(perceived, min, max) mapped to 0..1")
+    print( "             device    = 2 + normalized * 48   (then int-clipped 0..50)\n")
+
+    # The two physically meaningful break-points of the curve.
+    floor_irr = math.exp(min_val / pre_scale) - 1   # below this -> value 2
+    full_irr = math.exp(max_val / pre_scale) - 1     # at/above this -> value 50
+    print(f"   -> device value stays at the floor (2) for ALL irradiance "
+          f"<= {floor_irr:.1f} W/m^2")
+    print(f"   -> device value reaches full (50) only at irradiance "
+          f">= {full_irr:.0f} W/m^2")
+    print( "      (reference: clear-sky noon GHI peaks ~1000 W/m^2; the solar")
+    print( "       constant above the atmosphere is 1361 W/m^2)\n")
+
+    print("   irr(W/m^2)  perceived  normalized  device")
+    for irr in (0, 5, 10, 25, 50, 100, 200, 400, 600, 800, 1000):
+        perceived, n = normalize(irr, min_val, max_val, pre_scale)
+        print(f"   {irr:>8}    {perceived:8.3f}   {n:8.3f}   {device_value(n):6.1f}"
+              f"  (int {int(max(0, min(50, device_value(n))))})")
+
+    if full_irr > 1361:
+        print("\n   [!] max_val is set so high that FULL brightness is physically")
+        print("       unreachable — the keyboard tops out well below 50 even in")
+        print("       direct noon sun. The usable range is compressed.")
+    print()
+
+
+def live_paths(s, min_val, max_val, pre_scale):
+    print("=" * 72)
+    print("2. LIVE — what each irradiance source returns right now")
+    print("=" * 72)
+    now = datetime.now()
+    print(f"   host local time : {now.isoformat(timespec='seconds')}  "
+          f"(tz offset {now.astimezone().strftime('%z') or 'naive'})")
+    print(f"   online location lookup allowed : {s.location_lookup}")
+    print(f"   online irradiance lookup allowed: {s.online_lookup}\n")
+
+    s.init_location()
+    if not s.location_known:
+        print("   [!] location UNKNOWN (IP geolocation failed / disabled).")
+        print("       get_irradiance_now() returns the crude hour-of-day fallback:")
+        irr = min(19 - 7, max(0, now.hour - 7)) / 12
+        _report_value("hour-of-day fallback", irr, min_val, max_val, pre_scale)
+        return
+    print(f"   location: lat {s.latitude:.4f}  lon {s.longitude:.4f}")
+    print(f"   pvlib Location.tz = {getattr(s.site, 'tz', '?')!r} "
+          "(constructed without a tz -> defaults to 'UTC')\n")
+
+    # (a) The actual call the firmware-facing code makes.
+    try:
+        irr = s.get_irradiance_now()
+        _report_value("get_irradiance_now() [the value actually used]", irr,
+                      min_val, max_val, pre_scale)
+    except Exception as e:
+        print(f"   get_irradiance_now() raised {type(e).__name__}: {e}")
+        print("   (the worker periodic swallows this -> brightness is NOT updated)\n")
+
+    # (b) Clear-sky path the way the code does it (naive local time) vs the
+    #     timezone-correct way — this exposes the tz bug.
+    _clearsky_timezone_probe(s)
+
+
+def _report_value(label, irr, min_val, max_val, pre_scale):
+    perceived, n = normalize(irr, min_val, max_val, pre_scale)
+    print(f"   {label}")
+    print(f"      irradiance = {irr:.2f} W/m^2  -> device value "
+          f"{device_value(n):.1f} (int {int(max(0, min(50, device_value(n))))})")
+    if device_value(n) <= 2.5:
+        print("      => this is the FLOOR (2). Cause: irradiance read as "
+              f"<= {math.exp(min_val/pre_scale)-1:.1f} W/m^2.\n")
+    else:
+        print()
+
+
+def _clearsky_timezone_probe(s):
+    """Show the modelled clear-sky GHI across today, the buggy (naive-local,
+    treated-as-UTC) way and the timezone-correct way, so the offset is visible."""
+    try:
+        import pandas as pd
+        from pvlib.location import Location
+    except Exception as e:
+        print(f"   (skipping clear-sky timezone probe: {e})")
+        return
+
+    print("   clear-sky timezone probe (fallback path):")
+    print("   The code calls Location(lat, lon).get_clearsky(pd.Timestamp.now()).")
+    print("   pd.Timestamp.now() is timezone-NAIVE host-local time, and the")
+    print("   Location was built with no tz (default 'UTC'), so pvlib models the")
+    print("   sun as if your wall clock were UTC. If you are far from UTC in")
+    print("   longitude that puts the modelled sun hours away from reality.\n")
+
+    today = date.today()
+    hours = pd.date_range(datetime(today.year, today.month, today.day),
+                          periods=24, freq="h")
+
+    # Buggy: naive local time, Location default tz='UTC'.
+    site_utc = Location(s.latitude, s.longitude)
+    ghi_buggy = site_utc.get_clearsky(hours)["ghi"]
+
+    # Correct: localize the times to the location's own timezone.
+    try:
+        from timezonefinder import TimezoneFinder
+        tz = TimezoneFinder().timezone_at(lat=s.latitude, lng=s.longitude)
+    except Exception:
+        tz = None
+    correct_line = ""
+    if tz:
+        site_local = Location(s.latitude, s.longitude, tz=tz)
+        local_hours = hours.tz_localize(tz)
+        ghi_correct = site_local.get_clearsky(local_hours)["ghi"].values
+        peak_correct = int(local_hours[ghi_correct.argmax()].hour)
+        correct_line = (f"   tz-correct ({tz}): modelled solar peak at "
+                        f"~{peak_correct:02d}:00 local")
+
+    peak_buggy = int(hours[ghi_buggy.values.argmax()].hour)
+    print(f"   as-coded (naive->UTC): modelled solar peak at ~{peak_buggy:02d}:00 "
+          "of your wall clock")
+    if correct_line:
+        print(correct_line)
+    cur = int(datetime.now().hour)
+    print(f"   modelled GHI at your current hour ({cur:02d}:00) via the as-coded "
+          f"path: {ghi_buggy.values[cur]:.1f} W/m^2")
+    if correct_line and ghi_buggy.values[cur] < 10 <= max(ghi_correct):
+        print("   [!] the as-coded path reads ~0 now while the tz-correct model has "
+              "real daylight\n       -> THIS is the 'stuck at 2' cause on this path.")
+    print()
+
+
+def main():
+    settings = PolySettings()
+    min_val = settings.get("irradiance_min")
+    max_val = settings.get("irradiance_max")
+    pre_scale = settings.get("irradiance_prescaler")
+
+    print("\nPolyKybd daylight-brightness diagnostics\n")
+    if not settings.get("brightness_set_daylight_dependent"):
+        print("[note] brightness_set_daylight_dependent is OFF — the periodic does "
+              "nothing; the keyboard keeps whatever brightness was last set.\n")
+
+    curve_analysis(min_val, max_val, pre_scale)
+
+    s = Sunlight(settings.get("brightness_allow_online_location_lookup"),
+                 settings.get("brightness_allow_online_irradiance_request"))
+    live_paths(s, min_val, max_val, pre_scale)
+
+
+if __name__ == "__main__":
+    main()

--- a/polyhost/services/sunlight_helper.py
+++ b/polyhost/services/sunlight_helper.py
@@ -5,6 +5,7 @@ import math
 import requests
 from pvlib.location import Location
 import pandas as pd
+import pytz
 import geocoder
 
 class Sunlight:
@@ -24,8 +25,11 @@ class Sunlight:
                 self.location = geocoder.ip('me', timeout=5.0)
                 self.latitude, self.longitude = self.location.latlng
 
-                # Create location object
-                self.site = Location(self.latitude, self.longitude)
+                # Create location object. tz='UTC' is deliberate: clear-sky
+                # solar position is driven by the absolute UTC instant we pass
+                # in (see get_irradiance_now), not by the civil timezone — so
+                # we keep the model in UTC and feed it tz-aware UTC timestamps.
+                self.site = Location(self.latitude, self.longitude, tz='UTC')
 
                 self.log.info("Location lat %f long %f", self.latitude, self.longitude)
                 self.location_known = True
@@ -37,10 +41,6 @@ class Sunlight:
 
         if self.location_known:
             if self.online_lookup:
-                now = datetime.now()
-                today = now.date().isoformat()
-                hour_now = now.hour
-
                 # Step 3: Query Open-Meteo hourly solar radiation
                 url = (
                     f"https://api.open-meteo.com/v1/forecast?"
@@ -49,26 +49,59 @@ class Sunlight:
                     f"&timezone=auto"
                 )
 
-                # Bounded timeout: this runs on the GUI thread (10-min brightness
-                # task) — without it a stalled connection freezes the UI.
-                response = requests.get(url, timeout=10)
-                data = response.json()
+                # The whole online lookup is best-effort: any failure (network,
+                # bad JSON, missing fields) logs and falls through to the
+                # location/time clear-sky model below rather than propagating.
+                # Bounded timeout: this runs on the HID worker thread (10-min
+                # brightness periodic) — without it a stalled connection wedges
+                # that thread's periodic schedule.
+                try:
+                    response = requests.get(url, timeout=10)
+                    data = response.json()
 
-                # Step 4: Extract current hour's solar radiation
-                times = data['hourly']['time']
-                radiation = data['hourly']['shortwave_radiation']
+                    # Step 4: Extract current hour's solar radiation
+                    times = data['hourly']['time']
+                    radiation = data['hourly']['shortwave_radiation']
 
-                # Find index for current hour
-                for idx, timestamp in enumerate(times):
-                    if timestamp.startswith(today) and int(timestamp[11:13]) == hour_now:
-                        self.log.debug("Timestamp for irradiance data[%d]: %s", idx, timestamp)
-                        return (radiation[idx] + (radiation[idx+1] if len(radiation)>(idx+1) else radiation[idx]))/2
+                    # Match the current hour in the LOCATION's timezone (the
+                    # time table uses timezone=auto, i.e. local-to-location).
+                    # Deriving "now" from the host clock breaks whenever the
+                    # host's timezone differs from the keyboard's location.
+                    tz_name = data.get('timezone')
+                    try:
+                        loc_now = (datetime.now(pytz.utc).astimezone(pytz.timezone(tz_name))
+                                   if tz_name else datetime.now())
+                    except Exception:
+                        loc_now = datetime.now()
+                    today = loc_now.date().isoformat()
+                    hour_now = loc_now.hour
 
-                self.log.warning("Found no matching entry in time table from api.open-meteo.com: %s", times)
-                self.log.info("Using location and time based approach instead.")
+                    # Find index for current hour
+                    for idx, timestamp in enumerate(times):
+                        if timestamp.startswith(today) and int(timestamp[11:13]) == hour_now:
+                            self.log.debug("Timestamp for irradiance data[%d]: %s", idx, timestamp)
+                            # open-meteo can emit null for individual hours;
+                            # treat a null current hour as 0 and a null next
+                            # hour as a repeat of the current one.
+                            cur = radiation[idx]
+                            cur = 0.0 if cur is None else cur
+                            nxt = radiation[idx + 1] if len(radiation) > (idx + 1) else cur
+                            nxt = cur if nxt is None else nxt
+                            return (cur + nxt) / 2
 
-            # Define current time in UTC
-            pd_now = pd.Timestamp.now()
+                    self.log.warning("Found no matching entry in time table from api.open-meteo.com: %s", times)
+                    self.log.info("Using location and time based approach instead.")
+                except Exception as e:
+                    self.log.warning(
+                        "Online irradiance lookup failed (%s: %s); using location/time model instead.",
+                        type(e).__name__, e)
+
+            # Fall back to the clear-sky model. Use the absolute UTC instant
+            # (tz-aware) so pvlib places the sun correctly regardless of the
+            # host's timezone — a naive Timestamp.now() was treated as UTC by
+            # pvlib, shifting the modelled sun by the user's UTC offset and
+            # reading ~0 W/m^2 (-> minimum brightness) during real daylight.
+            pd_now = pd.Timestamp.now(tz=pytz.utc)
             times = pd.DatetimeIndex([pd_now])
 
             clear_sky = self.site.get_clearsky(times)  # GHI, DNI, DHI values (in W/m^2)

--- a/polyhost/services/sunlight_helper.py
+++ b/polyhost/services/sunlight_helper.py
@@ -116,7 +116,16 @@ class Sunlight:
     def get_brightness_now(self, min_val=1.8, max_val=6.5, pre_scale = 0.75):
         irradiance = self.get_irradiance_now()
         perceived_brightness = math.log(1+irradiance)*pre_scale
-        normalized = (max(min_val, min(max_val, perceived_brightness)) - min_val) / (max_val - min_val)
+        span = max_val - min_val
+        if span <= 0:
+            # Degenerate config (max <= min) — would divide by zero. Warn and
+            # treat as "no usable range" rather than crashing the periodic.
+            self.log.warning(
+                "irradiance_max (%s) <= irradiance_min (%s): brightness range is "
+                "empty; defaulting to minimum. Check your brightness settings.",
+                max_val, min_val)
+            return 0.0
+        normalized = (max(min_val, min(max_val, perceived_brightness)) - min_val) / span
         self.log.info(
             "Normalized brightness value: %f, perceived: %f (irradiance %f)",
             normalized,

--- a/polyhost/settings.py
+++ b/polyhost/settings.py
@@ -25,8 +25,15 @@ class PolySettings:
             "brightness_set_daylight_dependent": True,
             "brightness_allow_online_irradiance_request": True,
             "brightness_allow_online_location_lookup": True,
+            # Maps solar irradiance (W/m^2) to keycap brightness via
+            # perceived = ln(1+irr)*prescaler, clamped to [min, max] then
+            # scaled to the device's 2..50 range. irradiance_min=1.8 floors to
+            # the dimmest value below ~10 W/m^2 (true twilight/night).
+            # irradiance_max=5.2 = ln(1+1000)*0.75, so a clear-sky noon
+            # (~1000 W/m^2) reaches full brightness — the old 6.5 needed an
+            # unreachable ~5800 W/m^2, capping sunny-day brightness at ~36/50.
             "irradiance_min": 1.8,
-            "irradiance_max": 6.5,
+            "irradiance_max": 5.2,
             "irradiance_prescaler": 0.75,
             "max_hid_message_before_delay": 15,
             "delay_time_after_max_hid_messages": 0.3,

--- a/polyhost/settings.py
+++ b/polyhost/settings.py
@@ -35,6 +35,16 @@ class PolySettings:
             "irradiance_min": 1.8,
             "irradiance_max": 5.2,
             "irradiance_prescaler": 0.75,
+            # Perceptual gamma applied to the daylight brightness before it is
+            # scaled to the keyboard's 2..50 range (see PolyCore._brightness_
+            # periodic). The keycap OLEDs run near the bottom of their contrast
+            # range where perceived brightness ~ luminance^(1/3). This is a
+            # by-eye tuning knob: gamma>1 evens out the perceived ramp but DIMS
+            # the mid-range (e.g. midday can drop noticeably); gamma<1 brightens
+            # it. Default 1.0 = the plain linear mapping (no dimming) — raise it
+            # toward ~2.2 if the ramp feels too steep at low light, lower it if
+            # daytime ends up too dim. Endpoints (0->2, 1->50) are unaffected.
+            "brightness_gamma": 1.0,
             "max_hid_message_before_delay": 15,
             "delay_time_after_max_hid_messages": 0.3,
             "hid_reconnect_retries": 5,

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ platformdirs
 geocoder
 pandas
 pvlib
+pytz
 requests
 pyserial
 packaging


### PR DESCRIPTION
Host-side counterpart to the qmk_firmware PR on the same branch. Six commits covering the daylight-brightness investigation and the new host-auto/manual mode.

## Commits
- **Add daylight-brightness diagnostics tool** — surface why the computed level is what it is.
- **Fix daylight brightness "stuck at 2"** — timezone, online matching, calibration.
- **Handle degenerate config** — `prescaler=0` / `max<=min`; fix spinbox step.
- **Tunable host-side perceptual gamma (default off)** — even out perceived steps near the bottom of the OLED contrast range; `gamma=1.0` reproduces the old linear behaviour.
- **Retransmit immediately when a daylight setting changes** — don't wait for the next 10-min periodic.
- **Drive the keyboard's host-auto mode (protocol v5).**

## Host-auto mode (the v5 piece)
Uses the firmware's new `SET_BRIGHTNESS` flags (protocol ≥ 5; pre-v5 falls back to the plain persisted set):
- `_brightness_periodic` (10-min) sends `VOLATILE` only — a background tick can't override a manual choice made on the keyboard.
- `_engage_brightness` (settings change + on connect): daylight on → `VOLATILE|AUTO_ON` + current value; daylight off → `AUTO_OFF` (keyboard reverts to its stored manual brightness). This is the "host re-takes control" path.
- `apply_reconnect` calls it on a fresh connect so the keyboard (auto mode is RAM-only, boots off) reflects the host's daylight setting immediately.
- Explicit `set_brightness` (RPC / polyctl) keeps `flags=0` → persists and clears auto, identical to a keyboard key.
- `poly_kybd.set_brightness` / mock gain a `flags` arg, gated via `get_protocol_version`.

## Verification
`py_compile` clean across touched modules. Requires firmware on protocol v5 (the paired PR) for the auto-mode behaviour; older firmware is unaffected (`flags=0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014gvsLwzVDNtVPY7mzmM5T9

---
_Generated by [Claude Code](https://claude.ai/code/session_014gvsLwzVDNtVPY7mzmM5T9)_

## Summary by Sourcery

Add daylight-dependent brightness diagnostics and improve brightness computation, configuration robustness, and host-driven auto mode integration with protocol v5 keyboards.

New Features:
- Introduce a standalone daylight-brightness diagnostics tool that reproduces and explains the host brightness pipeline.
- Add host-side support for protocol v5 brightness flags to drive keyboard auto/volatile brightness modes, including immediate application on connect and setting changes.
- Expose a tunable perceptual gamma setting for daylight brightness mapping to even out perceived brightness steps.

Bug Fixes:
- Correct timezone handling for both online irradiance data and clear-sky irradiance modelling to prevent brightness getting stuck at minimum during daylight.
- Handle degenerate daylight brightness configurations, such as zero prescaler or max less than or equal to min, without crashes and with clearer behavior.

Enhancements:
- Refine the default daylight brightness calibration to reach full brightness under realistic clear-sky conditions.
- Immediately recompute and retransmit brightness when relevant settings change or in-process settings are saved, instead of waiting for the periodic task.
- Align host and mock keyboard brightness APIs to accept protocol flags and improve float setting editors with finer spinbox stepping.

Build:
- Add pytz as a dependency for timezone-aware irradiance calculations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Keyboard brightness now synchronizes immediately upon device reconnection.
  * Settings changes now update brightness immediately instead of waiting for periodic refresh.

* **Improvements**
  * Enhanced daylight-based brightness computation with configurable gamma and irradiance parameters.
  * Improved network resilience with explicit timeout handling for brightness lookups.
  * Better handling of missing or invalid brightness data.

* **Bug Fixes**
  * Fixed timezone handling in brightness calculations to use UTC consistently.

* **Chores**
  * Added diagnostics tool for brightness computation analysis.
  * Updated default irradiance settings for improved brightness mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->