### PR TITLE
Fix macOS install & tray-app UX (Python 3.10+ guard, autostart, Dock icon, oversized icons)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ Then start it:
 
 ## Manual install
 
+> **Requires Python 3.10 or newer.** Create the virtual environment with a
+> 3.10+ interpreter — on macOS the system `python3` from the Xcode Command Line
+> Tools is 3.9 and cannot run the app (you'll get a `TypeError: unsupported
+> operand type(s) for |`). Use `brew install python` (or python.org) and build
+> the venv with e.g. `python3.12 -m venv .venv`.
+
 ```bash
 git clone https://github.com/thpoll83/PolyKybdHost.git
 cd PolyKybdHost
@@ -81,7 +87,11 @@ crash with an `ImportError` if a dependency slipped through.
   sudo udevadm control --reload-rules && sudo udevadm trigger
   ```
   Replug the keyboard afterwards.
-- **macOS** — `brew install hidapi`.
+- **macOS** — `brew install hidapi`. Use a Homebrew/python.org Python 3.10+ for
+  the venv (see the note above); the system `python3` is 3.9. Installing
+  Homebrew's `python` also pulls binary wheels for the `pyobjc-*` frameworks
+  (a transitive dependency of `PyWinCtl`), so the first `pip install` is much
+  faster than compiling them against the Command Line Tools.
 
 ## Running
 

--- a/polyhost/__main__.py
+++ b/polyhost/__main__.py
@@ -12,6 +12,27 @@ if __name__ == "__main__" and parent_dir not in sys.path:
     sys.path.insert(0, parent_dir)
     print("Script is executed directly, sys.path corrected to:\n", sys.path)
 
+# Hard requirement: Python 3.10+. The codebase uses `match` statements
+# (polyhost/device/poly_kybd.py) and PEP 604 `X | Y` annotations evaluated at
+# import time, both of which raise on 3.9 — most visibly the macOS system
+# interpreter from the Xcode Command Line Tools (/Library/Developer/...python3,
+# which is 3.9). Without this guard the user just sees a cryptic
+# "TypeError: unsupported operand type(s) for |" deep in an import. Fail early
+# and tell them what to do instead. This block is stdlib-only and 3.9-parseable,
+# so it always runs before any 3.10-only module is imported.
+if sys.version_info < (3, 10):
+    _v = ".".join(str(n) for n in sys.version_info[:3])
+    sys.stderr.write(
+        "PolyKybdHost requires Python 3.10 or newer, but this interpreter is "
+        f"Python {_v}\n  ({sys.executable}).\n\n"
+        "On macOS the system 'python3' from the Xcode Command Line Tools is 3.9 "
+        "and will not work.\nInstall a newer Python (e.g. 'brew install python' "
+        "or python.org) and create the\nvirtual environment with it, for example:\n\n"
+        "    python3.12 -m venv .venv && .venv/bin/python -m pip install -r requirements.txt\n"
+        "    .venv/bin/python -m polyhost\n"
+    )
+    raise SystemExit(1)
+
 from polyhost._bootstrap import bootstrap_dependencies
 
 bootstrap_dependencies(parent_dir)

--- a/polyhost/forwarder.py
+++ b/polyhost/forwarder.py
@@ -108,7 +108,6 @@ class PolyForwarder(QApplication):
         self.set_style()
 
         self.menu = QMenu()
-        self.menu.setStyleSheet("QMenu {icon-size: 64px;} QMenu::item {icon-size: 64px; background: transparent;}")
 
         self.exit = QAction(get_icon("power.svg"), "Quit", parent=self)
         # noinspection PyUnresolvedReferences

--- a/polyhost/forwarder.py
+++ b/polyhost/forwarder.py
@@ -45,6 +45,9 @@ class PolyForwarder(QApplication):
     def __init__(self, log_level, host=None, host_file=None,
                  report_rpc=False, report_port=None, report_authkey_file=None):
         super().__init__(sys.argv)
+        # Tray-only app: keep it out of the macOS Dock (no-op elsewhere).
+        from polyhost.util.macos_ui import hide_dock_icon
+        hide_dock_icon()
         self.host = host
         self.host_file = os.path.expanduser(host_file) if host_file else None
 

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -186,6 +186,9 @@ class PolyHost(QApplication):
     def __init__(self, log_level, debug_mode, ignore_version=False,
                  client_mode=False, endpoint=None, connect_retry=False):
         super().__init__(sys.argv)
+        # Tray-only app: keep it out of the macOS Dock (no-op elsewhere).
+        from polyhost.util.macos_ui import hide_dock_icon
+        hide_dock_icon()
         fmt = "[%(asctime)s] %(levelname)-7s {%(filename)s:%(lineno)d} %(message)s" if debug_mode>0 else "[%(asctime)s] %(levelname)-7s %(message)s"
         level = DEBUG_DETAILED if debug_mode>1 else log_level
 

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -307,7 +307,6 @@ class PolyHost(QApplication):
         self.log.debug("Building menu...")
         self.set_style()
         self.menu = QMenu()
-        self.menu.setStyleSheet("QMenu {icon-size: 64px;} QMenu::item {icon-size: 64px; background: transparent;}")
 
         self.status = QAction(get_icon("sync.svg"), "Waiting for PolyKybd...", parent=self)
         self.status.setToolTip("Press to pause connection")
@@ -879,6 +878,14 @@ class PolyHost(QApplication):
                 # once the firmware version is known, by which point the rest of
                 # the menu already exists, so insert rather than add.
                 self.keeb_lang_menu = QMenu(title)
+                # Enlarge only the language menu's icons — the per-language flag
+                # icons are the ones worth showing big. Applying this on the whole
+                # tray menu (the old behaviour) instead inflated the submenu-title
+                # glyphs (All Commands / Font Pack / Idle Anti-Burn-In / Fix
+                # Left-Right Side), which looked oversized next to the normal
+                # action icons. Scoping it here keeps those at the default size.
+                self.keeb_lang_menu.setStyleSheet(
+                    "QMenu {icon-size: 64px;} QMenu::item {icon-size: 64px; background: transparent;}")
                 self.keeb_lang_menu.menuAction().setIcon(get_icon("language.svg"))
                 actions = menu.actions()
                 if len(actions) > 1:

--- a/polyhost/services/add_to_startup.py
+++ b/polyhost/services/add_to_startup.py
@@ -392,10 +392,6 @@ def add_to_startup(wrapper_path, app_name, icon_path):
 
     elif system == "Darwin":
         plist_path = _macos_plist_path(app_name)
-        # ~/Library/LaunchAgents does not exist on a fresh macOS account until
-        # the first LaunchAgent is installed; write_text() would raise
-        # FileNotFoundError otherwise (seen in the field on a clean install).
-        plist_path.parent.mkdir(parents=True, exist_ok=True)
         plist_content = f"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
 "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -414,6 +410,26 @@ def add_to_startup(wrapper_path, app_name, icon_path):
 </dict>
 </plist>
 """
+        # Idempotent: if an identical plist is already loaded, do nothing.
+        # Rewriting the plist and re-running `launchctl load` on every launch
+        # re-registers the login item, which makes macOS (Ventura+) pop up
+        # "Background Items Added" each time. Only touch it when it's missing or
+        # its content actually changed (e.g. the wrapper path moved).
+        try:
+            already = plist_path.read_text()
+        except OSError:
+            already = None
+        if already == plist_content:
+            print(f"Startup plist already up to date: {plist_path}")
+            return
+        # ~/Library/LaunchAgents does not exist on a fresh macOS account until
+        # the first LaunchAgent is installed; write_text() would raise
+        # FileNotFoundError otherwise (seen in the field on a clean install).
+        plist_path.parent.mkdir(parents=True, exist_ok=True)
+        # Unload an existing (stale) definition first so launchd picks up the
+        # new content cleanly instead of keeping the old registration.
+        if already is not None:
+            subprocess.run(["launchctl", "unload", str(plist_path)], check=False)
         plist_path.write_text(plist_content)
         subprocess.run(["launchctl", "load", str(plist_path)], check=False)
         print(f"Startup plist created and loaded at: {plist_path}")

--- a/polyhost/services/add_to_startup.py
+++ b/polyhost/services/add_to_startup.py
@@ -392,6 +392,10 @@ def add_to_startup(wrapper_path, app_name, icon_path):
 
     elif system == "Darwin":
         plist_path = _macos_plist_path(app_name)
+        # ~/Library/LaunchAgents does not exist on a fresh macOS account until
+        # the first LaunchAgent is installed; write_text() would raise
+        # FileNotFoundError otherwise (seen in the field on a clean install).
+        plist_path.parent.mkdir(parents=True, exist_ok=True)
         plist_content = f"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
 "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/polyhost/util/macos_ui.py
+++ b/polyhost/util/macos_ui.py
@@ -1,0 +1,38 @@
+"""macOS-specific UI tweaks for the tray apps.
+
+Kept tiny and import-safe on every platform: the functions here no-op off
+macOS and swallow import/runtime errors, so callers can invoke them
+unconditionally right after constructing the QApplication.
+"""
+import logging
+import platform
+
+log = logging.getLogger(__name__)
+
+# NSApplicationActivationPolicyAccessory — the app runs without a Dock icon and
+# without a menu bar, the runtime equivalent of Info.plist's LSUIElement=1. This
+# is what turns a plain QApplication into a proper "tray/menu-bar only" agent
+# app. (Regular=0, Accessory=1, Prohibited=2.)
+_NS_ACCESSORY = 1
+
+
+def hide_dock_icon() -> bool:
+    """Make this process a background/accessory app on macOS (no Dock icon).
+
+    Returns True if the policy was applied, False otherwise (non-macOS, or
+    AppKit/PyObjC unavailable). Safe to call unconditionally.
+    """
+    if platform.system() != "Darwin":
+        return False
+    try:
+        # PyObjC ships transitively on macOS (PyWinCtl depends on it), but guard
+        # anyway so a missing AppKit never stops the tray from coming up.
+        from AppKit import NSApp, NSApplication
+        app = NSApp() if callable(NSApp) else NSApp
+        if app is None:
+            app = NSApplication.sharedApplication()
+        app.setActivationPolicy_(_NS_ACCESSORY)
+        return True
+    except Exception as exc:  # ImportError or any AppKit hiccup
+        log.debug("Could not set macOS accessory activation policy: %s", exc)
+        return False

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -87,15 +87,30 @@ if [ -z "$PY" ] && [ "$(uname -s)" = "Darwin" ] && [ -r /dev/tty ]; then
         *)  # default: Homebrew
             if ! command -v brew >/dev/null 2>&1; then
                 echo ">> Installing Homebrew (it may ask for your password)..." > /dev/tty
-                /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" < /dev/tty
+                if ! /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" < /dev/tty; then
+                    echo "!! Homebrew installation failed. Install it manually from https://brew.sh then re-run this installer." >&2
+                    exit 1
+                fi
                 # Put brew on PATH for the rest of this script (Apple Silicon vs Intel).
                 for brewbin in /opt/homebrew/bin/brew /usr/local/bin/brew; do
                     [ -x "$brewbin" ] && eval "$("$brewbin" shellenv)" && break
                 done
+                if ! command -v brew >/dev/null 2>&1; then
+                    echo "!! Homebrew installed but 'brew' is not on PATH. Open a new terminal and re-run this installer." >&2
+                    exit 1
+                fi
             fi
             echo ">> Installing Python via Homebrew..." > /dev/tty
-            brew install python
+            if ! brew install python; then
+                echo "!! 'brew install python' failed (see the brew output above). Resolve it, then re-run this installer." >&2
+                exit 1
+            fi
             PY="$(find_python || true)"
+            if [ -z "$PY" ]; then
+                echo "!! Python was installed via Homebrew but no 3.10+ interpreter is on PATH." >&2
+                echo "   Open a new terminal (so brew's bin dir is picked up) and re-run this installer." >&2
+                exit 1
+            fi
             ;;
     esac
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -58,8 +58,34 @@ for cand in python3.13 python3.12 python3.11 python3.10 python3 python; do
 done
 if [ -z "$PY" ]; then
     echo "!! PolyKybdHost requires Python 3.10 or newer, but none was found on PATH."
-    echo "   The macOS system python3 (Xcode Command Line Tools) is 3.9 and will not work."
-    echo "   Install a newer Python, e.g.:  brew install python"
+    case "$(uname -s)" in
+        Darwin)
+            echo "   The macOS system python3 (Xcode Command Line Tools) is 3.9 and will not work."
+            echo "   Install a newer Python, then re-run this installer:"
+            echo
+            if command -v brew >/dev/null 2>&1; then
+                echo "     brew install python        # Homebrew detected"
+            else
+                echo "     # Option A - Homebrew (recommended):"
+                echo "     /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\""
+                echo "     brew install python"
+                echo
+                echo "     # Option B - official installer: download from https://www.python.org/downloads/macos/"
+            fi
+            ;;
+        Linux)
+            echo "   Install Python 3.10+ with your distro's package manager, then re-run this installer:"
+            echo
+            echo "     sudo apt install python3 python3-venv     # Debian/Ubuntu"
+            echo "     sudo dnf install python3                   # Fedora/RHEL"
+            echo "     sudo pacman -S python                      # Arch"
+            echo
+            echo "   If your distro is too old to ship 3.10+, see https://www.python.org/downloads/"
+            ;;
+        *)
+            echo "   Install Python 3.10 or newer from https://www.python.org/downloads/ and re-run this installer."
+            ;;
+    esac
     exit 1
 fi
 echo ">> Using $PY ($("$PY" --version 2>&1))"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -44,9 +44,25 @@ fi
 cd "$TARGET_DIR"
 
 # --- python virtual environment ---------------------------------------------
-PY=python3
-command -v "$PY" >/dev/null 2>&1 || PY=python
-command -v "$PY" >/dev/null 2>&1 || { echo "!! Python 3 not found on PATH."; exit 1; }
+# PolyKybdHost needs Python 3.10+ (match statements, PEP 604 unions). Prefer an
+# explicitly-versioned interpreter so we don't silently build the venv on the
+# macOS system python3 (3.9, from the Xcode Command Line Tools), which can't run
+# the app. Fall back to bare python3/python only if it is new enough.
+PY=""
+for cand in python3.13 python3.12 python3.11 python3.10 python3 python; do
+    command -v "$cand" >/dev/null 2>&1 || continue
+    if "$cand" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 10) else 1)' 2>/dev/null; then
+        PY=$cand
+        break
+    fi
+done
+if [ -z "$PY" ]; then
+    echo "!! PolyKybdHost requires Python 3.10 or newer, but none was found on PATH."
+    echo "   The macOS system python3 (Xcode Command Line Tools) is 3.9 and will not work."
+    echo "   Install a newer Python, e.g.:  brew install python"
+    exit 1
+fi
+echo ">> Using $PY ($("$PY" --version 2>&1))"
 
 echo ">> Creating virtual environment in .venv"
 "$PY" -m venv .venv

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -48,14 +48,58 @@ cd "$TARGET_DIR"
 # explicitly-versioned interpreter so we don't silently build the venv on the
 # macOS system python3 (3.9, from the Xcode Command Line Tools), which can't run
 # the app. Fall back to bare python3/python only if it is new enough.
-PY=""
-for cand in python3.13 python3.12 python3.11 python3.10 python3 python; do
-    command -v "$cand" >/dev/null 2>&1 || continue
-    if "$cand" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 10) else 1)' 2>/dev/null; then
-        PY=$cand
-        break
-    fi
-done
+find_python() {  # echoes the first 3.10+ interpreter on PATH, or nothing
+    for cand in python3.13 python3.12 python3.11 python3.10 python3 python; do
+        command -v "$cand" >/dev/null 2>&1 || continue
+        if "$cand" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 10) else 1)' 2>/dev/null; then
+            echo "$cand"
+            return 0
+        fi
+    done
+    return 1
+}
+
+PY="$(find_python || true)"
+
+if [ -z "$PY" ] && [ "$(uname -s)" = "Darwin" ] && [ -r /dev/tty ]; then
+    # Interactive macOS fallback: offer to install Python 3.10+ for the user.
+    # Variant A (Homebrew) can be fully automated; variant B (python.org) is a
+    # GUI .pkg, so we point at it rather than driving it.
+    echo "!! PolyKybdHost requires Python 3.10 or newer, but none was found on PATH." > /dev/tty
+    echo "   The macOS system python3 (Xcode Command Line Tools) is 3.9 and will not work." > /dev/tty
+    echo > /dev/tty
+    echo "   Install options:" > /dev/tty
+    echo "     [A] Homebrew  - I can install it now (brew install python)" > /dev/tty
+    echo "     [B] python.org - download the .pkg yourself from https://www.python.org/downloads/macos/" > /dev/tty
+    echo "     [S] Skip       - abort and install Python manually" > /dev/tty
+    printf "   Choose [A/b/s]: " > /dev/tty
+    read -r choice < /dev/tty || choice=""
+    case "$(printf '%s' "$choice" | tr '[:upper:]' '[:lower:]')" in
+        b)
+            echo ">> Opening the python.org downloads page; re-run this installer after installing." > /dev/tty
+            command -v open >/dev/null 2>&1 && open "https://www.python.org/downloads/macos/" || true
+            exit 1
+            ;;
+        s)
+            echo ">> Skipping. Install Python 3.10+ and re-run this installer." > /dev/tty
+            exit 1
+            ;;
+        *)  # default: Homebrew
+            if ! command -v brew >/dev/null 2>&1; then
+                echo ">> Installing Homebrew (it may ask for your password)..." > /dev/tty
+                /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" < /dev/tty
+                # Put brew on PATH for the rest of this script (Apple Silicon vs Intel).
+                for brewbin in /opt/homebrew/bin/brew /usr/local/bin/brew; do
+                    [ -x "$brewbin" ] && eval "$("$brewbin" shellenv)" && break
+                done
+            fi
+            echo ">> Installing Python via Homebrew..." > /dev/tty
+            brew install python
+            PY="$(find_python || true)"
+            ;;
+    esac
+fi
+
 if [ -z "$PY" ]; then
     echo "!! PolyKybdHost requires Python 3.10 or newer, but none was found on PATH."
     case "$(uname -s)" in
@@ -63,15 +107,12 @@ if [ -z "$PY" ]; then
             echo "   The macOS system python3 (Xcode Command Line Tools) is 3.9 and will not work."
             echo "   Install a newer Python, then re-run this installer:"
             echo
-            if command -v brew >/dev/null 2>&1; then
-                echo "     brew install python        # Homebrew detected"
-            else
-                echo "     # Option A - Homebrew (recommended):"
+            echo "     # Option A - Homebrew (recommended):"
+            command -v brew >/dev/null 2>&1 || \
                 echo "     /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\""
-                echo "     brew install python"
-                echo
-                echo "     # Option B - official installer: download from https://www.python.org/downloads/macos/"
-            fi
+            echo "     brew install python"
+            echo
+            echo "     # Option B - official installer: https://www.python.org/downloads/macos/"
             ;;
         Linux)
             echo "   Install Python 3.10+ with your distro's package manager, then re-run this installer:"

--- a/tests/services/add_to_startup_test.py
+++ b/tests/services/add_to_startup_test.py
@@ -192,5 +192,46 @@ class RemoveAutostartTest(unittest.TestCase):
         startmenu.unlink.assert_not_called()
 
 
+class MacAutostartIdempotencyTest(unittest.TestCase):
+    """macOS must not re-register the LaunchAgent on every launch — doing so
+    re-triggers the "Background Items Added" notification (Ventura+). The plist
+    is only (re)written + reloaded when missing or its content changed."""
+
+    def _run(self, tmp, wrapper="/Users/x/.venv/wrap.sh"):
+        plist = Path(tmp) / "LaunchAgents" / "com.PolyHost.plist"
+        with mock.patch.object(add_to_startup.platform, "system", return_value="Darwin"), \
+             mock.patch.object(add_to_startup, "_macos_plist_path", return_value=plist), \
+             mock.patch.object(add_to_startup.subprocess, "run") as run:
+            add_to_startup.add_to_startup(Path(wrapper), "PolyHost", "/icon.png")
+        return plist, run
+
+    def test_first_launch_writes_and_loads(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            plist, run = self._run(tmp)
+            self.assertTrue(plist.exists())
+            # launchctl load was invoked exactly once (no unload — nothing prior).
+            run.assert_called_once()
+            self.assertEqual(run.call_args[0][0][:2], ["launchctl", "load"])
+
+    def test_second_identical_launch_is_noop(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            self._run(tmp)                  # first: registers
+            plist, run = self._run(tmp)     # second: identical content
+            self.assertTrue(plist.exists())
+            run.assert_not_called()         # no launchctl, no re-register
+
+    def test_changed_wrapper_reloads(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            self._run(tmp, wrapper="/Users/x/.venv/old.sh")
+            _, run = self._run(tmp, wrapper="/Users/x/.venv/new.sh")
+            # Path moved -> unload the stale one, then load the new one.
+            calls = [c[0][0][:2] for c in run.call_args_list]
+            self.assertIn(["launchctl", "unload"], calls)
+            self.assertIn(["launchctl", "load"], calls)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes a batch of issues hit while installing and running PolyKybdHost on macOS.

## Background

A fresh macOS install via the system `python3` (Python 3.9 from the Xcode Command Line Tools) failed with a cryptic `TypeError: unsupported operand type(s) for |` — the app requires Python 3.10+ (`match` statements, PEP 604 unions). On top of that, autostart crashed on clean accounts, the tray menu had a few oversized icons, the login item re-registered on every launch, and the app showed a Dock icon.

## Changes

**Python 3.10+ requirement (clear failure instead of cryptic crash)**
- `__main__.py`: stdlib-only, 3.9-parseable guard that exits early with actionable guidance when run on Python < 3.10, before any 3.10-only module is imported.
- `scripts/install.sh`: pick a 3.10+ interpreter (`python3.13`…`3.10`, then bare `python3`/`python` only if new enough) instead of silently building the venv on system 3.9. When none is found on macOS and a terminal is available, offer to install Python — `[A]` Homebrew (fully automated: bootstraps Homebrew if absent, puts `brew` on PATH for Apple Silicon/Intel, installs Python, re-detects), `[B]` python.org, `[S]` skip. Non-interactive runs and other platforms print platform-specific guidance.
- `README.md`: documents the requirement and the pyobjc/Command Line Tools slowness.

**macOS autostart**
- Create `~/Library/LaunchAgents` before writing the LaunchAgent plist — it doesn't exist on a fresh account (`FileNotFoundError` in the field).
- Make registration idempotent: skip entirely when the existing plist is identical; only rewrite + `launchctl (un)load` when missing or changed. Stops the "Background Items Added" notification firing on every launch (Ventura+).

**Tray-app UX**
- Hide the Dock icon: new `util/macos_ui.hide_dock_icon()` sets `NSApplicationActivationPolicyAccessory` (runtime `LSUIElement`) via PyObjC, guarded to no-op off macOS / without AppKit. Called from `PolyHost` and `PolyForwarder`.
- Fix oversized submenu icons (All PolyKybd Commands, Font Pack, Idle Anti-Burn-In, Fix Left/Right Side): the `icon-size: 64px` stylesheet meant for the language flag icons was inflating `addMenu(icon, title)` submenu glyphs instead. Scoped it to the language submenu where the flags actually live.

## Tests

- `tests/services/add_to_startup_test.py`: three new macOS idempotency cases (first launch registers, identical relaunch is a no-op, changed wrapper path reloads). Full file 21/21 green.

## Notes / not verified here

GUI and macOS-specific behavior (Dock icon, the `[A]` Homebrew install path, the tray icon sizing) couldn't be exercised in the headless Linux container — verified by static analysis + unit tests. Worth a quick look on a real Mac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LgQhVinQwKj7quuAALN5C5)_

## Summary by Sourcery

Enforce a Python 3.10+ runtime, harden macOS autostart behavior, and refine the tray-only app experience on macOS (Dock visibility and menu icon sizing).

New Features:
- Provide a macOS-safe utility to run the tray apps as Dock-less background/accessory applications.

Bug Fixes:
- Make macOS autostart registration idempotent and resilient to missing LaunchAgents directories, preventing repeated login item re-registration and related errors.

Enhancements:
- Improve interpreter discovery in the install script to require Python 3.10+ and offer guided installation paths on macOS, with clearer guidance for other platforms.
- Scope large icon styling to the language submenu so other tray menu items retain normal-sized icons.

Build:
- Update the install script to create virtual environments only with Python 3.10+ interpreters and optionally bootstrap Homebrew and Python on macOS when needed.

Documentation:
- Document the Python 3.10+ requirement, recommend using a Homebrew/python.org interpreter on macOS, and note pyobjc-related performance considerations during installation.

Tests:
- Add macOS-specific tests that verify the LaunchAgent plist is only written and (un)loaded when necessary, ensuring idempotent autostart behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added macOS tray behavior that hides the app from the Dock while keeping it available in the menu bar.
  * Improved installer and startup guidance to help users choose a compatible Python 3.10+ interpreter.

* **Bug Fixes**
  * Prevents the app from starting on unsupported Python versions with a clearer error message.
  * Makes macOS startup registration smarter by avoiding unnecessary reloads when nothing changed.

* **Documentation**
  * Updated setup instructions and platform notes with version-specific macOS guidance and faster install tips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->