### PR TITLE
feat(forwarder): forward host OS + add 'Check for updates' menu item

### DIFF
--- a/polyhost/core/poly_core.py
+++ b/polyhost/core/poly_core.py
@@ -112,6 +112,11 @@ class PolyCore:
         # Set on a fresh connect; consumed by the first applied snapshot after
         # it so the overlay state on the keyboard is cleared exactly once.
         self.needs_overlay_reset = False
+        # Last OS value pushed to the keyboard (an OsType.value int, or None). The
+        # window-tracking tick re-asserts the local OS when local windows drive the
+        # display and the forwarder's OS when a remote-forwarded window is active,
+        # deduped against this so set_os only fires on an actual change.
+        self._last_pushed_os = None
         # Re-entrancy guard for the font-pack auto-flash: True only while a flash
         # is actually running, so a connection flap mid-flash can't start a second
         # one — but it is cleared on completion, so each fresh connect (e.g. a
@@ -385,12 +390,53 @@ class PolyCore:
                 self.submit_overlay_cmd(cmd)
             if data and cmd == OverlayCommand.OFF_ON:
                 self.send_overlay_data(data)
+            self._track_active_os(handler)
         elif self.poly_settings.get("dev_run_window_detection_if_not_connected_to_poly_kybd"):
             handler.handle_active_window(update_cycle_msec, new_window_accept_msec)
 
