### PR TITLE
Brightness: per-environment damping of the daylight swing (window → windowless)

### DIFF
--- a/polyhost/core/poly_core.py
+++ b/polyhost/core/poly_core.py
@@ -38,7 +38,7 @@ from polyhost.device.poly_kybd import PolyKybd
 from polyhost.handler.common import OverlayCommand
 from polyhost.services.sleep_listener import install_sleep_listener
 from polyhost.services.sunlight_helper import Sunlight
-from polyhost.settings import PolySettings
+from polyhost.settings import PolySettings, brightness_environment_params
 
 RECONNECT_CYCLE_MSEC = 1000
 # After an overlay/MRU send the keyboard goes deaf for a few hundred ms while it
@@ -678,11 +678,16 @@ class PolyCore:
 
     def _compute_daylight_value(self):
         """Map the current daylight irradiance to a device value (2..50),
-        applying the perceptual gamma. The keycap OLEDs are driven near the
-        bottom of their contrast range (firmware caps at 49/50 for current/
-        burn-in), where perceived brightness ~ luminance^(1/3), so a linear
-        value feels uneven; gamma>1 evens out the perceived steps (1.0 = the
-        old linear behaviour). Endpoints (0->2, 1->50) are preserved."""
+        applying the perceptual gamma, then damping the swing for the configured
+        environment. The keycap OLEDs are driven near the bottom of their
+        contrast range (firmware caps at 49/50 for current/burn-in), where
+        perceived brightness ~ luminance^(1/3), so a linear value feels uneven;
+        gamma>1 evens out the perceived steps (1.0 = the old linear behaviour).
+        The full-swing 'curve' (0->2, 1->50) is then damped toward the
+        environment's baseline (see BRIGHTNESS_ENVIRONMENTS): device = baseline +
+        k*(curve - baseline). The 'window' preset (k=1) leaves the curve
+        untouched; smaller k flattens the daylight swing for desks further from
+        a window, while keeping k>0 so it still dims at night."""
         min_val = self.poly_settings.get("irradiance_min")
         max_val = self.poly_settings.get("irradiance_max")
         prescaler = self.poly_settings.get("irradiance_prescaler")
@@ -690,7 +695,10 @@ class PolyCore:
         gamma = self.poly_settings.get("brightness_gamma")
         if gamma and gamma > 0:
             brightness = brightness ** gamma
-        return 2 + brightness * 48
+        curve = 2 + brightness * 48
+        baseline, k = brightness_environment_params(
+            self.poly_settings.get("brightness_environment"))
+        return baseline + k * (curve - baseline)
 
     def _brightness_periodic(self, cancel):
         """Worker periodic (10 min): daylight-dependent brightness incl. the
