### PR TITLE
security: gate host key-injection (press/release) on debug mode

### DIFF
--- a/polyhost/core/poly_core.py
+++ b/polyhost/core/poly_core.py
@@ -60,13 +60,31 @@ def get_overlay_path(filepath):
     return os.path.join(_RES_DIR, "overlays", filepath)
 
 
+def strip_key_injection(lines):
+    """Drop the ``press``/``release`` key-injection commands from a script.
+
+    Returns ``(kept_lines, dropped_count)``. Used to enforce that a non-debug
+    host never drives arbitrary keystrokes on the keyboard via a command file
+    or the ``commands.execute`` control RPC (see ``PolyCore.execute_commands``).
+    """
+    kept = [ln for ln in lines
+            if ln.strip().split(" ", 1)[0] not in ("press", "release")]
+    return kept, len(lines) - len(kept)
+
+
 class PolyCore:
     """Operational facade: commands in, events out. No Qt, no widgets."""
 
     def __init__(self, log, ignore_version=False, start_worker=True,
-                 apply_reconnect_in_core=False):
+                 apply_reconnect_in_core=False, allow_key_injection=False):
         self.log = log
         self.ignore_version = ignore_version
+        # SECURITY: the `press`/`release` script commands inject real keystrokes
+        # on the keyboard (firmware HID cmd 14 -> the keyboard types into the
+        # host's focused app). That is a demo/dev capability, so it is honoured
+        # only when the owning process was started in debug mode (--debug). The
+        # firmware also NACKs cmd 14 unless DB_TOGG is on; this is the host half.
+        self.allow_key_injection = allow_key_injection
         # When True (headless, no GUI to render), the reconnect periodic
         # applies its own snapshot (state + post-connect + status_changed).
         # The Qt client leaves this False and applies in _apply_reconnect_result.
@@ -866,7 +884,21 @@ class PolyCore:
         return self.keeb.get_sw_version()
 
     def execute_commands(self, lines):
-        """Queue a (cancel-aware) command script across every device entry."""
+        """Queue a (cancel-aware) command script across every device entry.
+
+        Unless key injection is allowed (host started in debug mode), the
+        ``press``/``release`` commands are stripped here so a command file (or
+        the ``commands.execute`` control RPC) can never drive arbitrary
+        keystrokes on a production host.
+        """
+        lines = list(lines)
+        if not self.allow_key_injection:
+            lines, dropped = strip_key_injection(lines)
+            if dropped:
+                self.log.warning(
+                    "Ignoring %d key-injection command(s) (press/release): host "
+                    "not started in debug mode (--debug).", dropped)
+
         def _job(cancel):
             for entry in self.device_mgr.all_entries:
                 if cancel.is_set():

--- a/polyhost/headless.py
+++ b/polyhost/headless.py
@@ -27,7 +27,7 @@ from polyhost.server.control_server import ControlServer
 class HeadlessHost:
     """Qt-free host: core + control server + core-owned window tick."""
 
-    def __init__(self, log, ignore_version=False):
+    def __init__(self, log, ignore_version=False, allow_key_injection=False):
         self.log = log
         self._stop = threading.Event()
         self._stopped = False
@@ -36,7 +36,8 @@ class HeadlessHost:
         self._restart_after_stop = False
         self._relay_path = None
         self.core = PolyCore(log=log, ignore_version=ignore_version,
-                             start_worker=False, apply_reconnect_in_core=True)
+                             start_worker=False, apply_reconnect_in_core=True,
+                             allow_key_injection=allow_key_injection)
         # React to a core-driven self-update (`polyctl update install`): the
         # core only applies + emits; the host owns the restart.
         self.core.subscribe(self._on_update_event)
@@ -207,5 +208,8 @@ def run_headless(log_level=logging.INFO, ignore_version=False):
         _os.getenv("DISPLAY", "n/a"),
         _os.getenv("WAYLAND_DISPLAY", "n/a"),
     )