-    def report_window(self, handle, name, title):
+    def _track_active_os(self, handler):
+        """Keep the keyboard's OS in sync with the machine currently driving the
+        display: the forwarder's OS while a remote-forwarded window is active, else
+        the local OS. This is what makes the OS feature follow a forwarded session
+        (the keyboard reflects whichever computer you're working on), and revert to
+        the local OS when local window tracking takes back over. Deduped via
+        ``_push_os`` so set_os only fires on an actual change."""
+        from polyhost.input.unicode_input import get_host_os
+        from polyhost.device.command_ids import OsType
+        forwarded = None
+        rh = getattr(handler, "remote_handler", None)
+        if rh is not None and handler.is_remote_mapping_entry():
+            forwarded = getattr(rh, "forwarded_os", None)
+        # A forwarded UNKNOWN(0)/None means the forwarder didn't report an OS — keep
+        # the local OS rather than blanking the keyboard back to auto/unknown.
+        desired = get_host_os()
+        if isinstance(forwarded, int) and forwarded:
+            try:
+                desired = OsType(forwarded)
+            except ValueError:
+                pass  # unknown wire value — fall back to the local OS
+        self._push_os(desired)
+
+    def _push_os(self, os):
+        """Submit a host-auto OS push to the keyboard, deduped against the last one.
+
+        Accepts an OsType (or int); a no-op when it matches what was last pushed.
+        set_os self-gates on protocol v7+, so this is harmless on older firmware."""
+        from polyhost.device.command_ids import OsType as _OsType
+        value = os.value if isinstance(os, _OsType) else int(os)
+        if value == self._last_pushed_os:
+            return
+        self._last_pushed_os = value
+        self.log.info("Pushing OS %s to keyboard.", _OsType(value))
+        self.worker.submit("set_os", lambda c, v=value: self.keeb.set_os(v))
+
+    def report_window(self, handle, name, title, os=None):
         """Inject an external active-window report into remote window tracking
         (the ``window.report`` RPC / ``polyctl window report``).
+
+        ``os`` (optional, an OsType value int) is the forwarder's host OS, stored
+        on the remote handler so the window-tracking tick can push it to the
+        keyboard while the forwarded window is the active overlay driver.
 
         Mirrors what the cross-machine TCP relay does, but over the control
         socket — a local client (or a future unified transport) can feed the
@@ -401,7 +447,7 @@ class PolyCore:
         handler = self.overlay_handler
         if handler is None or getattr(handler, "remote_handler", None) is None:
             return False, "window tracking unavailable"
-        handler.remote_handler.report_window(handle, name, title)
+        handler.remote_handler.report_window(handle, name, title, os=os)
         return True, {"reported": True}
 
     def submit_overlay_cmd(self, cmd):
@@ -628,11 +674,10 @@ class PolyCore:
                     # applies it only in auto mode (a manual pin / Android wins), and
                     # set_os self-gates on protocol v7+, so this is a no-op on older
                     # firmware. Re-asserted on every connect — host wins when present.
+                    # Force the push (last_pushed reset) so a reconnect always re-syncs.
                     from polyhost.input.unicode_input import get_host_os
-                    host_os = get_host_os()
-                    self.log.info("Pushing host OS %s to keyboard.", host_os)
-                    self.worker.submit("set_os",
-                                       lambda c, o=host_os: self.keeb.set_os(o))
+                    self._last_pushed_os = None
+                    self._push_os(get_host_os())
                 self.device_mgr.reset_all_caches()
                 if self.overlay_handler is not None:
                     self.overlay_handler.force_resend()

--- a/polyhost/forwarder.py
+++ b/polyhost/forwarder.py
@@ -8,13 +8,17 @@ import sys
 import time
 
 
-from PyQt5.QtCore import QTimer, Qt
+import subprocess
+
+from PyQt5.QtCore import QTimer, Qt, QObject, pyqtSignal
 from PyQt5.QtGui import QPalette, QColor
 from PyQt5.QtWidgets import (
     QApplication,
     QSystemTrayIcon,
     QMenu,
-    QAction)
+    QAction,
+    QMessageBox,
+    QProgressDialog)
 from polyhost._version import __version__
 from polyhost.gui.get_icon import get_icon
 from polyhost.gui.icon_state_manager import IconStateManager
@@ -41,6 +45,18 @@ HEARTBEAT_MSEC = 15000  # resend current window state periodically so the host c
 from polyhost.util.log_util import DEBUG_DETAILED, make_stream_handler, make_collapse_handler  # noqa: F401  (registers debug_detailed on import)
 from polyhost.handler.active_window import log_env_info
 
+class _UpdateBridge(QObject):
+    """Marshals the updater threads' callbacks (which fire off the Qt thread) back
+    onto the Qt main thread via queued signals — the forwarder has no WorkerBridge."""
+    available = pyqtSignal(object)
+    no_update = pyqtSignal()
+    error = pyqtSignal(str)
+    progress = pyqtSignal(int, str)
+    finished_ok = pyqtSignal()
+    relay_needed = pyqtSignal(str)
+    failed = pyqtSignal(str)
+
+
 class PolyForwarder(QApplication):
     def __init__(self, log_level, host=None, host_file=None,
                  report_rpc=False, report_port=None, report_authkey_file=None):
@@ -59,6 +75,12 @@ class PolyForwarder(QApplication):
         self._report_port = report_port
         self._report_client = None
         self._report_authkey = None
+
+        # This machine's OS, forwarded alongside the active window so the keyboard
+        # reflects the OS of the computer you are working on (not just the one it is
+        # plugged into). Constant for the process lifetime. An OsType value int.
+        from polyhost.input.unicode_input import get_host_os
+        self._os_value = get_host_os().value
 
         fmt = "[%(asctime)s] %(levelname)-7s {%(filename)s:%(lineno)d} - %(message)s"
         file_handler = RotatingFileHandler(
@@ -126,8 +148,26 @@ class PolyForwarder(QApplication):
         # noinspection PyUnresolvedReferences
         self.log_dialog.triggered.connect(self.open_log)
         self.log_viewer = None
-        
+
+        self.update_action = QAction(get_icon("sync.svg"), "Check for updates...", parent=self)
+        # noinspection PyUnresolvedReferences
+        self.update_action.triggered.connect(self._on_update_clicked)
+
+        # Update plumbing (host-app update only — the forwarder has no device).
+        self._update_bridge = _UpdateBridge()
+        self._update_bridge.available.connect(self._on_update_available)
+        self._update_bridge.no_update.connect(self._on_no_update)
+        self._update_bridge.error.connect(self._on_check_error)
+        self._update_bridge.progress.connect(self._on_update_progress)
+        self._update_bridge.finished_ok.connect(self._on_update_done)
+        self._update_bridge.relay_needed.connect(self._on_relay_needed)
+        self._update_bridge.failed.connect(self._on_update_failed)
+        self._update_checker = None
+        self._update_installer = None
+        self._update_progress = None
+
         self.menu.addAction(self.log_dialog)
+        self.menu.addAction(self.update_action)
         self.menu.addAction(self.support)
         self.menu.addAction(self.about)
         self.menu.addAction(self.exit)
@@ -183,7 +223,7 @@ class PolyForwarder(QApplication):
                 from polyhost.server.window_report_client import connect
                 self._report_client = connect(
                     host, self._report_port, self._report_authkey)
-            self._report_client.report(handle, name, title)
+            self._report_client.report(handle, name, title, os=self._os_value)
             return True
         except Exception as e:
             self.log.error("Window-report RPC to %s failed: %s", host, e)
@@ -209,7 +249,9 @@ class PolyForwarder(QApplication):
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             s.settimeout(3.0)
             s.connect((str(ip), TCP_PORT))
-            s.send(f"{handle};{name};{title}".encode("utf-8"))
+            # 4th field = this machine's OS (an OsType value int); older daemons
+            # split on ';' and read the first three fields, ignoring the extra one.
+            s.send(f"{handle};{name};{title};{self._os_value}".encode("utf-8"))
             s.close()
             return True
         except socket.timeout as err:
@@ -240,6 +282,109 @@ class PolyForwarder(QApplication):
     def open_about():
         webbrowser.open("https://ko-fi.com/polykb", new=0, autoraise=True)
         
+    # ------------------------------------------------------------------
+    # Host-app update (mirrors the tray app's flow, host-only — no firmware,
+    # since the forwarder has no device). Threads marshal back via _update_bridge.
+    # ------------------------------------------------------------------
+    def _on_update_clicked(self):
+        from polyhost.services.updater import UpdateChecker
+        if self._update_installer is not None and self._update_installer.is_alive():
+            return
+        if self._update_checker is not None and self._update_checker.is_alive():
+            return
+        self.update_action.setText("Checking for updates...")
+        ub = self._update_bridge
+        self._update_checker = UpdateChecker(
+            current_fw_version=None,   # host-only: the forwarder owns no keyboard
+            on_update_available=lambda rel: ub.available.emit(rel),
+            on_host_no_update=lambda: ub.no_update.emit(),
+            on_error=lambda msg: ub.error.emit(msg),
+        )
+        self._update_checker.start()
+
+    def _on_update_available(self, release):
+        self.update_action.setText("Check for updates...")
+        if QMessageBox.question(
+                None, "Update PolyKybdHost",
+                f"Version {release.version} is available.\n\n"
+                "Download, install, and restart the forwarder now?",
+                QMessageBox.Yes | QMessageBox.No, QMessageBox.Yes) != QMessageBox.Yes:
+            return
+        self._run_update_installer(release)
+
+    def _on_no_update(self):
+        self.update_action.setText("Check for updates...")
+        QMessageBox.information(
+            None, "PolyKybdHost Update",
+            f"You are running the latest version (v{__version__}).")
+
+    def _on_check_error(self, msg):
+        self.update_action.setText("Check for updates...")
+        QMessageBox.warning(
+            None, "PolyKybdHost Update",
+            f"Could not check for updates:\n\n{msg}\n\nRun with --debug 1 for details.")
+
+    def _run_update_installer(self, release):
+        from polyhost.services.updater import UpdateInstaller
+        if self._update_installer is not None and self._update_installer.is_alive():
+            return
+        self.update_action.setEnabled(False)
+        self._update_progress = QProgressDialog(
+            f"Downloading v{release.version}…", "", 0, 100)
+        self._update_progress.setWindowTitle("PolyKybdHost Update")
+        self._update_progress.setCancelButton(None)
+        self._update_progress.setMinimumDuration(0)
+        self._update_progress.show()
+        ub = self._update_bridge
+        self._update_installer = UpdateInstaller(
+            release,
+            on_progress=lambda pct, m: ub.progress.emit(pct, m),
+            on_finished_ok=lambda: ub.finished_ok.emit(),
+            on_relay_needed=lambda path: ub.relay_needed.emit(path),
+            on_failed=lambda m: ub.failed.emit(m),
+        )
+        self._update_installer.start()
+
+    def _on_update_progress(self, percent, message):
+        if self._update_progress is None:
+            return
+        self._update_progress.setLabelText(message)
+        if percent < 0:
+            self._update_progress.setRange(0, 0)
+        else:
+            if self._update_progress.maximum() == 0:
+                self._update_progress.setRange(0, 100)
+            self._update_progress.setValue(percent)
+
+    def _on_update_done(self):
+        from polyhost.services.updater import restart_app
+        if self._update_progress is not None:
+            self._update_progress.close()
+            self._update_progress = None
+        self.log.info("Update applied, restarting forwarder...")
+        self.quit_app()
+        restart_app()
+
+    def _on_relay_needed(self, relay_path):
+        if self._update_progress is not None:
+            self._update_progress.setLabelText("Restarting to complete update…")
+            self._update_progress.setValue(100)
+        popen_kwargs = {"close_fds": False}
+        if sys.platform == "win32":
+            popen_kwargs["creationflags"] = (
+                subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP)
+        subprocess.Popen([sys.executable, relay_path], **popen_kwargs)  # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit
+        QTimer.singleShot(1200, self.quit)
+
+    def _on_update_failed(self, message):
+        if self._update_progress is not None:
+            self._update_progress.close()
+            self._update_progress = None
+        self.update_action.setEnabled(True)
+        self.log.error("Update failed: %s", message)
+        QMessageBox.warning(
+            None, "Update failed", f"Could not apply the update:\n\n{message}")
+
     def quit_app(self):
         self.icon_manager.set_disconnected()
         self.is_closing = True

--- a/polyhost/handler/remote_window.py
+++ b/polyhost/handler/remote_window.py
@@ -11,10 +11,12 @@ BUFFER_SIZE = 1024
 
 # Needs to be started as thread
 def receive_from_forwarder(log, on_report, stop_event):
-    """Accept ``handle;name;title`` reports from a forwarder and hand each to
-    ``on_report(handle, name, title)`` — the same entry point the window.report
-    RPC uses (RemoteHandler.report_window), so the TCP relay is now just a
-    transport over the unified path rather than poking a separate store."""
+    """Accept ``handle;name;title[;os]`` reports from a forwarder and hand each to
+    ``on_report(handle, name, title, os=...)`` — the same entry point the
+    window.report RPC uses (RemoteHandler.report_window), so the TCP relay is now
+    just a transport over the unified path rather than poking a separate store.
+    The optional 4th ``os`` field (an OsType value int) is sent by forwarders that
+    forward their OS; older forwarders omit it (back-compatible split)."""
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
@@ -37,8 +39,14 @@ def receive_from_forwarder(log, on_report, stop_event):
                 data = data.decode("utf-8")
                 entries = [0, "", ""] if not data else data.split(";")
                 if len(entries) > 2:
-                    on_report(entries[0], entries[1], entries[2])
-                    log.debug_detailed("Remote data from %s: handle=%s name=%s", addr, entries[0], entries[1])
+                    os = None
+                    if len(entries) > 3 and entries[3] != "":
+                        try:
+                            os = int(entries[3])
+                        except ValueError:
+                            os = None
+                    on_report(entries[0], entries[1], entries[2], os=os)
+                    log.debug_detailed("Remote data from %s: handle=%s name=%s os=%s", addr, entries[0], entries[1], os)
             finally:
                 conn.close()
         except socket.timeout:
@@ -63,6 +71,9 @@ class RemoteHandler:
         self.last_entry = None
         self.connections = {}
         self.mapping = mapping
+        # Latest OS reported by the forwarder (an OsType value int), or None when
+        # the forwarder does not forward its OS. Read by PolyCore's window tick.
+        self.forwarded_os = None
         self.listen_to_forwarder()
 
     def _has_remote_entries(self):
@@ -81,21 +92,25 @@ class RemoteHandler:
         self.forwarder.daemon = True
         self.forwarder.start()
 
-    def report_window(self, handle, name, title):
+    def report_window(self, handle, name, title, os=None):
         """Single entry point for an active-window report, from either source:
         the cross-machine TCP relay (`receive_from_forwarder`) or the
         ``window.report`` control-socket RPC / ``polyctl window report``.
 
         Stores the latest report; ``remote_changed`` reads it and runs the
