### PR TITLE
Rename manufacturer PolyFabriq → PolyTasten

### DIFF
--- a/polyhost/device/hid_fw_up.py
+++ b/polyhost/device/hid_fw_up.py
@@ -25,7 +25,7 @@ _RP2040_SRAM_END    = 0x20042000   # 264 KB SRAM
 # evolvable.
 _POLYKYBD_SIGNATURES = (
     "PolyKybd".encode('utf-16-le'),   # USB product string  (keyboard_name = "PolyKybd Split72")
-    "Poly".encode('utf-16-le'),       # USB manufacturer prefix (manufacturer = "PolyFabriq")
+    "Poly".encode('utf-16-le'),       # USB manufacturer prefix (manufacturer = "PolyTasten")
     # b'polykybd',           # QMK_KEYBOARD path prefix (ASCII, variant-agnostic) -- commented out: path may change
 )
 
@@ -103,7 +103,7 @@ def validate_polykybd_firmware(fw_bytes: (bytes, bytearray)) -> tuple[bool, str]
     """Check that fw_bytes contains at least one PolyKybd-specific signature.
 
     QMK embeds the USB product name ("PolyKybd Split72") and manufacturer
-    ("PolyFabriq") as UTF-16LE USB string descriptors.  The signatures table
+    ("PolyTasten") as UTF-16LE USB string descriptors.  The signatures table
     carries one entry per logical check so each can be updated independently.
 
     The full firmware image must be passed; a 264-byte header is not enough.

--- a/tests/device/hid_fw_up_test.py
+++ b/tests/device/hid_fw_up_test.py
@@ -246,7 +246,7 @@ class TestValidateRp2040Firmware(unittest.TestCase):
 class TestValidatePolykybdFirmware(unittest.TestCase):
     """Two separate signature entries, each tested independently:
       - "PolyKybd" UTF-16LE  covers the USB product string "PolyKybd Split72"
-      - "Poly" UTF-16LE      covers the USB manufacturer prefix "PolyFabriq"
+      - "Poly" UTF-16LE      covers the USB manufacturer prefix "PolyTasten"
     Either match is sufficient; tests verify each path independently.
     """
 
@@ -257,9 +257,9 @@ class TestValidatePolykybdFirmware(unittest.TestCase):
         self.assertEqual(msg, '')
 
     def test_manufacturer_string_detected(self):
-        # "PolyFabriq" UTF-16LE contains the "Poly" prefix, so it matches the
+        # "PolyTasten" UTF-16LE contains the "Poly" prefix, so it matches the
         # manufacturer signature entry
-        ok, _ = validate_polykybd_firmware(_make_fw("PolyFabriq".encode('utf-16-le')))
+        ok, _ = validate_polykybd_firmware(_make_fw("PolyTasten".encode('utf-16-le')))
         self.assertTrue(ok)
 
     def test_manufacturer_prefix_alone_is_sufficient(self):


### PR DESCRIPTION
## Summary

Rebrand the (not-yet-registered) company name from **PolyFabriq** to **PolyTasten**.

## Changes
- `polyhost/device/hid_fw_up.py` — comments referencing the USB manufacturer name.
- `tests/device/hid_fw_up_test.py` — comments + the sample string in the manufacturer-prefix match test.

No functional change here: firmware validation matches the variant-agnostic `"Poly"` USB-descriptor prefix, which still covers `PolyTasten`.

## Verification
- `tests.device.hid_fw_up_test` passes (83 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014SxvJKToHaLeWBnmEAGqHd)_

## Summary by Sourcery

Update USB manufacturer naming references from PolyFabriq to PolyTasten across firmware validation code and tests.

Enhancements:
- Align firmware signature comments with the new PolyTasten manufacturer name.

Tests:
- Adjust firmware validation tests to use the PolyTasten manufacturer string while preserving the existing prefix-based matching behavior.