### PR TITLE
tools: keycap render fix + base-layer & language-layer demo GIFs

### DIFF
--- a/tools/gfx_font.py
+++ b/tools/gfx_font.py
@@ -71,10 +71,32 @@ def load_all_fonts(font_dir: str) -> list[GfxFont]:
         _parse_header(open(p, encoding='utf-8', errors='replace').read(),
                       bitmaps, glyph_arrays, raw_fonts)
 
-    used = os.path.join(font_dir, 'gfx_used_fonts.h')
-    order = re.search(r'ALL_FONTS\s*\[\]\s*=\s*\{(.*?)\};',
-                      open(used, encoding='utf-8').read(), re.S)
-    names = re.findall(r'&\s*(\w+)', order.group(1)) if order else list(raw_fonts)
+    # Font priority order (front-to-back, first match wins), mirroring the
+    # firmware's g_all_fonts = RESIDENT_FONTS ++ pack:
+    #   1. generated/all_fonts_order.json — the exact full global order (resident
+    #      + every pack bundle), emitted by generate_fonts.py. Preferred.
+    #   2. the RESIDENT_FONTS[] table in gfx_used_fonts.h (the font-pack split
+    #      renamed it from ALL_FONTS[]), then any remaining parsed fonts appended
+    #      so pack scripts still resolve after the resident set.
+    #   3. bare glob order (last resort).
+    # NOTE: matching only ALL_FONTS used to silently fail after the RESIDENT_FONTS
+    # rename, dropping to glob order — which sorted a stray 56px FreeSansBold24pt
+    # to index 0, so every ASCII letter rendered in that giant font (oversized
+    # keycaps). Keep this resilient to the table name.
+    names = None
+    order_json = os.path.join(font_dir, 'generated', 'all_fonts_order.json')
+    if os.path.exists(order_json):
+        import json
+        names = json.load(open(order_json, encoding='utf-8')).get('order')
+    if not names:
+        used = os.path.join(font_dir, 'gfx_used_fonts.h')
+        order = re.search(r'(?:RESIDENT|ALL)_FONTS\s*\[\]\s*=\s*\{(.*?)\};',
+                          open(used, encoding='utf-8').read(), re.S) if os.path.exists(used) else None
+        if order:
+            names = re.findall(r'&\s*(\w+)', order.group(1))
+            names += [n for n in raw_fonts if n not in names]   # append pack fonts after resident
+        else:
+            names = list(raw_fonts)
 
     out = []
     for n in names:

--- a/tools/lang_demo.py
+++ b/tools/lang_demo.py
@@ -225,11 +225,13 @@ class LangBoard(KleRenderer):
         d.rounded_rectangle(rect, radius=radius, fill=body, outline=self.theme.key_outline, width=2)
 
         kx, ky, kw, kh = rect[0], rect[1], rect[2] - rect[0], rect[3] - rect[1]