-        shared matcher (`common.find_matching_entry`)."""
+        shared matcher (`common.find_matching_entry`). ``os`` (optional, an OsType
+        value int) is the forwarder's OS — kept on ``forwarded_os`` for the window
+        tick; left unchanged when None so a report without an OS never clears it."""
         self.connections["_report"] = {
             "handle": str(handle),
             "name": str(name),
             "title": str(title),
         }
         self.connections["_latest"] = "_report"
+        if os is not None:
+            self.forwarded_os = os
         self.log.debug_detailed(
-            "report_window: handle=%s name=%s title=%s", handle, name, title)
+            "report_window: handle=%s name=%s title=%s os=%s", handle, name, title, os)
 
     def _match_remote(self):
         """Match the current remote window's app/title against the mapping using

--- a/polyhost/server/window_report_client.py
+++ b/polyhost/server/window_report_client.py
@@ -36,13 +36,19 @@ class WindowReportClient:
         if not ok:
             raise WindowReportError(why)
 
-    def report(self, handle, name, title):
-        """Send one window report; raise WindowReportError on failure/timeout."""
+    def report(self, handle, name, title, os=None):
+        """Send one window report; raise WindowReportError on failure/timeout.
+
+        ``os`` (optional, an OsType value int) lets the forwarder forward its host
+        OS; omitted from the params when None so the field is simply absent for
+        forwarders that do not forward their OS."""
         req_id = self._next_id
         self._next_id += 1
+        params = {"handle": str(handle), "name": str(name), "title": str(title)}
+        if os is not None:
+            params["os"] = int(os)
         p.send_message(self._conn, p.make_request(
-            req_id, p.M_WINDOW_REPORT,
-            {"handle": str(handle), "name": str(name), "title": str(title)}))
+            req_id, p.M_WINDOW_REPORT, params))
         while True:
             if not self._conn.poll(self._timeout):
                 raise WindowReportError("timed out waiting for window.report reply")

--- a/polyhost/server/window_report_server.py
+++ b/polyhost/server/window_report_server.py
@@ -156,7 +156,7 @@ class WindowReportServer:
             return
         try:
             ret = self._on_report(params["handle"], params["name"],
-                                  params.get("title", ""))
+                                  params.get("title", ""), os=params.get("os"))
             # report_window returns the (ok, payload) contract; surface failure.
             if isinstance(ret, tuple) and len(ret) == 2 and not ret[0]:
                 reply = p.make_error(req_id, p.ERR_DEVICE, str(ret[1]))

--- a/tests/core/poly_core_apply_test.py
+++ b/tests/core/poly_core_apply_test.py
@@ -74,7 +74,13 @@ class TestReportWindow(unittest.TestCase):
         self.assertTrue(ok)
         self.assertEqual(payload, {"reported": True})
         core.overlay_handler.remote_handler.report_window.assert_called_once_with(
-            "7", "Code.exe", "x - VS Code")
+            "7", "Code.exe", "x - VS Code", os=None)
+
+    def test_forwards_os_to_remote_handler(self):
+        core = make_core()
+        core.report_window("7", "Code.exe", "x - VS Code", os=2)
+        core.overlay_handler.remote_handler.report_window.assert_called_once_with(
+            "7", "Code.exe", "x - VS Code", os=2)
 
     def test_no_window_tracking_returns_error(self):
         core = make_core()

--- a/tests/core/poly_core_overlay_test.py
+++ b/tests/core/poly_core_overlay_test.py
@@ -28,6 +28,12 @@ def make_core(*, connected=True, handler=True, run_when_disconnected=False):
     core.poly_settings.get.side_effect = lambda k: {
         "dev_run_window_detection_if_not_connected_to_poly_kybd": run_when_disconnected,
     }.get(k, False)
+    # Seed the OS dedup to the local OS so the window tick's OS-tracking re-assert
+    # is a no-op here (these tests pin overlay-send behaviour, not OS pushes).
+    from polyhost.input.unicode_input import get_host_os
+    core._last_pushed_os = get_host_os().value
+    if handler:
+        core.overlay_handler.is_remote_mapping_entry.return_value = False
     return core
 
 
@@ -85,6 +91,48 @@ class TestTickWindowTracking(unittest.TestCase):
         core.tick_window_tracking()
         core.overlay_handler.handle_active_window.assert_called_once()
         core.worker.submit.assert_not_called()
+
+
+class TestOsTracking(unittest.TestCase):
+    """The window tick pushes the forwarder's OS while a remote-forwarded window
+    drives the display, and reverts to the local OS when local tracking resumes —
+    deduped so set_os only fires on a change."""
+
+    def _os_submits(self, core):
+        return [c for c in core.worker.submit.call_args_list if c.args and c.args[0] == "set_os"]
+
+    def test_forwarded_os_pushed_then_reverts(self):
+        from polyhost.input.unicode_input import get_host_os
+        core = make_core()
+        core._last_pushed_os = None  # nothing pushed yet
+        core.overlay_handler.handle_active_window.return_value = (None, OverlayCommand.NONE)
+
+        # Remote-forwarded window active, forwarder reports macOS (2).
+        core.overlay_handler.is_remote_mapping_entry.return_value = True
+        core.overlay_handler.remote_handler.forwarded_os = 2
+        core.tick_window_tracking()
+        self.assertEqual(self._os_submits(core), self._os_submits(core)[:1])  # at least one
+        self.assertEqual(core._last_pushed_os, 2)
+
+        # A second identical tick is deduped (no new set_os).
+        before = len(self._os_submits(core))
+        core.tick_window_tracking()
+        self.assertEqual(len(self._os_submits(core)), before)
+
+        # Local window takes back over -> revert to the local OS.
+        core.overlay_handler.is_remote_mapping_entry.return_value = False
+        core.tick_window_tracking()
+        self.assertEqual(core._last_pushed_os, get_host_os().value)
+
+    def test_remote_without_os_keeps_local(self):
+        from polyhost.input.unicode_input import get_host_os
+        core = make_core()
+        core._last_pushed_os = None
+        core.overlay_handler.handle_active_window.return_value = (None, OverlayCommand.NONE)
+        core.overlay_handler.is_remote_mapping_entry.return_value = True
+        core.overlay_handler.remote_handler.forwarded_os = None  # old forwarder
+        core.tick_window_tracking()
+        self.assertEqual(core._last_pushed_os, get_host_os().value)
 
 
 if __name__ == '__main__':

--- a/tests/server/window_report_server_test.py
+++ b/tests/server/window_report_server_test.py
@@ -36,6 +36,7 @@ def _free_port():
 class WindowReportServerTest(unittest.TestCase):
     def setUp(self):
         self.reports = []
+        self.last_os = None
         self.report_result = (True, {"reported": True})
         self.authkey = b"winreport-testkey"
         self.port = _free_port()
@@ -56,8 +57,9 @@ class WindowReportServerTest(unittest.TestCase):
         except Exception:
             pass
 
-    def _on_report(self, handle, name, title):
+    def _on_report(self, handle, name, title, os=None):
         self.reports.append((handle, name, title))
+        self.last_os = os
         return self.report_result
 
     def _client(self, authkey=None):
@@ -72,6 +74,12 @@ class WindowReportServerTest(unittest.TestCase):
         result = c.report(1234, "code.exe", "main.py - VS Code")
         self.assertEqual(result, {"ok": True})
         self.assertEqual(self.reports, [("1234", "code.exe", "main.py - VS Code")])
+        self.assertIsNone(self.last_os)  # no os field -> callback gets None
+
+    def test_report_forwards_os(self):
+        c = self._client()
+        c.report(1, "term", "bash", os=2)  # 2 == OsType.MACOS
+        self.assertEqual(self.last_os, 2)
 
     def test_callback_failure_surfaces_as_error(self):
         self.report_result = (False, "no remote mapping active")


### PR DESCRIPTION
Two forwarder gaps surfaced while testing the active-OS feature.

## 1. The forwarder now forwards its OS

Previously a forwarded session left the keyboard reflecting the OS of the machine it's **physically plugged into**, not the one being worked on. The forwarder now sends its OS (an `OsType` value int) as an **optional field** on every window report — over both the authenticated window-report RPC and the legacy plaintext relay (a 4th `;os` field older daemons simply ignore).

On the receiving side the OS is kept on the remote handler, and the window-tracking tick pushes it to the keyboard **while a remote-forwarded window drives the display**, reverting to the local OS when local tracking resumes. Pushes are deduped (set_os only fires on a change) and `set_os` self-gates on protocol v7+, so it's a no-op on older firmware. A report without an OS keeps the local OS — no regression for older forwarders.

## 2. 'Check for updates' menu item

The forwarder tray menu had no way to update the app. Added one mirroring the main app's host-update flow (host-only — the forwarder owns no keyboard, so the firmware path is skipped), with the updater threads marshalled back to the Qt thread via a small signal bridge.

## Tests

Added/updated coverage for the OS round-trip (`window_report_server`, `report_window` delegation) and the window-tracking forward/revert logic; full core/handler/server suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dk6a2Uq7qexd1z9G6A9XsJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dk6a2Uq7qexd1z9G6A9XsJ)_

## Summary by Sourcery

Forward the host OS from the forwarder through the window reporting pipeline so the keyboard OS tracks the machine currently driving the display, and add a host-app update flow with a 'Check for updates' tray action to the forwarder.

New Features:
- Forward the forwarder host OS as an optional field in both RPC and TCP window reports so remote sessions can drive keyboard OS selection.
- Add a 'Check for updates' tray menu item to the forwarder with a GUI-driven host update and restart flow.

Enhancements:
- Track and deduplicate OS pushes in PolyCore so the keyboard OS switches between local and forwarded hosts only when needed.
- Extend remote window handling and the window report server/client to carry through the optional OS field without breaking older clients.

Tests:
- Add and update tests covering OS forwarding via window reports, OS tracking behaviour during remote/local window transitions, and OS propagation through the window report server.