### PR TITLE
Add idle anti-burn-in style toggle to the tray menu

### DIFF
--- a/polyhost/client/remote_core.py
+++ b/polyhost/client/remote_core.py
@@ -232,6 +232,12 @@ class RemoteCore:
     def set_idle(self, idle):
         return self._device(p.M_IDLE_SET, {"idle": idle})
 
+    def set_idle_style(self, value):
+        return self._device(p.M_IDLE_STYLE_SET, {"value": value})
+
+    def get_idle_style(self):
+        return self._device(p.M_IDLE_STYLE_GET)
+
     # -- overlays -----------------------------------------------------------
     def send_overlay_data(self, files):
         try:

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -15,6 +15,7 @@ from PyQt5.QtWidgets import (
     QSystemTrayIcon,
     QMenu,
     QAction,
+    QActionGroup,
     QDialog,
     QDialogButtonBox,
     QHBoxLayout,
@@ -26,6 +27,7 @@ from PyQt5.QtWidgets import (
     QStyle,
     QVBoxLayout, )
 
+from polyhost.device.command_ids import IdleStyle
 from polyhost.gui.get_icon import get_icon
 from polyhost.gui.icon_state_manager import IconStateManager
 from polyhost.gui.log_viewer import LogViewerDialog
@@ -355,6 +357,26 @@ class PolyHost(QApplication):
         # noinspection PyUnresolvedReferences
         self.layout_editor.triggered.connect(self.open_layout_editor)
         self.menu.addAction(self.layout_editor)
+
+        # Idle anti-burn-in style (firmware v4+). Device-coupled: it drives the
+        # device through core.get/set_idle_style (worker run_sync in-process, RPC
+        # in client mode), so it works in both modes; the blanket enable/disable
+        # in managed_connection_status greys the whole submenu while disconnected.
+        self.idle_style_menu = self.menu.addMenu(get_icon("backlight_high.svg"), "Idle Anti-Burn-In")
+        idle_group = QActionGroup(self)
+        idle_group.setExclusive(True)
+        self.idle_pulse_action = QAction("Pulse (legacy)", parent=self, checkable=True)
+        self.idle_pulse_action.setData(IdleStyle.PULSE.value)
+        self.idle_jitter_action = QAction("Jitter (move legend)", parent=self, checkable=True)
+        self.idle_jitter_action.setData(IdleStyle.JITTER.value)
+        for act in (self.idle_pulse_action, self.idle_jitter_action):
+            idle_group.addAction(act)
+            # noinspection PyUnresolvedReferences
+            act.triggered.connect(self.change_idle_style)
+            self.idle_style_menu.addAction(act)
+        # noinspection PyUnresolvedReferences
+        self.idle_style_menu.aboutToShow.connect(self.refresh_idle_style_menu)
+
         self.menu.addAction(self.settings_dialog)
         self.menu.addAction(self.log_dialog)
 
@@ -1014,6 +1036,26 @@ class PolyHost(QApplication):
             self.update_ui_on_lang_change(lang)
         else:
             self.keeb_lang_menu.setTitle(f"Could not set {lang}: {msg}")
+
+    def refresh_idle_style_menu(self):
+        # Read the current style straight from the device (core marshals the HID
+        # round-trip onto the worker in-process, or over RPC in client mode) and
+        # tick the matching item. On failure (old firmware / disconnected) leave
+        # both unchecked rather than guessing.
+        ok, value = self.core.get_idle_style()
+        self.idle_pulse_action.setChecked(bool(ok) and value == IdleStyle.PULSE.value)
+        self.idle_jitter_action.setChecked(bool(ok) and value == IdleStyle.JITTER.value)
+
+    def change_idle_style(self):
+        value = self.sender().data()
+        ok, msg = self.core.set_idle_style(value)
+        if ok:
+            self.log.info("Idle anti-burn-in style set to %s.", IdleStyle(value).name.lower())
+        else:
+            # Firmware too old (needs v4+) or device busy — log and re-sync the
+            # checkmark to the device's actual style so the menu doesn't lie.
+            self.report_device_result("Error", f"Could not set idle style: {msg}")
+            self.refresh_idle_style_menu()
 
     def read_overlay_mapping_file(self, file):
         if not file:


### PR DESCRIPTION
## What

Adds a GUI entry for the firmware's idle anti-burn-in style. The CLI/core/device support landed in #69; this adds the missing tray control so the style can be toggled without `polyctl`.

An **"Idle Anti-Burn-In"** tray submenu with exclusive **Pulse** / **Jitter** items. It reads the current style from the device on open and applies the selection over the existing HID cmd 28 path.

## Changes
- **`host.py`**: build the submenu (`QActionGroup`, exclusive); refresh the checkmark from `core.get_idle_style()` on `aboutToShow`; apply via `core.set_idle_style()` on click. It's device-coupled, so the blanket enable/disable in `managed_connection_status` greys it while disconnected; on an old-firmware failure (needs protocol v4+) it logs and re-syncs the checkmark. The core marshals the HID round-trip onto the worker in-process / over RPC in client mode, so a direct call from the menu handler is safe in both modes.
- **`client/remote_core.py`**: expose `get_idle_style` / `set_idle_style` over the existing `M_IDLE_STYLE_GET/SET` RPCs so the toggle also works in `--connect` client mode.

## Testing
- Idle-style device tests pass.
- The GUI host/client construction test passes in **both** default and `--connect` modes under xvfb.

Pairs with the firmware rework in thpoll83/qmk_firmware#83 (per-key jitter). The protocol is unchanged by this PR — it still just selects pulse vs jitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CuPnCAA6syPsWqXx6gPgHj

---
_Generated by [Claude Code](https://claude.ai/code/session_01CuPnCAA6syPsWqXx6gPgHj)_

## Summary by Sourcery

Add a system tray submenu to control the device’s idle anti-burn-in style and expose corresponding RPC methods for remote clients.

New Features:
- Introduce an 'Idle Anti-Burn-In' tray submenu with mutually exclusive Pulse and Jitter options that reflect and control the device’s current idle style.

Enhancements:
- Hook the idle anti-burn-in tray submenu into core idle-style getters/setters so it stays in sync with the device across local and client modes.
- Extend the remote core client to support getting and setting the idle anti-burn-in style via existing RPC messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Idle Anti-Burn-In submenu with configurable idle style options: "Pulse (legacy)" and "Jitter (move legend)"
  * Users can now query and apply idle style settings from the device
  * Menu automatically syncs with current device state and handles errors gracefully

<!-- end of auto-generated comment: release notes by coderabbit.ai -->