### PR TITLE
Fix Windows language tag parsing for space-joined tags

### DIFF
--- a/polyhost/input/win_helper.py
+++ b/polyhost/input/win_helper.py
@@ -57,7 +57,16 @@ class WindowsInputHelper(InputHelper):
     @staticmethod
     def _parse_language_tags(stdout):
         """Collect the IETF tags from 'LanguageTag: <tag>' lines, ignoring a bare
-        table header (no colon). Accepts bytes or str."""
+        table header (no colon). Accepts bytes or str.
+
+        The value after the colon is split on whitespace, so a single line that
+        carries several tags is expanded into one entry per tag. Some Windows /
+        PowerShell builds don't enumerate the WinUserLanguageList in the pipeline,
+        so 'LanguageTag: ' + $_.LanguageTag member-enumerates the whole list and
+        joins it with the default $OFS (a space) into one line
+        ('LanguageTag: en-AT en-US de-AT'). Without the split that arrives as a
+        single bogus tag 'en-AT en-US de-AT', which matches no language (field log
+        2026-06-20) and shows as one entry in the debug language menu."""
         tags = []
         for raw in stdout.splitlines():
             try:
@@ -66,7 +75,7 @@ class WindowsInputHelper(InputHelper):
                 line = str(raw)
             line = line.strip()
             if line.startswith('LanguageTag') and ':' in line:
-                tags.append(line.split(':', 1)[1].strip())
+                tags.extend(line.split(':', 1)[1].split())
         return tags
 
     def get_current_language(self):

--- a/tests/input/win_helper_parse_test.py
+++ b/tests/input/win_helper_parse_test.py
@@ -74,6 +74,21 @@ class ParseLanguageTagsTest(unittest.TestCase):
         # lacks our 'LanguageTag:' shape, so nothing bogus is returned.
         self.assertEqual(_parse_tags(table), [])
 
+    def test_space_joined_tags_on_one_line(self):
+        # Some Windows/PowerShell builds don't enumerate the language list in the
+        # pipeline, so 'LanguageTag: ' + $_.LanguageTag member-enumerates it and
+        # joins every tag with the default $OFS (a space) onto a single line.
+        # That must expand to one tag per language, not a single bogus tag
+        # 'en-AT en-US de-AT' (field log 2026-06-20).
+        self.assertEqual(
+            _parse_tags("LanguageTag: en-AT en-US de-AT"),
+            ["en-AT", "en-US", "de-AT"])
+
+    def test_space_joined_tags_as_bytes(self):
+        self.assertEqual(
+            _parse_tags(b"LanguageTag: en-AT en-US de-AT\n"),
+            ["en-AT", "en-US", "de-AT"])
+
     def test_empty_output(self):
         self.assertEqual(_parse_tags(""), [])
 


### PR DESCRIPTION
## Summary

Fixes a bug in Windows language tag parsing where some PowerShell builds join multiple language tags into a single space-separated string on one line (e.g., `LanguageTag: en-AT en-US de-AT`), which was previously treated as a single bogus tag instead of being split into individual tags.

The fix changes `_parse_language_tags()` to split the value after the colon on whitespace, expanding space-joined tags into one entry per tag. This handles the case where PowerShell's member-enumeration of `$_.LanguageTag` joins the entire list with the default `$OFS` (space) onto a single line.

## Changes

- **`polyhost/input/win_helper.py`**: Updated `_parse_language_tags()` to use `.split()` instead of `.strip()` when extracting the tag value, and extended the docstring to explain the PowerShell behavior and why the split is necessary.
- **`tests/input/win_helper_parse_test.py`**: Added two test cases:
  - `test_space_joined_tags_on_one_line()`: Verifies space-joined tags on a single line are correctly parsed
  - `test_space_joined_tags_as_bytes()`: Verifies the same behavior works with bytes input

## Version bump label
*(none)* — Bug fix

## Testing
- Added unit tests covering the new behavior (both string and bytes input)
- Existing tests continue to pass

https://claude.ai/code/session_018ngLg22KMTQeWQxEBibfaP

## Summary by Sourcery

Fix Windows language tag parsing to correctly handle space-separated tags emitted on a single line by some PowerShell builds.

Bug Fixes:
- Treat space-joined language tags on a single 'LanguageTag:' line as separate tags instead of a single invalid tag.

Tests:
- Add unit tests to verify correct parsing of space-joined language tags for both string and bytes input.