-    host = HeadlessHost(log, ignore_version=ignore_version)
+    # --debug maps to DEBUG / DEBUG_DETAILED (both <= DEBUG); no flag -> INFO.
+    # Only a debug-mode daemon may honour press/release key-injection commands.
+    host = HeadlessHost(log, ignore_version=ignore_version,
+                        allow_key_injection=log_level <= logging.DEBUG)
     host.run()

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -285,7 +285,8 @@ class PolyHost(QApplication):
             # tray. The client uses RemoteCore instead and never imports this.
             from polyhost.core.poly_core import PolyCore
             self.core = PolyCore(log=self.log, ignore_version=ignore_version,
-                                 start_worker=False)
+                                 start_worker=False,
+                                 allow_key_injection=debug_mode > 0)
             self.keeb = self.core.keeb
             self.worker = self.core.worker
             self.device_mgr = self.core.device_mgr

--- a/tests/core/key_injection_gate_test.py
+++ b/tests/core/key_injection_gate_test.py
@@ -1,0 +1,40 @@
+"""The host-side key-injection gate (security).
+
+`press`/`release` script commands inject real keystrokes on the keyboard
+(firmware HID cmd 14). They are honoured only when the host runs in debug
+mode; otherwise `PolyCore.execute_commands` strips them. Here we test the pure
+filter that does the stripping — no device/worker needed.
+"""
+import unittest
+
+from polyhost.core.poly_core import strip_key_injection
+
+
+class StripKeyInjectionTest(unittest.TestCase):
+    def test_drops_press_and_release(self):
+        lines = ["press 0x04", "release 0x04", "PRESS 0x05"]
+        kept, dropped = strip_key_injection(lines)
+        # only exact `press`/`release` heads are dropped (case-sensitive keyword)
+        self.assertEqual(kept, ["PRESS 0x05"])
+        self.assertEqual(dropped, 2)
+
+    def test_keeps_legitimate_commands(self):
+        lines = ["wait 0.5", "overlay send foo.png", "overlay reset"]
+        kept, dropped = strip_key_injection(lines)
+        self.assertEqual(kept, lines)
+        self.assertEqual(dropped, 0)
+
+    def test_mixed_script_strips_only_injection(self):
+        lines = ["overlay reset", "press 0x29", "wait 1", "release 0x29"]
+        kept, dropped = strip_key_injection(lines)
+        self.assertEqual(kept, ["overlay reset", "wait 1"])
+        self.assertEqual(dropped, 2)
+
+    def test_handles_leading_whitespace(self):
+        kept, dropped = strip_key_injection(["   press 0x04", "\toverlay reset"])
+        self.assertEqual(kept, ["\toverlay reset"])
+        self.assertEqual(dropped, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Host-side half of the key-injection hardening (the firmware companion already NACKs HID cmd 14 unless `DB_TOGG` is on — thpoll83/qmk_firmware#86).

The `press`/`release` script commands inject real keystrokes on the keyboard (cmd 14 → the keyboard types into the focused app), reachable via:
- the GUI **"Load command file…"** action, and
- the **`commands.execute`** control-socket RPC.

They are now honoured **only when the owning process was started in debug mode (`--debug`)**.

## Changes

- **`PolyCore`** gains `allow_key_injection` (default `False`). `execute_commands` strips `press`/`release` via the new pure `strip_key_injection()` helper and logs a warning, leaving legitimate `overlay`/`wait` commands untouched. This single chokepoint covers both the GUI command-file path and the control RPC.
- **`host.py`** passes `allow_key_injection = debug_mode > 0` (in-process GUI).
- **`headless.py`** threads it through `HeadlessHost`; `run_headless` derives it from the log level (`--debug` → `DEBUG`/`DEBUG_DETAILED`), so a daemon spawned with `--debug` enables it and a normal daemon does not. In `--connect` client mode the daemon (the device owner) enforces it.
- Device-level `press_key`/`PolyKybd.execute_commands` are **unchanged** (pure mechanism), so existing device tests pass.

## Testing

- New `tests/core/key_injection_gate_test.py` covers the filter (drop `press`/`release`, keep `overlay`/`wait`, leading-whitespace handling).
- Full affected suite green: **184 tests** (`key_injection_gate`, `import_guard`, `poly_core_apply`, `poly_kybd_cmd`, `poly_kybd_cancel`, `poly_kybd_mock`, `control_server`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NinUrR5rxUWk1w9RKz5unE)_