### PR TITLE
security(FW-2): send the firmware image signature during flash

### DIFF
--- a/polyhost/device/hid_fw_up.py
+++ b/polyhost/device/hid_fw_up.py
@@ -1,4 +1,5 @@
 import binascii
+import os
 import struct
 import time
 
@@ -8,6 +9,9 @@ CMD_FW_UP_BEGIN       = 0x40
 CMD_FW_UP_CHUNK       = 0x41
 CMD_FW_UP_COMMIT      = 0x42
 CMD_FW_UP_APPLY       = 0x44
+CMD_FW_UP_SIGNATURE   = 0x45   # FW-2: 64-byte Ed25519 image signature, sent in 2 parts before COMMIT
+
+FW_SIG_LEN = 64
 
 FW_UP_CHUNK_SIZE  = 56
 FW_UP_VERSION_LEN = 16
@@ -339,11 +343,36 @@ def flash_firmware(hid, bin_path: str, progress_cb=None, cancel_flag: list = Non
                f"(waiting {int(pause * 1000)} ms)…")
         time.sleep(pause)
 
+    # -- FW_UP_SIGNATURE (FW-2) --
+    # If a detached signature sits next to the .bin (<bin>.sig, 64 raw Ed25519
+    # bytes), send it before COMMIT so the firmware can verify image authenticity
+    # against its embedded public key. Sent in two 32-byte parts (64 bytes don't
+    # fit one HID report). Best-effort: firmware without signing support NACKs the
+    # unknown command and flashes unsigned, so a NACK here is not fatal.
+    sig_path = bin_path + ".sig"
+    if os.path.exists(sig_path):
+        try:
+            with open(sig_path, 'rb') as f:
+                sig = f.read()
+        except OSError:
+            sig = b''
+        if len(sig) == FW_SIG_LEN:
+            report(97, "Sending image signature…")
+            for part in (0, 1):
+                pkt = (bytearray([HID_POLYKYBD, CMD_FW_UP_SIGNATURE, part])
+                       + sig[part * 32:part * 32 + 32])
+                hid.send_and_read(pkt, timeout=2000)  # NACK on older firmware is fine
+        else:
+            report(97, f"Ignoring {os.path.basename(sig_path)} — "
+                       f"expected {FW_SIG_LEN} bytes, got {len(sig)}.")
+
     # -- FW_UP_COMMIT --
     # COMMIT verifies the running CRC32 the keyboard accumulated while it staged
     # the image; it does NOT apply/activate the image or reboot.  The new firmware
     # is stored and CRC-checked in the staging region but the keyboard keeps
     # running its current firmware — activation is a separate, future step.
+    # (FW-2: the firmware also verifies the Ed25519 signature here — currently
+    # warn-only, so an unsigned/old image still commits.)
     report(98, "Verifying the staged image (CRC32)…")
     pkt = bytearray([HID_POLYKYBD, CMD_FW_UP_COMMIT])
     ok, reply = hid.send_and_read(pkt, timeout=5000)