-        # OLED panel: landscape 72:40, filled to most of the keycap with an even
-        # margin, then CENTRED on both axes (the tuner look). Fit by width, and by
-        # height if that would overflow.
+        # OLED panel: landscape 72:40. The physical display is the SAME size on
+        # every keycap, so size it from the 1U dimension (the key HEIGHT — every key
+        # is 1U tall) and NOT from this key's width. A wider key (1.25U Shift/Tab/…)
+        # therefore shows an identical-size OLED with more bezel on the sides — it
+        # must never be stretched to fill the extra width. Centred on both axes.
         im = max(3, U // 12)
-        disp_w = max(2, kw - 2 * im)
+        disp_w = max(2, kh - 2 * im)
         disp_h = int(disp_w * (OLED_H / OLED_W))
         if disp_h > kh - 2 * im:
             disp_h = max(2, kh - 2 * im)

--- a/tools/lang_demo.py
+++ b/tools/lang_demo.py
@@ -36,7 +36,7 @@ from PIL import Image, ImageDraw, ImageFont
 
 import oled_preview as op
 from oled_preview import Lang, Renderer, load_named_glyphs
-from gfx_font import load_all_fonts, OLED_W, OLED_H
+from gfx_font import load_all_fonts, OLED_W, OLED_H, BUFFER_X, BASELINE
 from kle_render import KleRenderer, KeyContent, Theme
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -66,15 +66,75 @@ LANG_NAMES = {
     "iu-CA": "Inuktitut", "cr-CA": "Cree",
 }
 
-# Short labels for the non-letter keys so the board still reads as a keyboard
-# (the language render only covers letter/number/symbol keys).
-MOD_LABELS = {
-    "KC_LSFT": "Shift", "KC_RSFT": "Shift", "KC_LCTL": "Ctrl", "KC_RCTL": "Ctrl",
-    "KC_LALT": "Alt", "KC_RALT": "AltGr", "KC_LGUI": "Gui", "KC_RGUI": "Gui",
-    "KC_SPC": "Space", "KC_SPACE": "Space", "KC_ENT": "Enter", "KC_ENTER": "Enter",
-    "KC_BSPC": "Bksp", "KC_TAB": "Tab", "KC_ESC": "Esc", "KC_DEL": "Del",
-    "KC_CAPS": "Caps",
+# QMK keycode aliases → the canonical name used by op.ROW (the language LUT keys)
+# and by keycode_helper.c's switch. The keymap uses short aliases (KC_BSLS) while
+# those tables use the long form (KC_BACKSLASH), so normalise before matching.
+KC_ALIAS = {
+    # symbol keys that belong to the language LUT (op.ROW)
+    "KC_NUBS": "KC_NONUS_BACKSLASH", "KC_BSLS": "KC_BACKSLASH",
+    "KC_SCLN": "KC_SEMICOLON", "KC_NUHS": "KC_NONUS_HASH",
+    "KC_GRV": "KC_GRAVE", "KC_COMM": "KC_COMMA", "KC_MINS": "KC_MINUS",
+    "KC_EQL": "KC_EQUAL", "KC_QUOT": "KC_QUOTE", "KC_SLSH": "KC_SLASH",
+    "KC_LBRC": "KC_LBRC", "KC_RBRC": "KC_RBRC",
+    # special keys → the name keycode_helper.c switches on
+    "KC_ESC": "KC_ESCAPE", "KC_BSPC": "KC_BACKSPACE", "KC_ENT": "KC_ENTER",
+    "KC_DEL": "KC_DELETE", "KC_SPC": "KC_SPACE",
+    "KC_LCTL": "KC_LEFT_CTRL", "KC_RCTL": "KC_RIGHT_CTRL",
+    "KC_LALT": "KC_LEFT_ALT", "KC_RALT": "KC_RIGHT_ALT",
+    "KC_LWIN": "KC_LGUI", "KC_RWIN": "KC_RGUI", "KC_LCMD": "KC_LGUI",
 }
+
+
+def normalize_kc(tok: str) -> str:
+    return KC_ALIAS.get(tok, tok)
+
+
+def _split_ternary(expr: str):
+    """Split `cond ? A : B` at the top level (the ' : ' separator never appears
+    inside the U"..."/macro branches we care about). Returns (cond, A, B) or None."""
+    if ' ? ' not in expr:
+        return None
+    cond, rest = expr.split(' ? ', 1)
+    if ' : ' not in rest:
+        return None
+    a, b = rest.split(' : ', 1)
+    return cond.strip(), a.strip(), b.strip()
+
+
+def _pick_default_branch(expr: str) -> str:
+    """Resolve keycode_helper.c's conditional returns for the *resting* keycap:
+    state_flags = 0 (so MORE_TEXT / MODS_AS_TEXT off → the icon branch, not text),
+    num_lock / caps_lock off. Picks the branch a freshly-booted key would draw."""
+    t = _split_ternary(expr)
+    if t is None:
+        return expr.strip()
+    cond, a, b = t
+    # evaluate the condition under the resting state
+    if '!= 0' in cond:        val = False     # (state_flags & X) != 0  -> 0 != 0 -> false
+    elif '== 0' in cond:      val = True
+    elif cond.startswith('!'): val = True      # !state.num_lock -> !false -> true
+    else:                     val = False      # state.caps_lock / state.num_lock -> false
+    return _pick_default_branch(a if val else b)
+
+
+def parse_static_text_map(keycode_helper_c: str) -> dict:
+    """token -> the icon/text expression keycode_to_static_text() returns at rest.
+    Handles C fall-through (several `case`s sharing one `return`)."""
+    text = strip_c_comments(open(keycode_helper_c, encoding='utf-8').read())
+    body = text[text.index('switch (keycode)'):]
+    out, pending = {}, []
+    for m in re.finditer(r'case\s+([^:]+?)\s*:|return\s+(.*?);', body, re.S):
+        label, ret = m.group(1), m.group(2)
+        if label is not None:
+            pending.append(label.strip())
+        elif ret is not None:
+            # Keep the raw expression — spaces INSIDE a U"..." literal are the
+            # firmware's horizontal offset (U"  " ICON_UP), so don't collapse them.
+            branch = _pick_default_branch(ret.strip())
+            for lbl in pending:
+                out[lbl] = branch
+            pending = []
+    return out
 
 
 def strip_c_comments(s: str) -> str:
@@ -125,11 +185,11 @@ def parse_base_layer_keycodes(keymap_c: str) -> list[str]:
 
 
 def display_keycode(tok: str) -> str:
-    """Reduce a keymap token to a plain keycode where possible.
+    """Reduce a keymap token to the keycode whose legend shows on the base layer.
 
     LT(layer, KC_X) / MT(mod, KC_X) carry an inner tap keycode — use it so a
-    home-row-mod 'A' still letters as A. MO()/TO()/custom keycodes have no letter.
-    """
+    home-row-mod 'A' still letters as A. MO()/TO()/OSL() etc. stay whole (they
+    have their own entries in keycode_to_static_text)."""
     m = re.match(r'(?:LT|MT|LM)\([^,]+,\s*([^)]+)\)', tok)
     if m:
         return m.group(1).strip()
@@ -187,19 +247,38 @@ class LangBoard(KleRenderer):
         return tile
 
 
-def build_frame(L, R, matrix_kc, lang) -> dict[str, KeyContent]:
+def render_static(L, R, expr) -> Image.Image:
+    """Draw a keycode_to_static_text() expression (icons + control codes) into a
+    72x40 'L' image at the firmware's BUFFER_X / baseline origin (poly_keymap.c
+    draws static text at `BUFFER_X, 23`; the strings carry their own offsets)."""
+    img = Image.new('L', (OLED_W, OLED_H), 0)
+    px = img.load()
+    def sp(vx, vy):
+        if 0 <= vx < OLED_W and 0 <= vy < OLED_H:
+            px[vx, vy] = 255
+    cps = L.resolve(expr)
+    if cps:
+        R.draw(sp, cps, BUFFER_X, BASELINE)
+    return img
+
+
+def build_frame(L, R, matrix_kc, lang, static_map) -> dict[str, KeyContent]:
     out: dict[str, KeyContent] = {}
     for mp, tok in matrix_kc.items():
-        kc = display_keycode(tok)
-        if kc in op.ROW:
-            img = op.render_key(L, R, lang, kc, shift=False, caps=False)  # 72x40 'L'
-            c = KeyContent()
-            c._oled = img
-            out[mp] = c
-        elif kc in MOD_LABELS:
-            out[mp] = KeyContent(label=MOD_LABELS[kc])
+        kc = normalize_kc(display_keycode(tok))
+        whole = normalize_kc(tok)
+        if kc in op.ROW:                       # letter / number / symbol (language LUT)
+            img = op.render_key(L, R, lang, kc, shift=False, caps=False)
+        elif whole in static_map:              # MO(_FL0), TO(_EMJ), … (match the wrapped token)
+            img = render_static(L, R, static_map[whole])
+        elif kc in static_map:                 # KC_LSFT, KC_ENTER, KC_SPACE, arrows, …
+            img = render_static(L, R, static_map[kc])
         else:
             out[mp] = KeyContent(dim=True)
+            continue
+        c = KeyContent()
+        c._oled = img
+        out[mp] = c
     return out
 
 
@@ -239,6 +318,7 @@ def main():
         raise SystemExit(f"layout/keymap length mismatch: {len(matrices)} vs {len(kcs)}")
     matrix_kc = dict(zip(matrices, kcs))
 
+    static_map = parse_static_text_map(os.path.join(pk, 'keycode_helper.c'))
     named = load_named_glyphs(os.path.join(pk, 'lang', 'named_glyphs.h'))
     L = Lang(os.path.join(pk, 'lang', 'lang_lut.xlsx'), named)
     unknown = [x for x in langs if x not in L.langs]
@@ -262,7 +342,7 @@ def main():
 
     imgs, durations = [], []
     for li, lang in enumerate(langs):
-        board = renderer.render_frame(build_frame(L, R, matrix_kc, lang))
+        board = renderer.render_frame(build_frame(L, R, matrix_kc, lang, static_map))
         frame = Image.new('RGB', (board.width, board.height + CAP_H), Theme().bg)
         frame.paste(board, (0, 0))
         d = ImageDraw.Draw(frame)

--- a/tools/lang_demo.py
+++ b/tools/lang_demo.py
@@ -46,13 +46,13 @@ HOME = os.path.dirname(HOST_REPO)
 LAYOUT_NAME = "LAYOUT_left_right_stacked"
 BASE_LAYER = "_L0"
 
-# A visually diverse tour, en-US first as orientation, ending on the four newest
-# scripts (Pashto, Cherokee, Inuktitut, Cree — each a font the board only learned
-# recently). Override with --langs.
+# A visually diverse tour, en-US first as orientation, then the newest Canadian
+# Aboriginal Syllabics + Cherokee, an Indian script, Thai, Georgian, an African
+# script, then a spread of more scripts. Override with --langs.
 DEFAULT_TOUR = [
-    "en-US", "el-GR", "ru-RU", "ka-GE", "hy-AM", "he-IL", "ar-SA", "fa-IR",
-    "hi-IN", "bn-IN", "ta-IN", "te-IN", "th-TH", "am-ET", "zh-TW", "hw-US",
-    "ps-AF", "ck-US", "iu-CA", "cr-CA",
+    "en-US", "cr-CA", "ck-US", "hi-IN", "th-TH", "ka-GE", "am-ET", "hy-AM",
+    "el-GR", "he-IL", "ar-EG", "ru-RU", "ta-IN", "ps-AF", "iu-CA", "zh-TW",
+    "ko-KR", "fa-IR", "bn-IN", "yo-NG",
 ]
 
 # Pretty captions; falls back to the code itself for anything not listed.
@@ -63,7 +63,8 @@ LANG_NAMES = {
     "bn-IN": "Bengali", "ta-IN": "Tamil", "te-IN": "Telugu", "th-TH": "Thai",
     "am-ET": "Amharic (Ethiopic)", "zh-TW": "Bopomofo (Zhuyin)",
     "hw-US": "Hawaiian", "ps-AF": "Pashto", "ck-US": "Cherokee",
-    "iu-CA": "Inuktitut", "cr-CA": "Cree",
+    "iu-CA": "Inuktitut", "cr-CA": "Cree", "ar-EG": "Arabic (Egypt)",
+    "ko-KR": "Korean", "yo-NG": "Yoruba",
 }
 
 # QMK keycode aliases → the canonical name used by op.ROW (the language LUT keys)

--- a/tools/lang_demo.py
+++ b/tools/lang_demo.py
@@ -209,8 +209,13 @@ class LangBoard(KleRenderer):
         if img is None:
             return super()._oled_buffer(c)
         one = img.point(lambda v: 255 if v >= 128 else 0).convert('1')
-        rgb = Image.new('RGB', (OLED_W, OLED_H), self.theme.oled_bg)
-        rgb.paste(Image.new('RGB', (OLED_W, OLED_H), self.theme.oled_on), (0, 0), one)
+        on, bg = self.theme.oled_on, self.theme.oled_bg
+        if c.invert:   # kdisp_invert: brief lit-background / dark-glyph press flash
+            rgb = Image.new('RGB', (OLED_W, OLED_H), on)
+            rgb.paste(Image.new('RGB', (OLED_W, OLED_H), bg), (0, 0), one)
+        else:
+            rgb = Image.new('RGB', (OLED_W, OLED_H), bg)
+            rgb.paste(Image.new('RGB', (OLED_W, OLED_H), on), (0, 0), one)
         return rgb
 
     def _key_tile(self, p, c: KeyContent) -> Image.Image:

--- a/tools/lang_demo.py
+++ b/tools/lang_demo.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Render an animated GIF of the PolyKybd BASE layer cycling through languages.
+
+The companion to ``emoji_demo.py`` (which walks the emoji layer): this one keeps
+the board on the base ``[_L0]`` layer and swaps the *language* every frame, so you
+can watch the keycaps re-letter themselves — en-US, then a tour of scripts.
+
+Each keycap is drawn by ``oled_preview.render_key()`` — the pixel-exact firmware
+draw (base glyph + the small Shift / AltGr previews) from ``lang/lang_lut.xlsx``
+and the generated GFX fonts — and laid onto the real board geometry with
+``kle_render.KleRenderer``. So a frame matches what the hardware actually shows on
+that layout.
+
+Data sources (all read live, so the demo always matches the firmware):
+  * KLE geometry        polyhost/res/polykybd-split72.json
+  * arg-index -> matrix  split72/keyboard.json (LAYOUT_left_right_stacked)
+  * matrix  -> keycode   split72/keymaps/default/keymap.c  ([_L0] layer)
+  * per-key glyphs       lang/lang_lut.xlsx + lang/named_glyphs.h
+
+Usage:
+    python tools/lang_demo.py                         # default ~20-language tour
+    python tools/lang_demo.py --langs en-US,el-GR,ka-GE,ps-AF
+    python tools/lang_demo.py --out /tmp/langs.gif --unit 80 --settle 1600
+    python tools/lang_demo.py --still                 # also write a PNG of frame 0
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+
+import math
+
+from PIL import Image, ImageDraw, ImageFont
+
+import oled_preview as op
+from oled_preview import Lang, Renderer, load_named_glyphs
+from gfx_font import load_all_fonts, OLED_W, OLED_H
+from kle_render import KleRenderer, KeyContent, Theme
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+HOST_REPO = os.path.dirname(HERE)
+HOME = os.path.dirname(HOST_REPO)
+
+LAYOUT_NAME = "LAYOUT_left_right_stacked"
+BASE_LAYER = "_L0"
+
+# A visually diverse tour, en-US first as orientation, ending on the four newest
+# scripts (Pashto, Cherokee, Inuktitut, Cree — each a font the board only learned
+# recently). Override with --langs.
+DEFAULT_TOUR = [
+    "en-US", "el-GR", "ru-RU", "ka-GE", "hy-AM", "he-IL", "ar-SA", "fa-IR",
+    "hi-IN", "bn-IN", "ta-IN", "te-IN", "th-TH", "am-ET", "zh-TW", "hw-US",
+    "ps-AF", "ck-US", "iu-CA", "cr-CA",
+]
+
+# Pretty captions; falls back to the code itself for anything not listed.
+LANG_NAMES = {
+    "en-US": "English", "el-GR": "Greek", "ru-RU": "Russian (Cyrillic)",
+    "ka-GE": "Georgian", "hy-AM": "Armenian", "he-IL": "Hebrew",
+    "ar-SA": "Arabic", "fa-IR": "Persian", "hi-IN": "Hindi (Devanagari)",
+    "bn-IN": "Bengali", "ta-IN": "Tamil", "te-IN": "Telugu", "th-TH": "Thai",
+    "am-ET": "Amharic (Ethiopic)", "zh-TW": "Bopomofo (Zhuyin)",
+    "hw-US": "Hawaiian", "ps-AF": "Pashto", "ck-US": "Cherokee",
+    "iu-CA": "Inuktitut", "cr-CA": "Cree",
+}
+
+# Short labels for the non-letter keys so the board still reads as a keyboard
+# (the language render only covers letter/number/symbol keys).
+MOD_LABELS = {
+    "KC_LSFT": "Shift", "KC_RSFT": "Shift", "KC_LCTL": "Ctrl", "KC_RCTL": "Ctrl",
+    "KC_LALT": "Alt", "KC_RALT": "AltGr", "KC_LGUI": "Gui", "KC_RGUI": "Gui",
+    "KC_SPC": "Space", "KC_SPACE": "Space", "KC_ENT": "Enter", "KC_ENTER": "Enter",
+    "KC_BSPC": "Bksp", "KC_TAB": "Tab", "KC_ESC": "Esc", "KC_DEL": "Del",
+    "KC_CAPS": "Caps",
+}
+
+
+def strip_c_comments(s: str) -> str:
+    s = re.sub(r'/\*.*?\*/', '', s, flags=re.S)
+    s = re.sub(r'//[^\n]*', '', s)
+    return s
+
+
+def _split_args(inner: str) -> list[str]:
+    args, depth, cur = [], 0, ''
+    for ch in inner:
+        if ch == '(':
+            depth += 1; cur += ch
+        elif ch == ')':
+            depth -= 1; cur += ch
+        elif ch == ',' and depth == 0:
+            args.append(cur.strip()); cur = ''
+        else:
+            cur += ch
+    if cur.strip():
+        args.append(cur.strip())
+    return args
+
+
+def parse_layout_matrix(keyboard_json: str) -> list[str]:
+    d = json.load(open(keyboard_json, encoding='utf-8'))
+    lay = d['layouts'][LAYOUT_NAME]['layout']
+    return [f"{k['matrix'][0]},{k['matrix'][1]}" for k in lay]
+
+
+def parse_base_layer_keycodes(keymap_c: str) -> list[str]:
+    """arg index -> the raw keycode token for the [_L0] layer."""
+    text = strip_c_comments(open(keymap_c, encoding='utf-8').read())
+    i = text.index(f'[{BASE_LAYER}]')
+    k = text.index('(', text.index(LAYOUT_NAME, i))
+    depth, end = 0, None
+    for m in range(k, len(text)):
+        if text[m] == '(':
+            depth += 1
+        elif text[m] == ')':
+            depth -= 1
+            if depth == 0:
+                end = m
+                break
+    if end is None:
+        raise SystemExit(f"unbalanced {LAYOUT_NAME} parentheses for {BASE_LAYER}")
+    return [t.strip() for t in _split_args(text[k + 1:end])]
+
+
+def display_keycode(tok: str) -> str:
+    """Reduce a keymap token to a plain keycode where possible.
+
+    LT(layer, KC_X) / MT(mod, KC_X) carry an inner tap keycode — use it so a
+    home-row-mod 'A' still letters as A. MO()/TO()/custom keycodes have no letter.
+    """
+    m = re.match(r'(?:LT|MT|LM)\([^,]+,\s*([^)]+)\)', tok)
+    if m:
+        return m.group(1).strip()
+    return tok
+
+
+class LangBoard(KleRenderer):
+    """KleRenderer that blits a pre-rendered 72x40 OLED ('L' image stashed on the
+    KeyContent as ._oled) and frames each key like the keycap tuner — the OLED as a
+    clean, vertically-centred panel filling most of the keycap (even margins all
+    round), instead of the small top strip + striped bezel the emoji demo uses.
+    That stops the firmware-size legend from looking cramped/oversized at the top."""
+
+    def _oled_buffer(self, c: KeyContent):
+        img = getattr(c, '_oled', None)
+        if img is None:
+            return super()._oled_buffer(c)
+        one = img.point(lambda v: 255 if v >= 128 else 0).convert('1')
+        rgb = Image.new('RGB', (OLED_W, OLED_H), self.theme.oled_bg)
+        rgb.paste(Image.new('RGB', (OLED_W, OLED_H), self.theme.oled_on), (0, 0), one)
+        return rgb
+
+    def _key_tile(self, p, c: KeyContent) -> Image.Image:
+        U = self.unit
+        tw, th = max(1, round(p['w'] * U)), max(1, round(p['h'] * U))
+        tile = Image.new('RGBA', (tw, th), (0, 0, 0, 0))
+        d = ImageDraw.Draw(tile)
+        pad = self.key_pad
+        rect = [pad, pad, tw - pad - 1, th - pad - 1]
+        radius = max(2, int(min(tw, th) * 0.10))
+        body = self.theme.key_dim_bg if c.dim else self.theme.key_bg
+        d.rounded_rectangle(rect, radius=radius, fill=body, outline=self.theme.key_outline, width=2)
+
+        kx, ky, kw, kh = rect[0], rect[1], rect[2] - rect[0], rect[3] - rect[1]
+        # OLED panel: landscape 72:40, filled to most of the keycap with an even
+        # margin, then CENTRED on both axes (the tuner look). Fit by width, and by
+        # height if that would overflow.
+        im = max(3, U // 12)
+        disp_w = max(2, kw - 2 * im)
+        disp_h = int(disp_w * (OLED_H / OLED_W))
+        if disp_h > kh - 2 * im:
+            disp_h = max(2, kh - 2 * im)
+            disp_w = int(disp_h * (OLED_W / OLED_H))
+        dx = kx + (kw - disp_w) // 2
+        dy = ky + (kh - disp_h) // 2
+        d.rounded_rectangle([dx, dy, dx + disp_w, dy + disp_h], radius=2,
+                            fill=self.theme.oled_dim_bg if c.dim else self.theme.oled_bg)
+
+        oled = self._oled_buffer(c)
+        if oled is not None:
+            tile.paste(oled.resize((disp_w, disp_h), Image.NEAREST), (dx, dy))
+
+        if c.selected:
+            d.rounded_rectangle(rect, radius=radius, outline=self.theme.selected, width=3)
+        return tile
+
+
+def build_frame(L, R, matrix_kc, lang) -> dict[str, KeyContent]:
+    out: dict[str, KeyContent] = {}
+    for mp, tok in matrix_kc.items():
+        kc = display_keycode(tok)
+        if kc in op.ROW:
+            img = op.render_key(L, R, lang, kc, shift=False, caps=False)  # 72x40 'L'
+            c = KeyContent()
+            c._oled = img
+            out[mp] = c
+        elif kc in MOD_LABELS:
+            out[mp] = KeyContent(label=MOD_LABELS[kc])
+        else:
+            out[mp] = KeyContent(dim=True)
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--qmk', default=os.path.join(HOME, 'qmk_firmware'))
+    ap.add_argument('--kle', default=os.path.join(HOST_REPO, 'polyhost', 'res', 'polykybd-split72.json'))
+    ap.add_argument('--out', default=os.path.join(HERE, 'out', 'lang_layer.gif'))
+    ap.add_argument('--langs', default=','.join(DEFAULT_TOUR),
+                    help='comma-separated language codes, first one shown first')
+    # Render each OLED near its native 72px (crisp), then LANCZOS-downscale the
+    # finished frames so the GIF stays a sane size without the blocky NEAREST
+    # look that a small per-key downscale produces.
+    ap.add_argument('--unit', type=int, default=104, help='pixels per key unit (supersample)')
+    ap.add_argument('--scale', type=float, default=0.72, help='final GIF scale factor (LANCZOS)')
+    ap.add_argument('--gap', type=int, default=14, help='gap between the two halves in px')
+    ap.add_argument('--margin', type=int, default=12, help='outer margin in px')
+    ap.add_argument('--exclude', default='3,7;8,0', help='matrix positions with no display (encoders)')
+    ap.add_argument('--settle', type=int, default=1400, help='ms each language is held')
+    ap.add_argument('--first-hold', type=int, default=2200, help='ms to hold en-US (orientation)')
+    ap.add_argument('--still', action='store_true', help='also write a still PNG of frame 0')
+    ap.add_argument('--no-bezel', action='store_true')
+    args = ap.parse_args()
+
+    op.OVERSHOOT = 0   # hardware-exact 72x40 keycap renders, no debug margin
+    exclude = {m.strip() for m in args.exclude.split(';') if m.strip()}
+    langs = [s.strip() for s in args.langs.split(',') if s.strip()]
+
+    pk = os.path.join(args.qmk, 'keyboards', 'handwired', 'polykybd')
+    keyboard_json = os.path.join(pk, 'split72', 'keyboard.json')
+    keymap_c = os.path.join(pk, 'split72', 'keymaps', 'default', 'keymap.c')
+
+    matrices = parse_layout_matrix(keyboard_json)
+    kcs = parse_base_layer_keycodes(keymap_c)
+    if len(matrices) != len(kcs):
+        raise SystemExit(f"layout/keymap length mismatch: {len(matrices)} vs {len(kcs)}")
+    matrix_kc = dict(zip(matrices, kcs))
+
+    named = load_named_glyphs(os.path.join(pk, 'lang', 'named_glyphs.h'))
+    L = Lang(os.path.join(pk, 'lang', 'lang_lut.xlsx'), named)
+    unknown = [x for x in langs if x not in L.langs]
+    if unknown:
+        raise SystemExit(f"unknown language(s): {unknown}\nhave {len(L.langs)} langs")
+    R = Renderer(load_all_fonts(os.path.join(pk, 'base', 'fonts')))
+    print(f"  {len(L.langs)} languages available, touring {len(langs)}")
+
+    renderer = LangBoard(json.load(open(args.kle, encoding='utf-8')),
+                         unit=args.unit, glyphs=None, bezel=not args.no_bezel,
+                         margin=args.margin, exclude=exclude, dither=False)
+    renderer.compact_halves(lambda mp: 'L' if int(mp.split(',')[0]) < 5 else 'R', gap_px=args.gap)
+
+    # Caption bar under the board.
+    try:
+        cap_font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", 26)
+        sub_font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 18)
+    except Exception:
+        cap_font = sub_font = ImageFont.load_default()
+    CAP_H = 52
+
+    imgs, durations = [], []
+    for li, lang in enumerate(langs):
+        board = renderer.render_frame(build_frame(L, R, matrix_kc, lang))
+        frame = Image.new('RGB', (board.width, board.height + CAP_H), Theme().bg)
+        frame.paste(board, (0, 0))
+        d = ImageDraw.Draw(frame)
+        name = LANG_NAMES.get(lang, lang)
+        title = f"{lang}"
+        d.text((14, board.height + 6), title, font=cap_font, fill=(255, 225, 0))
+        tw = d.textlength(title, font=cap_font)
+        d.text((14 + tw + 12, board.height + 14), name, font=sub_font, fill=(210, 210, 210))
+        prog = f"{li + 1}/{len(langs)}"
+        pw = d.textlength(prog, font=sub_font)
+        d.text((frame.width - pw - 14, board.height + 14), prog, font=sub_font, fill=(120, 120, 120))
+        imgs.append(frame)
+        durations.append(args.first_hold if li == 0 else args.settle)
+
+    if args.scale != 1.0:
+        size = (int(imgs[0].width * args.scale), int(imgs[0].height * args.scale))
+        imgs = [im.resize(size, Image.LANCZOS) for im in imgs]
+
+    if args.still:
+        png = os.path.splitext(args.out)[0] + '_still.png'
+        os.makedirs(os.path.dirname(os.path.abspath(png)), exist_ok=True)
+        imgs[0].save(png)
+        print(f"  wrote {png}")
+
+    pal = imgs[0].quantize(colors=128, method=Image.MEDIANCUT)
+    pimgs = [im.quantize(palette=pal, dither=Image.NONE) for im in imgs]
+    os.makedirs(os.path.dirname(os.path.abspath(args.out)), exist_ok=True)
+    pimgs[0].save(args.out, save_all=True, append_images=pimgs[1:],
+                  duration=durations, loop=0, optimize=True, disposal=2)
+    sz = os.path.getsize(args.out)
+    print(f"  wrote {args.out}  ({len(pimgs)} frames, {sz / 1024:.0f} KB, {imgs[0].width}x{imgs[0].height})")
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/lang_layer_demo.py
+++ b/tools/lang_layer_demo.py
@@ -321,11 +321,10 @@ def main():
 
     for r in range(nreg):
         pages = region_pages(off, r, spp)
-        if r == 0:
-            add(r, 0, HOLD)
-        else:
-            add(r, 0, FLASH, flash=tab_mx.get(r))    # press the tab
-            add(r, 0, SETTLE)
+        # Every region (America included) opens with a tab press-flash, so the GIF
+        # loops seamlessly — the first frame matches the rhythm of all the others.
+        add(r, 0, FLASH, flash=tab_mx.get(r))          # press the tab
+        add(r, 0, HOLD if r == 0 else SETTLE)          # America dwells a touch longer
         for pg in range(1, pages):
             add(r, pg - 1, FLASH, flash=next_mx)       # press ▶
             add(r, pg, SETTLE)

--- a/tools/lang_layer_demo.py
+++ b/tools/lang_layer_demo.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Animated GIF of the PolyKybd LANGUAGE-SELECTION layer (_LL), walking every
+region tab and page — the language-layer counterpart to emoji_demo.py.
+
+The language layer mirrors the emoji layer's look: a top row of continent
+"region" tabs (America / Europe / Mid East / Africa / Asia / Oceania), and within
+the active region a grid of flag-slot keys that page through that region's
+languages. Each slot draws its country flag (full keycap height) with the language
+code (e.g. en-US) running vertically up the right edge; the active language gets an
+inverted bar. The frame sequence presses each region tab in turn and pages through
+any region that spans more than one page (Europe), exactly like emj_draw_tab_*.
+
+Faithful to the firmware: geometry from the KLE + split72/keyboard.json, the
+[_LL] roles from keymap.c, the region tables from lang_layer.c, and the per-key
+draw mirrors render_lang_flag_key / render_lang_region_tab / kdisp_write_gfx_vtext
+(poly_keymap.c, disp_array.c). Flag glyphs come from the font pack (flag_fonts.h,
+FLAG_CP_BASE + LANG_* index); the tiny code label is the resident Tiny font.
+
+Usage:
+    python tools/lang_layer_demo.py
+    python tools/lang_layer_demo.py --out /tmp/ll.gif --unit 104 --settle 1600
+    python tools/lang_layer_demo.py --current en-US     # which language shows selected
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+
+from PIL import Image, ImageDraw, ImageFont
+
+import oled_preview as op
+from oled_preview import Lang, Renderer, load_named_glyphs
+from gfx_font import (load_all_fonts, _parse_header, GfxFont,
+                      OLED_W, OLED_H, BUFFER_X, BASELINE)
+from kle_render import KeyContent, Theme
+from lang_demo import (LangBoard, parse_layout_matrix, parse_static_text_map,
+                       normalize_kc, render_static, strip_c_comments)
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+HOST_REPO = os.path.dirname(HERE)
+HOME = os.path.dirname(HOST_REPO)
+
+SCREEN_WIDTH, SCREEN_HEIGHT = OLED_W, OLED_H        # 72 x 40, firmware names
+FLAG_CP_BASE = 0xE000
+FLAG_LEFT_X  = BUFFER_X - 2                          # poly_keymap.c
+LABEL_COL_X  = BUFFER_X + 66
+LAYOUT_NAME  = "LAYOUT_left_right_stacked"
+
+
+# ── firmware tables (lang_layer.c / .h) ──────────────────────────────────────
+def _int_list(block: str) -> list[int]:
+    return [int(x) for x in re.findall(r'\d+', block)]
+
+
+def parse_lang_layer(lang_layer_c: str, lang_layer_h: str):
+    c = strip_c_comments(open(lang_layer_c, encoding='utf-8').read())
+    off = _int_list(re.search(r'REGION_OFFSET\s*\[[^\]]*\]\s*=\s*\{(.*?)\}', c, re.S).group(1))
+    langs = _int_list(re.search(r'REGION_LANGS\s*\[[^\]]*\]\s*=\s*\{(.*?)\}', c, re.S).group(1))
+    labels = re.findall(r'[uU]"((?:\\.|[^"\\])*)"',
+                        re.search(r'REGION_LABELS\s*\[[^\]]*\]\s*=\s*\{(.*?)\}', c, re.S).group(1))
+    h = open(lang_layer_h, encoding='utf-8').read()
+    spp = int(re.search(r'#\s*define\s+LANG_SLOTS_PER_PAGE\s+(\d+)', h).group(1))
+    nreg = int(re.search(r'#\s*define\s+NUM_LANG_REGIONS\s+(\d+)', h).group(1))
+    return off, langs, labels, spp, nreg
+
+
+def region_count(off, r):        return off[r + 1] - off[r]
+def region_pages(off, r, spp):   return max(1, (region_count(off, r) + spp - 1) // spp)
+
+
+def slot_lang(off, langs, spp, region, page, slot):
+    """LANG_* index for a page-relative slot, or None past the region's end."""
+    local = page * spp + slot
+    return langs[off[region] + local] if local < region_count(off, region) else None
+
+
+# ── single-font loader for the standalone Tiny label font ────────────────────
+def load_one_font(header_path: str, name: str) -> GfxFont:
+    bm, ga, rf = {}, {}, {}
+    _parse_header(open(header_path, encoding='utf-8', errors='replace').read(), bm, ga, rf)
+    f = rf[name]
+    return GfxFont(name, bm[f['bmp']], ga[f['gly']], f['first'], f['last'], f['yAdvance'])
+
+
+# ── [_LL] layer roles ────────────────────────────────────────────────────────
+def parse_ll_roles(keymap_c: str) -> list[str]:
+    t = strip_c_comments(open(keymap_c, encoding='utf-8').read())
+    i = t.index('[_LL]')
+    k = t.index('(', t.index(LAYOUT_NAME, i))
+    depth, end = 0, None
+    for m in range(k, len(t)):
+        if t[m] == '(':
+            depth += 1
+        elif t[m] == ')':
+            depth -= 1
+            if depth == 0:
+                end = m
+                break
+    args, depth, cur = [], 0, ''
+    for ch in t[k + 1:end]:
+        if ch == '(':
+            depth += 1; cur += ch
+        elif ch == ')':
+            depth -= 1; cur += ch
+        elif ch == ',' and depth == 0:
+            args.append(cur.strip()); cur = ''
+        else:
+            cur += ch
+    if cur.strip():
+        args.append(cur.strip())
+    return args
+
+
+def _macro_n(tok: str, name: str):
+    m = re.match(rf'{name}\(\s*(\d+)\s*\)', tok)
+    return int(m.group(1)) if m else None
+
+
+# ── per-key OLED renderers (72x40 'L'), mirroring the firmware ────────────────
+def _blank():
+    return Image.new('L', (OLED_W, OLED_H), 0)
+
+
+def render_flag_key(g_all_fonts, tiny_font, lang_idx, code, selected) -> Image.Image:
+    """render_lang_flag_key: full-height country flag on the left + the language
+    code running vertically up the right edge (inverted bar when selected)."""
+    img = _blank()
+    px = img.load()
+    f = op.Renderer(g_all_fonts)._font(FLAG_CP_BASE + lang_idx)
+    if f is not None:
+        g = f.glyphs[FLAG_CP_BASE + lang_idx - f.first]
+        fw, fh = g['width'], g['height']
+        # content lands flush at FLAG_LEFT_X, vertically centred (taller-than-keycap
+        # flag clips top/bottom). Single-font draw → no baseline-align shift.
+        x0 = FLAG_LEFT_X - BUFFER_X                 # buffer -> viewport
+        y0 = (SCREEN_HEIGHT - fh) // 2
+        bo, bit, bits = g['bitmapOffset'], 0, 0
+        for gy in range(fh):
+            for gx in range(fw):
+                if (bit & 7) == 0:
+                    bits = f.bitmap[bo]; bo += 1
+                if bits & 0x80:
+                    vx, vy = x0 + gx, y0 + gy
+                    if 0 <= vx < OLED_W and 0 <= vy < OLED_H:
+                        px[vx, vy] = 255
+                bits = (bits << 1) & 0xFF; bit += 1
+    _vtext(px, tiny_font, LABEL_COL_X, code, selected)
+    return img
+
+
+def _vtext(px, font, col_x, text, selected):
+    """kdisp_write_gfx_vtext: glyphs rotated 90°, advancing upward; a selected
+    label draws dark on a full-height lit bar."""
+    cps = [ord(c) for c in text]
+    total, min_x = 0, 127
+    for cp in cps:
+        if not (font.first <= cp <= font.last):
+            continue
+        g = font.glyphs[cp - font.first]
+        min_x = min(min_x, col_x + g['yOffset'])
+        total += g['xAdvance']
+    if total <= 0:
+        return
+    top_y = (SCREEN_HEIGHT - total) // 2
+    if top_y + total > SCREEN_HEIGHT - 1:
+        top_y = SCREEN_HEIGHT - 1 - total
+    if selected:
+        bx = min_x - 3
+        for sx in range(bx, BUFFER_X + SCREEN_WIDTH):
+            for sy in range(0, SCREEN_HEIGHT):
+                vx = sx - BUFFER_X
+                if 0 <= vx < OLED_W and 0 <= sy < OLED_H:
+                    px[vx, sy] = 255
+    vcur = top_y + total
+    for cp in cps:
+        if not (font.first <= cp <= font.last):
+            continue
+        g = font.glyphs[cp - font.first]
+        w, h, xo, yo = g['width'], g['height'], g['xOffset'], g['yOffset']
+        bo, bit, bits = g['bitmapOffset'], 0, 0
+        for gy in range(h):
+            for gx in range(w):
+                if (bit & 7) == 0:
+                    bits = font.bitmap[bo]; bo += 1
+                if bits & 0x80:
+                    sx, sy = col_x + yo + gy, vcur - xo - gx
+                    vx = sx - BUFFER_X
+                    if 0 <= vx < OLED_W and 0 <= sy < OLED_H:
+                        px[vx, sy] = 0 if selected else 255
+                bits = (bits << 1) & 0xFF; bit += 1
+        vcur -= g['xAdvance']
+
+
+def _fill(px, bx, by, w, h, val=255):
+    for sx in range(bx, bx + w):
+        for sy in range(by, by + h):
+            vx = sx - BUFFER_X
+            if 0 <= vx < OLED_W and 0 <= sy < OLED_H:
+                px[vx, sy] = val
+
+
+def render_region_tab(R_tiny, tiny_font, label, active) -> Image.Image:
+    """render_lang_region_tab + lang_draw_tab_indicator/bottom: centred continent
+    label, with the active tab's 3-px frame or an inactive tab's bottom bar."""
+    img = _blank()
+    px = img.load()
+    cps = [ord(c) for c in label]
+    lo, hi = R_tiny.bounds(cps)
+    w = hi - lo
+    x = BUFFER_X + (SCREEN_WIDTH - w) // 2 - lo
+    R_tiny.draw(lambda vx, vy: px.__setitem__((vx, vy), 255)
+                if 0 <= vx < OLED_W and 0 <= vy < OLED_H else None, cps, x, 22)
+    if active:
+        _fill(px, BUFFER_X + 1, 1, SCREEN_WIDTH - 2, 1)
+        _fill(px, BUFFER_X + 2, 0, SCREEN_WIDTH - 4, 1)
+        _fill(px, BUFFER_X, 2, 3, SCREEN_HEIGHT - 2)
+        _fill(px, BUFFER_X + SCREEN_WIDTH - 2, 2, 3, SCREEN_HEIGHT - 2)
+    else:
+        _fill(px, BUFFER_X, SCREEN_HEIGHT - 3, SCREEN_WIDTH, 3)
+    return img
+
+
+# ── frame builder ────────────────────────────────────────────────────────────
+def build_frame(ctx, region, page, flash=None):
+    (roles, off, langs, labels, spp, nreg, L, R, g_all, tiny, R_tiny,
+     static_map, current_idx) = ctx
+    out = {}
+    for mp, tok in roles.items():
+        img = None
+        n = _macro_n(tok, 'LCAT')
+        if n is not None and n < nreg:
+            img = render_region_tab(R_tiny, tiny, labels[n], n == region)
+        elif (n := _macro_n(tok, 'LSLOT')) is not None:
+            li = slot_lang(off, langs, spp, region, page, n)
+            if li is not None:
+                img = render_flag_key(g_all, tiny, li, L.langs[li], li == current_idx)
+            else:
+                out[mp] = KeyContent(blank=True); continue
+        elif _macro_n(tok, 'LMRU') is not None:
+            out[mp] = KeyContent(blank=True); continue           # recents empty in a static demo
+        elif tok in ('KC_LANG_PAGE_PREV', 'KC_LANG_PAGE_NEXT'):
+            if region_pages(off, region, spp) > 1:
+                arrow = 'ICON_LEFT' if tok.endswith('PREV') else 'ICON_RIGHT'
+                img = render_static(L, R, f'U"  " {arrow}')
+            else:
+                out[mp] = KeyContent(blank=True); continue
+        else:
+            kc = normalize_kc(tok)
+            if kc in static_map:
+                img = render_static(L, R, static_map[kc])
+            else:
+                out[mp] = KeyContent(dim=True); continue
+        c = KeyContent(invert=(mp == flash))
+        c._oled = img
+        out[mp] = c
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--qmk', default=os.path.join(HOME, 'qmk_firmware'))
+    ap.add_argument('--kle', default=os.path.join(HOST_REPO, 'polyhost', 'res', 'polykybd-split72.json'))
+    ap.add_argument('--out', default=os.path.join(HERE, 'out', 'lang_layer_select.gif'))
+    ap.add_argument('--current', default='en-US', help='language shown as the active selection')
+    ap.add_argument('--unit', type=int, default=104)
+    ap.add_argument('--scale', type=float, default=0.72)
+    ap.add_argument('--gap', type=int, default=14)
+    ap.add_argument('--margin', type=int, default=12)
+    ap.add_argument('--exclude', default='3,7;8,0')
+    ap.add_argument('--settle', type=int, default=1500)
+    ap.add_argument('--still', action='store_true')
+    ap.add_argument('--no-bezel', action='store_true')
+    args = ap.parse_args()
+
+    op.OVERSHOOT = 0
+    exclude = {m.strip() for m in args.exclude.split(';') if m.strip()}
+    pk = os.path.join(args.qmk, 'keyboards', 'handwired', 'polykybd')
+
+    matrices = parse_layout_matrix(os.path.join(pk, 'split72', 'keyboard.json'))
+    role_list = parse_ll_roles(os.path.join(pk, 'split72', 'keymaps', 'default', 'keymap.c'))
+    if len(matrices) != len(role_list):
+        raise SystemExit(f"layout/keymap length mismatch: {len(matrices)} vs {len(role_list)}")
+    roles = dict(zip(matrices, role_list))
+
+    off, langs, labels, spp, nreg = parse_lang_layer(
+        os.path.join(pk, 'lang_layer.c'), os.path.join(pk, 'lang_layer.h'))
+    static_map = parse_static_text_map(os.path.join(pk, 'keycode_helper.c'))
+    named = load_named_glyphs(os.path.join(pk, 'lang', 'named_glyphs.h'))
+    L = Lang(os.path.join(pk, 'lang', 'lang_lut.xlsx'), named)
+    g_all = load_all_fonts(os.path.join(pk, 'base', 'fonts'))
+    R = Renderer(g_all)
+    tiny = load_one_font(os.path.join(pk, 'base', 'fonts', 'lang_label_font.h'),
+                         'NotoSans_Regular_Tiny_6pt7b')
+    R_tiny = Renderer([tiny])
+    current_idx = L.langs.index(args.current) if args.current in L.langs else -1
+    print(f"  {nreg} regions, {sum(region_count(off,r) for r in range(nreg))} langs, "
+          f"{spp} slots/page; flag font {'present' if any(f.first<=FLAG_CP_BASE<=f.last for f in g_all) else 'MISSING'}")
+
+    ctx = (roles, off, langs, labels, spp, nreg, L, R, g_all, tiny, R_tiny,
+           static_map, current_idx)
+
+    renderer = LangBoard(json.load(open(args.kle, encoding='utf-8')),
+                         unit=args.unit, glyphs=None, bezel=not args.no_bezel,
+                         margin=args.margin, exclude=exclude, dither=False)
+    renderer.compact_halves(lambda mp: 'L' if int(mp.split(',')[0]) < 5 else 'R', gap_px=args.gap)
+
+    # which physical key is each region tab / page-next (for the press flash)
+    tab_mx = {n: mp for mp, t in roles.items() if (n := _macro_n(t, 'LCAT')) is not None}
+    next_mx = next((mp for mp, t in roles.items() if t == 'KC_LANG_PAGE_NEXT'), None)
+
+    FLASH, SETTLE, HOLD = 90, args.settle, args.settle + 600
+    frames, durations, meta = [], [], []
+
+    def add(region, page, dur, flash=None):
+        frames.append(build_frame(ctx, region, page, flash))
+        durations.append(dur)
+        meta.append((region, page))
+
+    for r in range(nreg):
+        pages = region_pages(off, r, spp)
+        if r == 0:
+            add(r, 0, HOLD)
+        else:
+            add(r, 0, FLASH, flash=tab_mx.get(r))    # press the tab
+            add(r, 0, SETTLE)
+        for pg in range(1, pages):
+            add(r, pg - 1, FLASH, flash=next_mx)       # press ▶
+            add(r, pg, SETTLE)
+
+    try:
+        cap_font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", 26)
+        sub_font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 18)
+    except Exception:
+        cap_font = sub_font = ImageFont.load_default()
+    CAP_H = 52
+
+    imgs = []
+    for f, (region, page) in zip(frames, meta):
+        board = renderer.render_frame(f)
+        frame = Image.new('RGB', (board.width, board.height + CAP_H), Theme().bg)
+        frame.paste(board, (0, 0))
+        d = ImageDraw.Draw(frame)
+        title = labels[region]
+        d.text((14, board.height + 6), title, font=cap_font, fill=(255, 225, 0))
+        tw = d.textlength(title, font=cap_font)
+        sub = f"language select"
+        pages = region_pages(off, region, spp)
+        if pages > 1:
+            sub += f"   ·   page {page + 1}/{pages}"
+        d.text((14 + tw + 14, board.height + 14), sub, font=sub_font, fill=(210, 210, 210))
+        imgs.append(frame)
+
+    if args.scale != 1.0:
+        size = (int(imgs[0].width * args.scale), int(imgs[0].height * args.scale))
+        imgs = [im.resize(size, Image.LANCZOS) for im in imgs]
+    if args.still:
+        png = os.path.splitext(args.out)[0] + '_still.png'
+        os.makedirs(os.path.dirname(os.path.abspath(png)), exist_ok=True)
+        imgs[0].save(png); print(f"  wrote {png}")
+
+    pal = imgs[0].quantize(colors=128, method=Image.MEDIANCUT)
+    pimgs = [im.quantize(palette=pal, dither=Image.NONE) for im in imgs]
+    os.makedirs(os.path.dirname(os.path.abspath(args.out)), exist_ok=True)
+    pimgs[0].save(args.out, save_all=True, append_images=pimgs[1:],
+                  duration=durations, loop=0, optimize=True, disposal=2)
+    print(f"  wrote {args.out}  ({len(pimgs)} frames, {os.path.getsize(args.out)/1024:.0f} KB, "
+          f"{imgs[0].width}x{imgs[0].height})")
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -3,3 +3,4 @@
 # (e.g. into a venv) when generating demo GIFs.
 Pillow>=10
 fonttools>=4
+openpyxl>=3   # lang_demo.py / oled_preview.py read lang/lang_lut.xlsx


### PR DESCRIPTION
## Summary
Adds two keycap-demo GIF generators (base layer and language-selection layer) and
fixes a real font-loading bug in the shared render code they surfaced.

### 🐛 `gfx_font.py` — font ordering (the load-bearing fix)
`load_all_fonts()` grepped `gfx_used_fonts.h` for `ALL_FONTS[]`, but the font-pack
split renamed that table to `RESIDENT_FONTS[]`. The regex stopped matching and the
loader silently fell back to alphabetical glob order, sorting a stray 56px
`FreeSansBold24pt` to index 0 — so **every ASCII letter rendered in that giant
font**. This silently affected `oled_preview.py`, `emoji_demo.py`, and the keycap
tuner too (oversized legends).

Fix: prefer `generated/all_fonts_order.json` (the exact firmware global order:
resident ++ pack), fall back to a `(?:RESIDENT|ALL)_FONTS[]` regex (appending any
remaining parsed fonts after the resident set so pack scripts still resolve), then
bare glob. ASCII now resolves to `NotoSans_Regular_Base_14pt`.

### ✨ `tools/lang_demo.py` — base layer, cycling languages
Animated GIF of `[_L0]` re-lettering through a tour of languages (en-US first),
rendered on the real split72 board:
- Letters/numbers/symbols per language via `oled_preview.render_key`.
- **Special keys** (mods / arrows / layer / Space / Enter / …) draw their real
  firmware icons, parsed from `keycode_helper.c`'s `keycode_to_static_text()`
  (resting/icon branch). QMK keycode alias map so `KC_BSLS`/`KC_SCLN`/… match the
  language LUT.
- OLED drawn at a **fixed 72:40 size** on every key (sized from the 1U height), so
  a 1.25U key shows the same display with more bezel — never stretched.
- Supersample + LANCZOS downscale for crisp output; press-flash support.

### ✨ `tools/lang_layer_demo.py` — language-selection layer (_LL)
Animated GIF of the language picker, walking every continent region tab and paging
through multi-page regions (Europe), like the emoji demo. Each slot draws the
country flag at full keycap height + the language code running vertically up the
right edge; the active language gets the inverted bar, the active tab gets the 3px
frame, page arrows light when needed, and pressing a tab / page arrow briefly
inverts the keycap (`kdisp_invert`). America flashes at the start too so the loop
is seamless. Mirrors `render_lang_flag_key` / `render_lang_region_tab` /
`kdisp_write_gfx_vtext` and the `lang_layer.c` region tables.

### Chores
- `openpyxl` added to `tools/requirements.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018PywFJy5mVcS2BhuWMNtu6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GIF preview tools for the keyboard’s language views, including the main key layout and the language-selection layer.
  * Previews now show language-specific glyphs, flags, labels, page indicators, and a caption bar for easier visual verification.

* **Bug Fixes**
  * Improved font and glyph ordering so previews select the correct characters more reliably, even when underlying font metadata changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->