### PR TITLE
macOS: fix hid import, stop per-launch prompts, diagnosable install

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,25 @@ crash with an `ImportError` if a dependency slipped through.
   (a transitive dependency of `PyWinCtl`), so the first `pip install` is much
   faster than compiling them against the Command Line Tools.
 
+  **macOS permissions (one-time).** The first time you run PolyKybd, macOS will
+  ask you to grant a couple of permissions in **System Settings → Privacy &
+  Security** (and prompt for your password to unlock that pane). This is a
+  one-time setup — it should not ask again on later launches:
+  - **Input Monitoring** — the PolyKybd is a keyboard, and macOS gates raw HID
+    access to keyboard-class devices behind this permission. PolyKybd needs it to
+    talk to the board over HID.
+  - **Accessibility** — PolyKybd types Unicode characters into the OS (the
+    composition feature) and reads the active window to switch layouts; macOS
+    requires Accessibility for both.
+
+  PolyKybd does **not** auto-change your macOS *system language* by default —
+  that path uses `languagesetup` with administrator rights and would prompt for
+  your password on every connect. Opt in with the `macos_native_set_language`
+  setting if you want it; otherwise use the keyboard's own language switching.
+  If macOS asks for permissions on *every* launch (not just once), make sure you
+  always start the app the same way (e.g. via the installed autostart entry), as
+  macOS ties each grant to the exact launching binary.
+
 ## Running
 
 ```bash

--- a/polyhost/device/hid_helper.py
+++ b/polyhost/device/hid_helper.py
@@ -7,6 +7,31 @@ from typing import Any
 if platform.system() == 'Windows':
     import ctypes
     ctypes.CDLL(os.path.dirname(os.path.realpath(__file__)) + '\\win-hidapi-0-15\\hidapi.dll')
+elif platform.system() == 'Darwin':
+    # The `hid` package loads libhidapi by *leaf* name ("libhidapi.dylib"), but
+    # macOS's default dyld search path excludes Homebrew's lib dirs
+    # (/opt/homebrew/lib on Apple Silicon, /usr/local/lib on Intel) and SIP
+    # strips DYLD_* env vars, so a brew-installed hidapi is invisible to the
+    # import. Pre-load it by absolute path here (mirrors the Windows DLL load
+    # above): once the image is in the process, `hid`'s leaf-name dlopen resolves
+    # to it. Best-effort — if nothing is found, the import below still raises the
+    # helpful "brew install hidapi" message. Absolute paths (not env vars) so it
+    # also works under launchd autostart, where HOMEBREW_PREFIX isn't set.
+    import ctypes
+    import glob as _glob
+    _dirs = ["/opt/homebrew/lib", "/opt/homebrew/opt/hidapi/lib",
+             "/usr/local/lib", "/usr/local/opt/hidapi/lib"]
+    _brew = os.environ.get("HOMEBREW_PREFIX")
+    if _brew:
+        _dirs.insert(0, os.path.join(_brew, "lib"))
+    for _d in _dirs:
+        _hits = _glob.glob(os.path.join(_d, "libhidapi*.dylib"))
+        if _hits:
+            try:
+                ctypes.CDLL(_hits[0])
+                break
+            except OSError:
+                pass
 try:
     import hid
 except ImportError:

--- a/polyhost/device/hid_helper.py
+++ b/polyhost/device/hid_helper.py
@@ -7,35 +7,70 @@ from typing import Any
 if platform.system() == 'Windows':
     import ctypes
     ctypes.CDLL(os.path.dirname(os.path.realpath(__file__)) + '\\win-hidapi-0-15\\hidapi.dll')
-elif platform.system() == 'Darwin':
-    # The `hid` package loads libhidapi by *leaf* name ("libhidapi.dylib"), but
-    # macOS's default dyld search path excludes Homebrew's lib dirs
-    # (/opt/homebrew/lib on Apple Silicon, /usr/local/lib on Intel) and SIP
-    # strips DYLD_* env vars, so a brew-installed hidapi is invisible to the
-    # import. Pre-load it by absolute path here (mirrors the Windows DLL load
-    # above): once the image is in the process, `hid`'s leaf-name dlopen resolves
-    # to it. Best-effort — if nothing is found, the import below still raises the
-    # helpful "brew install hidapi" message. Absolute paths (not env vars) so it
-    # also works under launchd autostart, where HOMEBREW_PREFIX isn't set.
+
+
+def _import_hid():
+    """Import the `hid` package, working around macOS not finding a
+    Homebrew-installed libhidapi.
+
+    `hid` loads the native library by *leaf* name
+    (``ctypes.cdll.LoadLibrary("libhidapi.dylib")``), but recent macOS / Python
+    framework builds don't search Homebrew's lib dirs (``/usr/local/lib`` on
+    Intel, ``/opt/homebrew/lib`` on Apple Silicon) by default, so a
+    brew-installed hidapi is invisible and the import fails. ``find_library``
+    *does* resolve the absolute path, so on a first-attempt failure we patch the
+    leaf-name load to use that path and retry. Pre-loading the dylib by absolute
+    path does NOT work — dyld won't match an already-loaded image for a leaf name
+    it can't otherwise find (verified on macOS Ventura + python.org 3.14). Runs in
+    every process that touches the device (GUI and headless daemon alike)."""
+    try:
+        import hid
+        return hid
+    except ImportError:
+        if platform.system() != 'Darwin':
+            print(_HIDAPI_MISSING_HELP)
+            raise
+
     import ctypes
-    import glob as _glob
-    _dirs = ["/opt/homebrew/lib", "/opt/homebrew/opt/hidapi/lib",
-             "/usr/local/lib", "/usr/local/opt/hidapi/lib"]
-    _brew = os.environ.get("HOMEBREW_PREFIX")
-    if _brew:
-        _dirs.insert(0, os.path.join(_brew, "lib"))
-    for _d in _dirs:
-        _hits = _glob.glob(os.path.join(_d, "libhidapi*.dylib"))
-        if _hits:
-            try:
-                ctypes.CDLL(_hits[0])
+    import ctypes.util
+    import glob
+    import importlib
+
+    path = ctypes.util.find_library("hidapi")
+    if not path:
+        for d in ("/opt/homebrew/lib", "/opt/homebrew/opt/hidapi/lib",
+                  "/usr/local/lib", "/usr/local/opt/hidapi/lib"):
+            hits = sorted(glob.glob(os.path.join(d, "libhidapi*.dylib")))
+            if hits:
+                path = hits[0]
                 break
-            except OSError:
-                pass
-try:
-    import hid
-except ImportError:
-    print("""Library hidapi missing. Please Install:
+
+    if path:
+        loader = ctypes.cdll
+        original = loader.LoadLibrary
+
+        def _redirect(name):
+            # hid tries several leaf names; send any libhidapi* request to the
+            # resolved absolute path so the leaf-name search can't miss it.
+            if name and os.path.basename(name).startswith("libhidapi"):
+                name = path
+            return original(name)
+
+        loader.LoadLibrary = _redirect
+        try:
+            return importlib.import_module("hid")
+        except ImportError:
+            pass
+        finally:
+            loader.LoadLibrary = original
+
+    # Nothing worked — print the install help and fail.
+    print(_HIDAPI_MISSING_HELP)
+    raise ImportError("Unable to load the hidapi native library "
+                      "(is it installed? on macOS: brew install hidapi)")
+
+
+_HIDAPI_MISSING_HELP = """Library hidapi missing. Please Install:
 
     Arch Linux
     ==========
@@ -95,8 +130,9 @@ except ImportError:
     Binary distributions are available.
 
     pkg install -g 'py3*-hid'
-    """)
-    raise
+    """
+
+hid = _import_hid()
 
 PERMISSION_MSG = f"""It looks like you do not have permission to access the device.
 Please run the following commands, then reconnect the device and restart the application:

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -465,6 +465,11 @@ class PolyHost(QApplication):
                 self.helper = LinuxGnomeInputHelper()
         elif platform.system() == "Darwin":
             self.helper = MacOSInputHelper()
+            self.log.info(
+                "macOS: PolyKybd needs 'Input Monitoring' (HID access to the "
+                "keyboard) and 'Accessibility' (Unicode input + window tracking) "
+                "in System Settings > Privacy & Security. This is a one-time grant "
+                "(see the macOS permissions note in the README).")
 
         if not self.helper:
             self.log.error("Unsupported OS! Exiting...")
@@ -725,7 +730,10 @@ class PolyHost(QApplication):
             # so a keyboard-side switch would leave the tray menu stale.
             self.update_ui_on_lang_change(kb_lang)
             lang, country = get_lang_and_country(kb_lang)
-            success, msg = self.helper.set_language(lang, country)
+            if self._should_auto_switch_os_language():
+                success, msg = self.helper.set_language(lang, country)
+            else:
+                success, msg = True, "OS-language auto-switch disabled"
             if success:
                 data = self.overlay_handler.get_overlay_data()
                 if data:
@@ -736,6 +744,18 @@ class PolyHost(QApplication):
                 self.log.warning("%s (%s)", warning, msg)
             self.current_lang = kb_lang
             self.icon_manager.set_idle()
+
+    def _should_auto_switch_os_language(self):
+        """Whether to auto-switch the OS input language to match the keyboard on
+        (re)connect. On macOS this runs `languagesetup` via osascript `with
+        administrator privileges`, which pops a password dialog every time — and
+        the keyboard's lang code never equals macOS's KeyboardLayout Name, so the
+        sync re-fires on every launch. Default it off there (opt in via the
+        `macos_native_set_language` setting); the explicit "Change System Input
+        Language" debug action still works. Other platforms keep prior behavior."""
+        if platform.system() == "Darwin":
+            return bool(self.poly_settings.get("macos_native_set_language"))
+        return True
 
     # ------------------------------------------------------------------
     # Client mode (H4a): render from the daemon's status_changed events
@@ -776,7 +796,10 @@ class PolyHost(QApplication):
             self.icon_manager.set_thinking()
             self.update_ui_on_lang_change(lang)
             lng, country = get_lang_and_country(lang)
-            success, msg = self.helper.set_language(lng, country)
+            if self._should_auto_switch_os_language():
+                success, msg = self.helper.set_language(lng, country)
+            else:
+                success, msg = True, "OS-language auto-switch disabled"
             if not success:
                 warning = f"Could not change OS language {lang}."
                 self.icon_manager.set_warning(warning, 5000)
@@ -881,14 +904,6 @@ class PolyHost(QApplication):
                 # once the firmware version is known, by which point the rest of
                 # the menu already exists, so insert rather than add.
                 self.keeb_lang_menu = QMenu(title)
-                # Enlarge only the language menu's icons — the per-language flag
-                # icons are the ones worth showing big. Applying this on the whole
-                # tray menu (the old behaviour) instead inflated the submenu-title
-                # glyphs (All Commands / Font Pack / Idle Anti-Burn-In / Fix
-                # Left-Right Side), which looked oversized next to the normal
-                # action icons. Scoping it here keeps those at the default size.
-                self.keeb_lang_menu.setStyleSheet(
-                    "QMenu {icon-size: 64px;} QMenu::item {icon-size: 64px; background: transparent;}")
                 self.keeb_lang_menu.menuAction().setIcon(get_icon("language.svg"))
                 actions = menu.actions()
                 if len(actions) > 1:

--- a/polyhost/input/macos_helper.py
+++ b/polyhost/input/macos_helper.py
@@ -8,6 +8,7 @@ lang_re = re.compile(r"^\s*\d+\) (.*)$")
 
 class MacOSInputHelper(InputHelper):
     def __init__(self):
+        super().__init__()   # sets self.log (the set_language/get_languages error paths use it)
         self.list = None
 
     def get_languages(self):

--- a/polyhost/services/add_to_startup.py
+++ b/polyhost/services/add_to_startup.py
@@ -330,6 +330,23 @@ def _install_windows_autostart(execute, win_args, working_dir, icon_path):
 # Unix / macOS helpers (wrapper-script based)
 # ---------------------------------------------------------------------------
 
+def _write_executable_if_changed(path, content):
+    """Write `content` to `path` (mode 0755) only if it differs from what's
+    already there. Rewriting the launcher on every startup changes the file a
+    registered macOS LaunchAgent points at, which makes macOS re-fire its
+    "Background Items Added" notification each launch — so leave it untouched
+    when nothing changed."""
+    path = Path(path)
+    try:
+        if path.read_text(encoding="utf-8") == content:
+            return False
+    except OSError:
+        pass
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+    return True
+
+
 def create_unix_shell_wrapper(venv_path, script_path, args="", wrapper_path=None):
     """Create a shell launcher that activates the venv and runs the app."""
     venv_path = Path(venv_path)
@@ -345,9 +362,8 @@ cd "{script_path.parent.parent}"
 python -m polyhost {args}
 """
 
-    wrapper_path.write_text(shell_content, encoding="utf-8")
-    wrapper_path.chmod(0o755)
-    print(f"Unix shell wrapper script created at: {wrapper_path}")
+    if _write_executable_if_changed(wrapper_path, shell_content):
+        print(f"Unix shell wrapper script created at: {wrapper_path}")
     return wrapper_path
 
 def create_linux_shortcut_desktop(app_name, autostart_dir, wrapper_path, icon_path):
@@ -536,9 +552,8 @@ def setup_autostart_for_app(script_path, args):
         execute_this = script_path.parent / "start_polyhost.sh"
         content = (f'#!/bin/bash\ncd "{script_path.parent.parent}"\n'
                    f'"{python_exe}" -m polyhost {joined_args}\n')
-        execute_this.write_text(content, encoding="utf-8")
-        execute_this.chmod(0o755)
-        print(f"Unix simple wrapper created at: {execute_this}")
+        if _write_executable_if_changed(execute_this, content):
+            print(f"Unix simple wrapper created at: {execute_this}")
 
     add_to_startup(execute_this, APP_NAME, icon_path)
     status = get_autostart_status()

--- a/polyhost/settings.py
+++ b/polyhost/settings.py
@@ -53,6 +53,13 @@ class PolySettings:
             "dev_mock_overlay_mru_cache_enabled": True,
             "dev_run_window_detection_if_not_connected_to_poly_kybd": False,
             "dev_win_native_set_language": False,
+            # macOS: auto-switch the system input language to match the keyboard
+            # on (re)connect. Off by default because it runs `languagesetup` via
+            # osascript "with administrator privileges" — a password prompt on
+            # every launch (the keyboard lang code never equals macOS's layout
+            # name, so the sync re-fires each connect). Turn on only if you want
+            # PolyKybd to drive the macOS system language.
+            "macos_native_set_language": False,
             # Daemon-by-default (headless-core H4b): when True, a plain GUI
             # launch runs the operational core in a separate headless daemon and
             # attaches this GUI to it as a client (spawning the daemon if none is

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -187,8 +187,25 @@ esac
 
 launch_app() {
     echo ">> Starting PolyKybd..."
-    nohup .venv/bin/python -m polyhost >/dev/null 2>&1 &
-    echo ">> PolyKybd started (PID $!); it also registers itself to autostart at login."
+    # Capture startup output to a log instead of /dev/null: if the app exits
+    # immediately (a missing dep, a startup crash) the user otherwise just sees
+    # an empty menu bar with no clue why. The log makes that diagnosable.
+    launch_log="$(pwd)/polyhost_launch.log"
+    nohup .venv/bin/python -m polyhost >"$launch_log" 2>&1 &
+    app_pid=$!
+    echo ">> PolyKybd started (PID $app_pid); it also registers itself to autostart at login."
+    # Give it a moment to fail fast, then check it's still alive.
+    sleep 3
+    if kill -0 "$app_pid" 2>/dev/null; then
+        if [ "$(uname -s)" = "Darwin" ]; then
+            echo ">> Look for the PolyKybd icon in the macOS menu bar (top-right) — it is a"
+            echo "   menu-bar app, so it does not appear in the Dock."
+        fi
+    else
+        echo "!! PolyKybd exited right after starting. Last lines of $launch_log:"
+        tail -n 15 "$launch_log" 2>/dev/null | sed 's/^/   | /'
+        echo ">> Fix the problem above, then relaunch with:  $RUN_HINT"
+    fi
 }
 
 echo ""


### PR DESCRIPTION
## Summary

Follow-up macOS fixes on top of the merged #79, addressing the install/runtime issues found while testing on hardware.

## Changes

- **`hid` import on macOS** (`hid_helper.py`): load Homebrew's `libhidapi` and redirect the loader to the resolved absolute path, so `import hid` works without the system libs being on the default search path.
- **No more per-launch prompts** (`host.py`, `macos_helper.py`, `settings.py`, `add_to_startup.py`):
  - The OS-language auto-switch (`languagesetup` via `osascript … with administrator privileges`) is now gated off by default behind a new `macos_native_set_language` setting — it no longer fires the "osascript wants to make changes" admin prompt **twice on every start**.
  - The autostart wrapper (`start_polyhost.sh`) and launchd plist are now written **only when their content actually changes**, so macOS stops re-firing the "Background Items Added" notification on every launch (one settling write, then silence).
- **Language menu icons** (`host.py`): render at normal size instead of oversized.
- **Diagnosable install** (`scripts/install.sh`): surface the real failure instead of silencing the app launch.
- **Docs** (`README.md`): document the macOS HID permissions / Homebrew `hidapi` requirement.

## Testing

- Verified on macOS hardware: `import hid` succeeds; the two `osascript` admin prompts no longer appear; "Background Items Added" fires once after the settling write, then no longer recurs across repeated restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LgQhVinQwKj7quuAALN5C5)_

## Summary by Sourcery

Improve macOS installation and runtime behavior, especially around HID loading, permissions, autostart noise, and diagnosability.

Bug Fixes:
- Ensure the Python `hid` package can load a Homebrew-installed `libhidapi` on macOS by resolving and redirecting the native library load.
- Prevent repeated macOS admin prompts and background-item notifications by gating OS language auto-switching behind a setting and only rewriting startup wrappers when their content changes.

Enhancements:
- Add a user-facing log message on macOS describing the required Input Monitoring and Accessibility permissions.
- Remove oversized styling for language menu icons so tray menu visuals match normal icon sizing.
- Make the install script capture and surface app startup failures via a log file for easier diagnosis.

Documentation:
- Document macOS HID permissions, the Homebrew `hidapi` requirement, and the behavior of macOS permissions and language auto-switching in the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer macOS setup guidance for first-run permissions and optional system-language switching.
  * Introduced a new setting to control whether macOS should automatically match the keyboard language.
  * Startup now keeps a launch log and shows helpful error details if the app exits immediately.

* **Bug Fixes**
  * Improved reliability of macOS input support by handling native library loading more robustly.
  * Reduced unnecessary rewriting of startup wrapper scripts when nothing has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->