@@ -725,6 +733,7 @@ class PolyCore:
     # daylight brightness rather than waiting for the next 10-min periodic.
     _BRIGHTNESS_SETTING_KEYS = frozenset({
         "brightness_set_daylight_dependent",
+        "brightness_environment",
         "irradiance_min", "irradiance_max", "irradiance_prescaler",
         "brightness_gamma",
         "brightness_allow_online_irradiance_request",

--- a/polyhost/gui/settings_dialog.py
+++ b/polyhost/gui/settings_dialog.py
@@ -4,11 +4,27 @@ from collections import defaultdict
 from PyQt5.QtCore import QSize, Qt
 from PyQt5.QtWidgets import (
     QDialog, QFormLayout, QDialogButtonBox,
-    QLabel, QLineEdit, QSpinBox, QDoubleSpinBox, QCheckBox, QWidget, QVBoxLayout, QHBoxLayout, QGroupBox, QSizePolicy,
+    QLabel, QLineEdit, QSpinBox, QDoubleSpinBox, QCheckBox, QComboBox, QWidget, QVBoxLayout, QHBoxLayout, QGroupBox, QSizePolicy,
     QScrollArea
 )
 
 from polyhost.gui.get_icon import get_icon
+from polyhost.settings import BRIGHTNESS_ENVIRONMENTS
+
+# Settings that should render as a fixed-choice dropdown instead of the generic
+# type-based editor. Maps the setting key to a list of (stored value, label).
+ENUM_SETTINGS = {
+    "brightness_environment": [(k, label) for k, label, _b, _g in BRIGHTNESS_ENVIRONMENTS],
+}
+
+
+def create_combo(value, choices):
+    combo = QComboBox()
+    for stored, label in choices:
+        combo.addItem(label, stored)
+    idx = combo.findData(value)
+    combo.setCurrentIndex(idx if idx >= 0 else 0)
+    return combo
 
 
 def create_editor(value):
@@ -86,7 +102,10 @@ class SettingsDialog(QDialog):
                 parts = cap.split(" ",1)
                 label = QLabel(parts[1])
                 label.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
-                widget = create_editor(value)
+                if full_key in ENUM_SETTINGS:
+                    widget = create_combo(value, ENUM_SETTINGS[full_key])
+                else:
+                    widget = create_editor(value)
 
                 field_container = QWidget()
                 field_layout = QHBoxLayout()
@@ -114,7 +133,9 @@ class SettingsDialog(QDialog):
     def get_updated_settings(self):
         updated = dict(self._all_settings)
         for key, widget in self.edit_widgets.items():
-            if isinstance(widget, QCheckBox):
+            if isinstance(widget, QComboBox):
+                updated[key] = widget.currentData()
+            elif isinstance(widget, QCheckBox):
                 updated[key] = widget.isChecked()
             elif isinstance(widget, QSpinBox):
                 updated[key] = widget.value()

--- a/polyhost/services/brightness_diag.py
+++ b/polyhost/services/brightness_diag.py
@@ -6,7 +6,8 @@ Run on the machine the keyboard is attached to:
 
 It reproduces the exact pipeline that the 10-min worker periodic
 (`PolyCore._brightness_periodic`) drives — `Sunlight.get_brightness_now()`
-→ device value `2 + normalized * 48` — and prints, path by path, *why* a
+→ curve `2 + normalized * 48` → environment damping `baseline + k*(curve -
+baseline)` — and prints, path by path, *why* a
 given device value comes out, so a "stuck at 2" report can be traced to a
 concrete cause (night, a mis-scaled curve, a failed online lookup, or the
 clear-sky timezone bug) instead of guessed at.
@@ -17,18 +18,22 @@ It only reads — it never talks to the keyboard and changes no settings.
 import math
 from datetime import datetime, timezone, timedelta
 
-from polyhost.settings import PolySettings
+from polyhost.settings import PolySettings, brightness_environment_params
 from polyhost.services.sunlight_helper import Sunlight
 
 
-def device_value(normalized, gamma=1.0):
+def device_value(normalized, gamma=1.0, env=(2.0, 1.0)):
     """The mapping PolyCore applies: normalized 0..1 -> device 2..50, with the
-    perceptual gamma applied first (gamma=1.0 is the legacy linear behaviour).
+    perceptual gamma applied first (gamma=1.0 is the legacy linear behaviour),
+    then the environment damping device = baseline + k*(curve - baseline)
+    (env = (baseline, k); the default (2, 1) is the undamped 'window' preset).
     The firmware then writes (value-1) straight to the SSD1306 contrast register
     (linear, capped at 49) — so the perceptual shaping lives entirely here."""
     if gamma and gamma > 0:
         normalized = normalized ** gamma
-    return 2 + normalized * 48
+    curve = 2 + normalized * 48
+    baseline, k = env
+    return baseline + k * (curve - baseline)
 
 
 def normalize(irradiance, min_val, max_val, pre_scale):
@@ -41,15 +46,24 @@ def normalize(irradiance, min_val, max_val, pre_scale):
     return perceived, normalized
 
 
-def curve_analysis(min_val, max_val, pre_scale, gamma=1.0):
+def curve_analysis(min_val, max_val, pre_scale, gamma=1.0, env_key="window", env=(2.0, 1.0)):
+    baseline, k = env
     print("=" * 72)
     print("1. CALIBRATION — irradiance -> device brightness curve")
     print("=" * 72)
     print(f"   settings: irradiance_min={min_val}  irradiance_max={max_val}  "
           f"prescaler={pre_scale}  brightness_gamma={gamma}")
+    print(f"             brightness_environment={env_key!r}  (baseline={baseline}, k={k})")
     print(f"   formula : perceived = ln(1+irr) * {pre_scale}")
     print( "             normalized = clamp(perceived, min, max) mapped to 0..1")
-    print(f"             device    = 2 + normalized**{gamma} * 48   (int-clipped 0..50)")
+    print(f"             curve     = 2 + normalized**{gamma} * 48")
+    print(f"             device    = {baseline} + {k} * (curve - {baseline})   (int-clipped 0..50)")
+    if k >= 1.0:
+        print( "             (k=1 -> the environment leaves the full daylight swing"
+               " untouched)")
+    else:
+        print(f"             (k<1 -> the daylight swing is flattened toward {baseline};"
+               " still dips at night)")
     print( "             firmware writes (device-1) straight to the OLED contrast")
     print( "             register, linear and capped at 49 (burn-in headroom).\n")
 
@@ -71,19 +85,23 @@ def curve_analysis(min_val, max_val, pre_scale, gamma=1.0):
     # The two physically meaningful break-points of the curve.
     floor_irr = math.exp(min_val / pre_scale) - 1   # below this -> value 2
     full_irr = math.exp(max_val / pre_scale) - 1     # at/above this -> value 50
-    print(f"   -> device value stays at the floor (2) for ALL irradiance "
+    dv_floor = device_value(0.0, gamma, env)
+    dv_full = device_value(1.0, gamma, env)
+    print(f"   -> device value bottoms out at {dv_floor:.1f} for ALL irradiance "
           f"<= {floor_irr:.1f} W/m^2")
-    print(f"   -> device value reaches full (50) only at irradiance "
+    print(f"   -> device value tops out at {dv_full:.1f} for irradiance "
           f">= {full_irr:.0f} W/m^2")
     print( "      (reference: clear-sky noon GHI peaks ~1000 W/m^2; the solar")
     print( "       constant above the atmosphere is 1361 W/m^2)\n")
 
-    print("   irr(W/m^2)  perceived  normalized  device")
+    print("   irr(W/m^2)  perceived  normalized   curve  device")
     for irr in (0, 5, 10, 25, 50, 100, 200, 400, 600, 800, 1000):
         perceived, n = normalize(irr, min_val, max_val, pre_scale)
-        dv = device_value(n, gamma)
-        print(f"   {irr:>8}    {perceived:8.3f}   {n:8.3f}   {dv:6.1f}"
-              f"  (int {int(max(0, min(50, dv)))})")
+        ng = n ** gamma if gamma and gamma > 0 else n
+        curve = 2 + ng * 48
+        dv = device_value(n, gamma, env)
+        print(f"   {irr:>8}    {perceived:8.3f}   {n:8.3f}   {curve:6.1f}"
+              f"  {dv:6.1f}  (int {int(max(0, min(50, dv)))})")
 
     if floor_irr > 50:
         print(f"\n   [!] irradiance_min is high: anything below {floor_irr:.0f} W/m^2")
@@ -95,7 +113,7 @@ def curve_analysis(min_val, max_val, pre_scale, gamma=1.0):
     print()
 
 
-def live_paths(s, min_val, max_val, pre_scale, gamma=1.0):
+def live_paths(s, min_val, max_val, pre_scale, gamma=1.0, env=(2.0, 1.0)):
     print("=" * 72)
     print("2. LIVE — what each irradiance source returns right now")
     print("=" * 72)
@@ -110,7 +128,7 @@ def live_paths(s, min_val, max_val, pre_scale, gamma=1.0):
         print("   [!] location UNKNOWN (IP geolocation failed / disabled).")
         print("       get_irradiance_now() returns the crude hour-of-day fallback:")
         irr = min(19 - 7, max(0, now.hour - 7)) / 12
-        _report_value("hour-of-day fallback", irr, min_val, max_val, pre_scale, gamma)
+        _report_value("hour-of-day fallback", irr, min_val, max_val, pre_scale, gamma, env)
         return
     print(f"   location: lat {s.latitude:.4f}  lon {s.longitude:.4f}")
     print("   irradiance source: online open-meteo (cloud-aware) with a pure-math\n"
@@ -120,7 +138,7 @@ def live_paths(s, min_val, max_val, pre_scale, gamma=1.0):
     try:
         irr = s.get_irradiance_now()
         _report_value("get_irradiance_now() [the value actually used]", irr,
-                      min_val, max_val, pre_scale, gamma)
+                      min_val, max_val, pre_scale, gamma, env)
     except Exception as e:
         print(f"   get_irradiance_now() raised {type(e).__name__}: {e}")
         print("   (the worker periodic swallows this -> brightness is NOT updated)\n")
@@ -130,22 +148,23 @@ def live_paths(s, min_val, max_val, pre_scale, gamma=1.0):
     _clearsky_probe(s)
 
 
-def _report_value(label, irr, min_val, max_val, pre_scale, gamma=1.0):
+def _report_value(label, irr, min_val, max_val, pre_scale, gamma=1.0, env=(2.0, 1.0)):
     _perceived, n = normalize(irr, min_val, max_val, pre_scale)
-    dv = device_value(n, gamma)
+    dv = device_value(n, gamma, env)
+    dv_floor = device_value(0.0, gamma, env)   # the value at zero daylight
     print(f"   {label}")
     print(f"      irradiance = {irr:.2f} W/m^2  -> device value "
           f"{dv:.1f} (int {int(max(0, min(50, dv)))})")
-    if dv <= 2.5:
+    if dv <= dv_floor + 0.5:
         if pre_scale > 0:
             floor_irr = math.exp(min_val / pre_scale) - 1
-            print("      => this is the FLOOR (2). Cause: irradiance read as "
-                  f"<= {floor_irr:.1f} W/m^2.\n")
+            print(f"      => this is the FLOOR ({dv_floor:.1f}). Cause: irradiance "
+                  f"read as <= {floor_irr:.1f} W/m^2.\n")
         else:
             # The tool exists to explain degenerate configs; a 0/negative
             # prescaler pins normalization at the floor, so don't divide by it.
-            print("      => this is the FLOOR (2). Cause: irradiance_prescaler "
-                  "<= 0 pins normalization at the minimum.\n")
+            print(f"      => this is the FLOOR ({dv_floor:.1f}). Cause: "
+                  "irradiance_prescaler <= 0 pins normalization at the minimum.\n")
     else:
         print()
 
@@ -178,17 +197,19 @@ def main():
     max_val = settings.get("irradiance_max")
     pre_scale = settings.get("irradiance_prescaler")
     gamma = settings.get("brightness_gamma")
+    env_key = settings.get("brightness_environment")
+    env = brightness_environment_params(env_key)
 
     print("\nPolyKybd daylight-brightness diagnostics\n")
     if not settings.get("brightness_set_daylight_dependent"):
         print("[note] brightness_set_daylight_dependent is OFF — the periodic does "
               "nothing; the keyboard keeps whatever brightness was last set.\n")
 
-    curve_analysis(min_val, max_val, pre_scale, gamma)
+    curve_analysis(min_val, max_val, pre_scale, gamma, env_key, env)
 
     s = Sunlight(settings.get("brightness_allow_online_location_lookup"),
                  settings.get("brightness_allow_online_irradiance_request"))
-    live_paths(s, min_val, max_val, pre_scale, gamma)
+    live_paths(s, min_val, max_val, pre_scale, gamma, env)
 
 
 if __name__ == "__main__":

--- a/polyhost/settings.py
+++ b/polyhost/settings.py
@@ -4,6 +4,39 @@ import os
 import yaml
 from platformdirs import user_config_dir
 
+
+# Per-environment device-side damping presets for the daylight brightness.
+# The daylight pipeline produces a full-swing "curve" value in the device's
+# 2..50 range (night -> 2, clear-sky noon -> 50). Each environment then damps
+# that swing toward a `baseline` device value:
+#
+#     device = baseline + k * (curve - baseline)
+#
+# k = 1.0 lets the full curve through (the behaviour before environments
+# existed); smaller k flattens the daylight swing toward `baseline` for desks
+# further from a window. k stays > 0 in every preset so the value still dips
+# when it gets dark — users want *less* light at night, not a flat constant.
+# Tuple is (key, dropdown label, baseline, k); list order is the dropdown order.
+BRIGHTNESS_ENVIRONMENTS = [
+    ("window",      "By a window (full daylight swing)",  2.0, 1.00),
+    ("near_window", "Near a window",                      8.0, 0.75),
+    ("bright_room", "Bright room",                       18.0, 0.50),
+    ("office",      "Large office, distant windows",     26.0, 0.32),
+    ("windowless",  "Windowless / artificial light",     28.0, 0.22),
+]
+# key -> (baseline, k) for the runtime lookup in PolyCore / the diagnostics.
+BRIGHTNESS_ENVIRONMENT_PARAMS = {k: (b, g) for k, _, b, g in BRIGHTNESS_ENVIRONMENTS}
+DEFAULT_BRIGHTNESS_ENVIRONMENT = "window"
+
+
+def brightness_environment_params(key):
+    """(baseline, k) for an environment key, defaulting to the no-damping
+    'window' preset for an unknown/missing key so a bad config can never break
+    the daylight pipeline."""
+    return BRIGHTNESS_ENVIRONMENT_PARAMS.get(
+        key, BRIGHTNESS_ENVIRONMENT_PARAMS[DEFAULT_BRIGHTNESS_ENVIRONMENT])
+
+
 class PolySettings:
     """ Stores program specific settings """
     def __init__(self):
@@ -23,6 +56,11 @@ class PolySettings:
         self.defaults = {
             "unicode_send_composition_mode": True,
             "brightness_set_daylight_dependent": True,
+            # Where the keyboard sits relative to natural light. Picks a damping
+            # preset (see BRIGHTNESS_ENVIRONMENTS) that flattens the daylight
+            # swing toward an indoor baseline the further you are from a window;
+            # "window" = the full, undamped swing (legacy behaviour).
+            "brightness_environment": DEFAULT_BRIGHTNESS_ENVIRONMENT,
             "brightness_allow_online_irradiance_request": True,
             "brightness_allow_online_location_lookup": True,
             # Maps solar irradiance (W/m^2) to keycap brightness via

--- a/tests/services/brightness_diag_test.py
+++ b/tests/services/brightness_diag_test.py
@@ -1,0 +1,59 @@
+import unittest
+
+from polyhost.settings import (
+    BRIGHTNESS_ENVIRONMENT_PARAMS,
+    DEFAULT_BRIGHTNESS_ENVIRONMENT,
+    brightness_environment_params,
+)
+from polyhost.services.brightness_diag import device_value
+
+
+class TestEnvironmentParams(unittest.TestCase):
+    def test_window_is_no_damping(self):
+        # The default 'window' preset must leave the curve untouched (k=1),
+        # so it is bit-identical to the pre-environment behaviour.
+        baseline, k = brightness_environment_params("window")
+        self.assertEqual(k, 1.0)
+        self.assertEqual(DEFAULT_BRIGHTNESS_ENVIRONMENT, "window")
+
+    def test_unknown_key_falls_back_to_window(self):
+        self.assertEqual(
+            brightness_environment_params("does-not-exist"),
+            BRIGHTNESS_ENVIRONMENT_PARAMS["window"],
+        )
+
+    def test_every_preset_still_dims_at_night(self):
+        # The whole point of device-side damping is that even a flat indoor
+        # preset keeps k>0, so darkness still pulls the value down below the
+        # daytime value (users want less light at night, not a flat constant).
+        for key, (baseline, k) in BRIGHTNESS_ENVIRONMENT_PARAMS.items():
+            self.assertGreater(k, 0.0, key)
+            night = device_value(0.0, env=(baseline, k))   # curve floor (2)
+            noon = device_value(1.0, env=(baseline, k))     # curve full (50)
+            self.assertLess(night, noon, f"{key} must dim at night")
+
+
+class TestDeviceValueDamping(unittest.TestCase):
+    def test_window_endpoints_match_legacy(self):
+        # Legacy mapping was exactly 2..50 across the normalized 0..1 range.
+        self.assertAlmostEqual(device_value(0.0, env=(2.0, 1.0)), 2.0)
+        self.assertAlmostEqual(device_value(1.0, env=(2.0, 1.0)), 50.0)
+
+    def test_damping_compresses_toward_baseline(self):
+        # device = baseline + k*(curve - baseline); a half-strength preset
+        # around baseline 20 halves the distance from 20 at both ends.
+        env = (20.0, 0.5)
+        self.assertAlmostEqual(device_value(0.0, env=env), 20.0 + 0.5 * (2.0 - 20.0))
+        self.assertAlmostEqual(device_value(1.0, env=env), 20.0 + 0.5 * (50.0 - 20.0))
+
+    def test_gamma_then_damping_order(self):
+        # gamma shapes the curve first, then damping is applied to the result.
+        n, gamma, env = 0.5, 2.0, (10.0, 0.5)
+        curve = 2 + (n ** gamma) * 48
+        self.assertAlmostEqual(
+            device_value(n, gamma=gamma, env=env), 10.0 + 0.5 * (curve - 10.0)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a **"keyboard lighting environment"** setting that flattens the daylight brightness swing toward an indoor baseline the further the keyboard sits from a window — while still dimming at night. Host-only; no firmware/protocol/rig change.

## Why
The daylight pipeline models **outdoor** irradiance and assumes the keyboard sees the full outdoor swing (≈ "right next to a window"). A desk deep in an office sees mostly constant ceiling light, so its brightness should barely move; a naive irradiance multiplier only *shifts* the log curve, it doesn't *flatten* it — so a damping model is the right knob.

## Model — device-side damping
The pipeline still produces the full-swing `curve` value (night → 2, clear-sky noon → 50). Each environment damps it toward a baseline:

```
device = baseline + k · (curve − baseline)
```

`k = 1.0` ("window") leaves the curve untouched — **bit-identical to today's behaviour**. Smaller `k` compresses the swing toward `baseline`. Every preset keeps `k > 0`, so darkness still pulls the value down (users want *less* light at night, not a flat constant).

| Environment | night → noon | swing |
|---|---|---|
| By a window (default) | 2.0 → 50.0 | 48 |
| Near a window | 3.5 → 39.5 | 36 |
| Bright room | 10.0 → 34.0 | 24 |
| Large office, distant windows | 18.3 → 33.7 | 15 |
| Windowless / artificial light | 22.3 → 32.8 | 11 |

## Changes
- **`settings.py`** — `BRIGHTNESS_ENVIRONMENTS` preset table + `brightness_environment_params()` (unknown key → safe `window` fallback); `brightness_environment` default `"window"` (existing configs unaffected).
- **`poly_core.py`** — `_compute_daylight_value` applies the damping after gamma; the setting joins the immediate-retransmit set so a change takes effect at once.
- **`settings_dialog.py`** — renders `brightness_environment` as a dropdown (generic enum hook).
- **`brightness_diag.py`** — folds the damping into the printed curve + live paths so the diagnostics still match what the device gets.
- **tests** — preset params, the night-dimming invariant, and gamma→damping ordering.

## Notes
- No ambient-light sensor on the keyboard, so this is a coarse user-chosen preset (a future ALS would replace the estimator).
- Preset numbers are easy to tune.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014gvsLwzVDNtVPY7mzmM5T9

---
_Generated by [Claude Code](https://claude.ai/code/session_014gvsLwzVDNtVPY7mzmM5T9)_