### PR TITLE
Restore GitHub firmware-update check in daemon/client mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,10 @@ For cross-repo context (how this repo relates to `qmk_firmware/` and `AdafruitGF
 
 - **Docstring coverage: ignore CodeRabbit's "Docstring Coverage … threshold 80%" pre-merge check.** That 80% target is a CodeRabbit default, **not** a project policy — the check is non-blocking and we deliberately do not chase it. Do **not** add docstrings to existing functions just to satisfy it (out-of-scope churn). Document new code where a docstring genuinely helps a reader, and no more.
 
+## Branch naming (all PolyKybd repos)
+
+- **Give every branch a name that hints at its content.** When creating a branch, append a short, descriptive slug describing the change (e.g. `claude/fix-firmware-update-menu-daemon-mode`, not just the auto-generated `claude/<random-scientist>-<id>`). The random scientist/id suffix from Claude Code on the web is auto-assigned server-side and can't always be overridden mid-session, but whenever a branch name is chosen by us, make it self-explanatory so the branch list reads as a changelog.
+
 ## Commands
 
 ### Run the application

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -888,6 +888,10 @@ class PolyHost(QApplication):
         if self._pending_fw_tmp_path and (
                 name == "fw_apply_done" or (name == "fw_flash_done" and not ok)):
             self._cleanup_fw_release_tmp()
+            # The async client-mode flash is done — restore the manual
+            # "Check for firmware update…" action (it was hidden while flashing).
+            self._pending_fw_release = None
+            self._reset_fw_update_action()
 
     @staticmethod
     def langcode_to_flag(lang_code):
@@ -1527,8 +1531,17 @@ class PolyHost(QApplication):
             self._flash_dialog.show()
             ok2, payload = self.core.flash_firmware(bin_path, apply=True)
             if not ok2:
+                # The flash never queued on the daemon, so no terminal
+                # fw_flash_done/fw_apply_done event will arrive to restore the
+                # action — clean up and reset it inline so the manual "Check for
+                # firmware update…" entry isn't lost.
                 self._flash_dialog.feed_finished(False, str(payload))
                 self._cleanup_fw_release_tmp()
+                self._pending_fw_release = None
+                self._reset_fw_update_action()
+                return
+            # Queued OK: hide the "Update firmware to vX…" prompt while the daemon
+            # flashes; the terminal event restores the action (see _on_flash_done).
             self._pending_fw_release = None
             self.firmware_update_action.setVisible(False)
             self.managed_connection_status()
@@ -1550,8 +1563,17 @@ class PolyHost(QApplication):
                     os.unlink(bin_path)
 
         self._pending_fw_release = None
-        self.firmware_update_action.setVisible(False)
+        self._reset_fw_update_action()
         self.managed_connection_status()
+
+    def _reset_fw_update_action(self):
+        """Return the firmware action to its idle 'Check for firmware update…'
+        state (visible, enabled per _fw_actions_allowed) once a flash reaches a
+        terminal outcome, so the manual check entry is never left hidden — in
+        either in-process or client (daemon) mode."""
+        self.firmware_update_action.setText("Check for firmware update…")
+        self.firmware_update_action.setVisible(True)
+        self.firmware_update_action.setEnabled(self._fw_actions_allowed())
 
     def _cleanup_fw_release_tmp(self):
         """Remove the temp .bin downloaded for the client-mode GitHub update

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -419,20 +419,23 @@ class PolyHost(QApplication):
         self._update_host_no_update = None
         self._update_fw_no_update = None
 
-        # The keyboard-firmware release flow downloads the .bin locally then
-        # flashes over HID — that can't drive a remote daemon, so it's
-        # in-process only (client mode flashes a local .bin via RPC instead;
-        # daemon-side release download is a later slice).
-        self.firmware_update_action = None
-        if not self.client_mode:
-            self.firmware_update_action = QAction(get_icon("keyboard.svg"), "Check for firmware update…", parent=self)
-            # noinspection PyUnresolvedReferences
-            self.firmware_update_action.triggered.connect(self._on_fw_up_clicked)
-            self.menu.addAction(self.firmware_update_action)
+        # The keyboard-firmware release flow checks GitHub for a newer release,
+        # downloads the .bin, then flashes it. In CLIENT mode the GUI has no
+        # local HID, so the download still happens here (network only) but the
+        # flash is handed to the daemon over the fw.flash RPC — the temp .bin is
+        # on the same machine, so the daemon can read it (see _on_fw_download_done).
+        # Available in both modes as of the daemon-default regression fix.
+        self.firmware_update_action = QAction(get_icon("keyboard.svg"), "Check for firmware update…", parent=self)
+        # noinspection PyUnresolvedReferences
+        self.firmware_update_action.triggered.connect(self._on_fw_up_clicked)
+        self.menu.addAction(self.firmware_update_action)
         self._pending_fw_release = None
         self._fw_up_downloader = None
         self._fw_up_progress = None
         self._await_manual_fw_prompt = False
+        # Set in client mode to the downloaded temp .bin that the daemon flashes
+        # asynchronously — cleaned up on the terminal flash event (_on_flash_done).
+        self._pending_fw_tmp_path = None
 
         if debug_mode > 0:
             debug_menu = self.menu.addMenu(get_icon("info.svg"), "Debugging")
@@ -643,8 +646,7 @@ class PolyHost(QApplication):
         # Re-enable the firmware actions inside the commands submenu (the loop
         # above just disabled its parent action on a mismatch). Both modes.
         self.cmdMenu.update_enabled(enabled, fw_enabled)
-        if not self.client_mode:
-            self.firmware_update_action.setEnabled(fw_enabled)
+        self.firmware_update_action.setEnabled(fw_enabled)
         # Available in both modes (driven via core methods).
         self.layout_editor.setEnabled(True)
         self.settings_dialog.setEnabled(True)
@@ -878,6 +880,14 @@ class PolyHost(QApplication):
         else:
             phase = "apply" if name == "fw_apply_done" else "flash"
             self.icon_manager.set_warning(f"Firmware {phase} failed", 5000)
+        # Client-mode GitHub update flow: the downloaded temp .bin must persist
+        # until the daemon's async flash/apply finishes. Clean it up once the
+        # flow reaches a terminal state — apply done, or flash failed (no apply
+        # follows). Guarded by _pending_fw_tmp_path so the manual flash (user's
+        # own file) is untouched.
+        if self._pending_fw_tmp_path and (
+                name == "fw_apply_done" or (name == "fw_flash_done" and not ok)):
+            self._cleanup_fw_release_tmp()
 
     @staticmethod
     def langcode_to_flag(lang_code):
@@ -1186,12 +1196,11 @@ class PolyHost(QApplication):
         self.log.debug("Starting update check...")
         # device_present (not connected): the firmware version is known even on
         # a protocol mismatch, and that's exactly when an update must be offered.
-        # Read it via the core-backed property (self.keeb is None in client
-        # mode). In client mode we skip the firmware check entirely — the
-        # keyboard-firmware release/flash flow is in-process only, so there's no
-        # firmware_update_action to drive (a falsy fw_version skips the fw check).
-        fw_version = self.kb_sw_version \
-            if (self._fw_actions_allowed() and not self.client_mode) else None
+        # Read it via the core-backed property (self.kb_sw_version works in both
+        # in-process and client mode — self.keeb itself is None in client mode).
+        # The firmware check runs in both modes now: the client downloads the
+        # release and flashes it via the daemon's fw.flash RPC.
+        fw_version = self.kb_sw_version if self._fw_actions_allowed() else None
 
         # Track whether the error event fires before host_no_update so we can
         # suppress the "no update" callback and show the real failure reason.
@@ -1448,7 +1457,7 @@ class PolyHost(QApplication):
         self._await_manual_fw_prompt = False
         self.firmware_update_action.setText("Check for firmware update…")
         self.firmware_update_action.setEnabled(self._fw_actions_allowed())
-        fw_version = self.keeb.get_sw_version() if self._fw_actions_allowed() else "unknown"
+        fw_version = self.kb_sw_version if self._fw_actions_allowed() else "unknown"
         _msgbox(QMessageBox.Information, "PolyKybd Firmware",
                 f"You are running the latest firmware (v{fw_version}).")
 
@@ -1504,6 +1513,27 @@ class PolyHost(QApplication):
                     f"Could not download the firmware:\n\n{error}")
             return
 
+        if self.client_mode:
+            # The daemon owns the device — flash the downloaded .bin over the
+            # fw.flash RPC with the same event-driven dialog as the manual
+            # client-mode flash. flash_firmware() queues async on the daemon and
+            # returns immediately, so the temp file must outlive this call: it is
+            # cleaned up on the terminal fw_apply_done / failed fw_flash_done
+            # event (see _on_flash_done), keyed off self._pending_fw_tmp_path.
+            self._pending_fw_tmp_path = bin_path
+            self._flash_dialog = HidFwUpDialog(
+                None, bin_path, parent=None, apply_after=True,
+                tray_icon=self.tray, external=True)
+            self._flash_dialog.show()
+            ok2, payload = self.core.flash_firmware(bin_path, apply=True)
+            if not ok2:
+                self._flash_dialog.feed_finished(False, str(payload))
+                self._cleanup_fw_release_tmp()
+            self._pending_fw_release = None
+            self.firmware_update_action.setVisible(False)
+            self.managed_connection_status()
+            return
+
         import os
         # Hold the worker off for the whole flash + apply. Otherwise the periodic
         # reconnect probe keeps re-acquiring the HID device while the flash dialog's
@@ -1522,6 +1552,21 @@ class PolyHost(QApplication):
         self._pending_fw_release = None
         self.firmware_update_action.setVisible(False)
         self.managed_connection_status()
+
+    def _cleanup_fw_release_tmp(self):
+        """Remove the temp .bin downloaded for the client-mode GitHub update
+        flow. No-op when there's nothing pending (the manual client flash uses
+        the user's own file, so it never sets _pending_fw_tmp_path)."""
+        path = self._pending_fw_tmp_path
+        if not path:
+            return
+        self._pending_fw_tmp_path = None
+        import os
+        try:
+            if os.path.exists(path):
+                os.unlink(path)
+        except OSError as e:  # noqa: BLE001 — best effort temp cleanup
+            self.log.warning("Could not remove temp firmware file %s: %s", path, e)
 
     def quit_app_and_daemon(self):
         """Client mode: ask the core daemon (which owns the device) to exit too,


### PR DESCRIPTION
## Problem

The **"Check for firmware update…"** tray entry — which polls GitHub for newer firmware releases and also drives the automatic daily check — was built only `if not self.client_mode`. Once **daemon mode became the default** (H4b-2, `daemon_mode` defaults `True`), a plain GUI launch runs as a `--connect` client, so the entry **and the automatic daily firmware check silently disappeared for everyone**. (The recent macOS icon-size work was unrelated — this is a separate regression from the daemon-default flip.)

## Fix

The release *check* only needs the current firmware version, which the client already has via the core-backed `kb_sw_version`. The *flash* is handed to the daemon over the existing `fw.flash` RPC — the downloaded `.bin` is a temp file on the same machine, so the daemon can read it.

- Build `firmware_update_action` and enable it in **both** modes.
- `_start_update_check` reads `kb_sw_version` in client mode too (drops the `and not self.client_mode` guard that forced `fw_version=None`).
- `_on_manual_no_fw_update` reads `kb_sw_version` instead of `self.keeb` (which is `None` in client mode).
- `_on_fw_download_done`: in client mode, flash the downloaded `.bin` over the `fw.flash` RPC with the event-driven dialog. `flash_firmware()` queues async, so the temp file is cleaned up on the terminal `fw_apply_done` / failed `fw_flash_done` event via `_pending_fw_tmp_path` (the manual flash uses the user's own file and is untouched).

## Also in this PR

- `docs: record descriptive-branch-naming preference in CLAUDE.md` — a small docs note so future branches get self-explanatory slugs.

## Testing

- `tests/gui/host_client_test.py` (default + `--connect` client construction) passes.

## Notes

- Diff is scoped to `polyhost/host.py` and `CLAUDE.md` only. The branch base predates PR #85 (tools demos + version bump to 0.9.6), but those touch different files — the merge into current `main` is clean and contains no reverts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CedzeKfAKHHHzkuadQVFTC

---
_Generated by [Claude Code](https://claude.ai/code/session_01CedzeKfAKHHHzkuadQVFTC)_

## Summary by Sourcery

Restore GitHub-based firmware update checking and flashing to work in both standalone and client/daemon modes, and document preferred descriptive branch naming.

New Features:
- Enable the tray 'Check for firmware update…' action and automatic firmware update checking when running in client/daemon mode by routing downloaded firmware flashing through the daemon.

Bug Fixes:
- Fix regression where daemon mode being the default disabled the firmware update tray entry and automatic firmware update checks.

Enhancements:
- Ensure firmware update UI state and messaging use the core-backed firmware version in both modes and clean up temporary downloaded firmware files after client-mode flashes complete.

Documentation:
- Document preferred descriptive branch naming conventions for all PolyKybd repositories in CLAUDE.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Firmware updates are now available in both local and client-connected modes.
  * Update checks now include firmware version verification in client mode.
  * Firmware update progress can continue through the app while the device flashes remotely.

* **Bug Fixes**
  * Fixed an issue where the firmware update action was unavailable in client mode.
  * Improved cleanup for temporary firmware files after update completion or failure.

* **Documentation**
  * Added guidance for clearer, more descriptive branch names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->