--- a/polyhost/device/hid_fw_up.py
+++ b/polyhost/device/hid_fw_up.py
@@ -351,20 +351,25 @@ def flash_firmware(hid, bin_path: str, progress_cb=None, cancel_flag: list = Non
     # unknown command and flashes unsigned, so a NACK here is not fatal.
     sig_path = bin_path + ".sig"
     if os.path.exists(sig_path):
+        sig = None
         try:
             with open(sig_path, 'rb') as f:
                 sig = f.read()
-        except OSError:
-            sig = b''
-        if len(sig) == FW_SIG_LEN:
-            report(97, "Sending image signature…")
-            for part in (0, 1):
-                pkt = (bytearray([HID_POLYKYBD, CMD_FW_UP_SIGNATURE, part])
-                       + sig[part * 32:part * 32 + 32])
-                hid.send_and_read(pkt, timeout=2000)  # NACK on older firmware is fine
-        else:
-            report(97, f"Ignoring {os.path.basename(sig_path)} — "
-                       f"expected {FW_SIG_LEN} bytes, got {len(sig)}.")
+        except OSError as e:
+            # Distinguish a real I/O failure (permissions, FS error) from a
+            # missing/short signature so the operator isn't told "got 0 bytes".
+            report(97, f"Could not read {os.path.basename(sig_path)}: {e} — flashing unsigned.")
+        if sig is not None:
+            half = FW_SIG_LEN // 2   # one 32-byte HID report per half of the 64-byte sig
+            if len(sig) == FW_SIG_LEN:
+                report(97, "Sending image signature…")
+                for part in (0, 1):
+                    pkt = (bytearray([HID_POLYKYBD, CMD_FW_UP_SIGNATURE, part])
+                           + sig[part * half:part * half + half])
+                    hid.send_and_read(pkt, timeout=2000)  # NACK on older firmware is fine
+            else:
+                report(97, f"Ignoring {os.path.basename(sig_path)} — "
+                           f"expected {FW_SIG_LEN} bytes, got {len(sig)}.")
 
     # -- FW_UP_COMMIT --
     # COMMIT verifies the running CRC32 the keyboard accumulated while it staged

--- a/tests/device/hid_fw_up_test.py
+++ b/tests/device/hid_fw_up_test.py
@@ -34,6 +34,8 @@ from polyhost.device.hid_fw_up import (
     CMD_FW_UP_CHUNK,
     CMD_FW_UP_COMMIT,
     CMD_FW_UP_APPLY,
+    CMD_FW_UP_SIGNATURE,
+    FW_SIG_LEN,
     FW_UP_CHUNK_SIZE,
     FW_UP_VERSION_LEN,
     FW_UP_MAX_SIZE,
@@ -1075,6 +1077,97 @@ class TestApplyStagedFirmware(unittest.TestCase):
         hid = _make_hid([(True, _ack_reply(CMD_FW_UP_APPLY))], reconnect=True)
         ok, _ = apply_staged_firmware(hid)   # no callback — must not raise
         self.assertTrue(ok)
+
+
+# ---------------------------------------------------------------------------
+# flash_firmware — FW-2 image signature (CMD_FW_UP_SIGNATURE)
+# ---------------------------------------------------------------------------
+
+def _flash_hid_signed(fw: bytes):
+    """Mock HID ACKing BEGIN + N*CHUNK + 2*SIGNATURE + COMMIT."""
+    n = _chunks(fw)
+    return _make_hid(
+        [(True, _ack_reply(CMD_FW_UP_BEGIN))] +
+        [(True, _ack_reply(CMD_FW_UP_CHUNK))] * n +
+        [(True, _ack_reply(CMD_FW_UP_SIGNATURE))] * 2 +
+        [(True, _ack_reply(CMD_FW_UP_COMMIT))]
+    )
+
+
+def _sig_packets(hid):
+    """The CMD_FW_UP_SIGNATURE packets sent to a mock hid, in order."""
+    return [c.args[0] for c in hid.send_and_read.call_args_list
+            if len(c.args[0]) >= 2 and c.args[0][1] == CMD_FW_UP_SIGNATURE]
+
+
+class TestFlashFirmwareSignature(unittest.TestCase):
+
+    def test_signature_sent_in_two_parts_when_sidecar_present(self):
+        fw = _make_polykybd_fw()
+        path = _write_bin(fw)
+        sig = bytes(range(64))
+        with open(path + '.sig', 'wb') as f:
+            f.write(sig)
+        try:
+            hid = _flash_hid_signed(fw)
+            ok, _ = flash_firmware(hid, path)
+            self.assertTrue(ok)
+            pkts = _sig_packets(hid)
+            self.assertEqual(len(pkts), 2)               # one report per 32-byte half
+            self.assertEqual(pkts[0][2], 0)              # part 0
+            self.assertEqual(bytes(pkts[0][3:35]), sig[:32])
+            self.assertEqual(pkts[1][2], 1)              # part 1
+            self.assertEqual(bytes(pkts[1][3:35]), sig[32:])
+        finally:
+            os.remove(path + '.sig')
+            os.remove(path)
+
+    def test_no_signature_sent_without_sidecar(self):
+        fw = _make_polykybd_fw()
+        path = _write_bin(fw)
+        try:
+            hid = _flash_hid(fw)   # no SIGNATURE entries in the side-effect list
+            ok, _ = flash_firmware(hid, path)
+            self.assertTrue(ok)
+            self.assertEqual(_sig_packets(hid), [])
+        finally:
+            os.remove(path)
+
+    def test_wrong_length_sidecar_is_ignored(self):
+        fw = _make_polykybd_fw()
+        path = _write_bin(fw)
+        with open(path + '.sig', 'wb') as f:
+            f.write(b'\x01' * 10)   # not 64 bytes
+        try:
+            hid = _flash_hid(fw)   # no SIGNATURE entries — none should be sent
+            ok, _ = flash_firmware(hid, path)
+            self.assertTrue(ok)
+            self.assertEqual(_sig_packets(hid), [])
+        finally:
+            os.remove(path + '.sig')
+            os.remove(path)
+
+    def test_signature_nack_is_not_fatal(self):
+        # Older firmware NACKs the unknown signature command; the flash must still
+        # succeed (best-effort, warn-only).
+        fw = _make_polykybd_fw()
+        path = _write_bin(fw)
+        with open(path + '.sig', 'wb') as f:
+            f.write(bytes(64))
+        try:
+            n = _chunks(fw)
+            hid = _make_hid(
+                [(True, _ack_reply(CMD_FW_UP_BEGIN))] +
+                [(True, _ack_reply(CMD_FW_UP_CHUNK))] * n +
+                [(True, _nack_reply(CMD_FW_UP_SIGNATURE))] * 2 +
+                [(True, _ack_reply(CMD_FW_UP_COMMIT))]
+            )
+            ok, _ = flash_firmware(hid, path)
+            self.assertTrue(ok)
+            self.assertEqual(len(_sig_packets(hid)), 2)
+        finally:
+            os.remove(path + '.sig')
+            os.remove(path)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Host companion to the firmware Ed25519 verify (qmk_firmware PR on branch `claude/fw2-firmware-signing`). When a detached signature sits next to the `.bin` (`<bin>.sig`, 64 raw Ed25519 bytes — produced by the firmware repo's `sign_firmware.py` / the release-signing step), `flash_firmware()` now sends it over HID (`CMD_FW_UP_SIGNATURE 0x45`) in two 32-byte parts just before COMMIT, so the keyboard can verify image authenticity against its embedded public key.

**Backward compatible / best-effort:** the signature is sent only when the sidecar exists and is exactly 64 bytes, and a NACK from firmware without signing support is non-fatal (the image flashes unsigned, as today). No protocol bump.

## Testing

`tests/device/hid_fw_up_test.py` — new coverage:
- signature sent in two correct parts when the sidecar is present;
- not sent without it;
- wrong-length sidecar ignored;
- a firmware NACK doesn't fail the flash.

Full fw-update suite green (123 tests across `hid_fw_up`, `poly_core_fw_update`, `control_server`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NinUrR5rxUWk1w9RKz5unE)_

## Summary by Sourcery

Send optional Ed25519 firmware image signatures alongside HID firmware updates for verification while keeping flashing backward compatible.

New Features:
- Add support for sending a 64-byte detached firmware image signature over HID (CMD_FW_UP_SIGNATURE) in two parts before COMMIT when a matching .sig sidecar file is present.

Enhancements:
- Log and ignore malformed or unreadable signature sidecar files while proceeding with an unsigned firmware flash.
- Treat signature command NACKs from older firmware as non-fatal so existing devices continue to flash successfully.

Tests:
- Add unit tests covering signature transmission, absence, wrong-length handling, and non-fatal NACK behavior during firmware flashing.