### PR TITLE
docs: cut a fresh branch off the default after a PR merges

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,10 @@ For cross-repo context (how this repo relates to `qmk_firmware/` and `AdafruitGF
 
 - **Docstring coverage: ignore CodeRabbit's "Docstring Coverage … threshold 80%" pre-merge check.** That 80% target is a CodeRabbit default, **not** a project policy — the check is non-blocking and we deliberately do not chase it. Do **not** add docstrings to existing functions just to satisfy it (out-of-scope churn). Document new code where a docstring genuinely helps a reader, and no more.
 
-## Branch naming (all PolyKybd repos)
+## Branching (all PolyKybd repos)
 
 - **Give every branch a name that hints at its content.** When creating a branch, append a short, descriptive slug describing the change (e.g. `claude/fix-firmware-update-menu-daemon-mode`, not just the auto-generated `claude/<random-scientist>-<id>`). The random scientist/id suffix from Claude Code on the web is auto-assigned server-side and can't always be overridden mid-session, but whenever a branch name is chosen by us, make it self-explanatory so the branch list reads as a changelog.
+- **Always start new work on a FRESH branch cut from the updated default branch — never keep committing to a branch whose PR has already merged.** Once a PR is merged, that branch is done: `git fetch origin <default>` (and for the next piece of work `git checkout -b claude/<new-slug> origin/<default>`). Cherry-pick only the still-unmerged commits onto the fresh branch if needed. This keeps each PR a clean, focused diff against the current default (`main` for host/rig, `PolyKybd` for the firmware) and avoids a new PR accidentally re-including already-merged commits.
 
 ## Commands
 


### PR DESCRIPTION
Renames the `CLAUDE.md` "Branch naming" section to **Branching (all PolyKybd repos)** and adds the convention: once a PR merges, never keep committing to that branch — fetch the updated default (`main` here) and start new work on a fresh branch off it, cherry-picking only still-unmerged commits. Keeps each PR a clean, focused diff and avoids re-including already-merged commits.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dk6a2Uq7qexd1z9G6A9XsJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dk6a2Uq7qexd1z9G6A9XsJ)_

## Summary by Sourcery

Documentation:
- Rename the CLAUDE.md branching section and document the convention to cut new work from an updated default branch instead of continuing on a merged PR branch.