### PR TITLE
polyctl doom install / install-pack: flash the Doom easter egg's game data and engine pack over HID

### DIFF
--- a/polyhost/cli/polyctl.py
+++ b/polyhost/cli/polyctl.py
@@ -306,6 +306,17 @@ def _write_empty_pack() -> str:
     return path
 
 
+def _cmd_doom(client, args):
+    """`doom install <whx>` — flash the easter egg's WHX game data to BOTH
+    halves over HID (rides the font-pack transport; survives firmware updates)."""
+    import os
+    if getattr(args, "doom_action", None) == "install":
+        path = os.path.abspath(args.file)
+        return _stream_fontpack_op(client, protocol.M_DOOM_INSTALL, {"path": path},
+                                   f"installing game data {path}")
+    return 2
+
+
 def _cmd_fontpack(client, args):
     action = getattr(args, "fontpack_action", None)
 
@@ -551,6 +562,13 @@ def build_parser():
     p_fp_wipe.add_argument("bundle", nargs="?",
                            help="bundle id/index to wipe; omit to wipe every slot")
     p_fp.set_defaults(func=_cmd_fontpack)
+
+    p_doom = sub.add_parser("doom", help="doom easter egg operations")
+    doom_sub = p_doom.add_subparsers(dest="doom_action", required=True)
+    p_doom_inst = doom_sub.add_parser(
+        "install", help="install the WHX game data to both halves (streams progress; no reboot)")
+    p_doom_inst.add_argument("file", help="path to the doom1.whx game-data image")
+    p_doom.set_defaults(func=_cmd_doom)
 
     p_upd = sub.add_parser("update", help="host self-update")
     upd_sub = p_upd.add_subparsers(dest="update_action", required=True)

--- a/polyhost/cli/polyctl.py
+++ b/polyhost/cli/polyctl.py
@@ -314,6 +314,10 @@ def _cmd_doom(client, args):
         path = os.path.abspath(args.file)
         return _stream_fontpack_op(client, protocol.M_DOOM_INSTALL, {"path": path},
                                    f"installing game data {path}")
+    if getattr(args, "doom_action", None) == "install-pack":
+        path = os.path.abspath(args.file)
+        return _stream_fontpack_op(client, protocol.M_DOOM_INSTALL_PACK, {"path": path},
+                                   f"installing engine pack {path}")
     return 2
 
 
@@ -568,6 +572,11 @@ def build_parser():
     p_doom_inst = doom_sub.add_parser(
         "install", help="install the WHX game data to both halves (streams progress; no reboot)")
     p_doom_inst.add_argument("file", help="path to the doom1.whx game-data image")
+    p_doom_pack = doom_sub.add_parser(
+        "install-pack",
+        help="install the executable engine pack to both halves (DoomPack firmware "
+             "flavour; the .plyd must match the firmware build — see doom/PACK_DESIGN.md)")
+    p_doom_pack.add_argument("file", help="path to the doom_pack_vN.plyd engine pack")
     p_doom.set_defaults(func=_cmd_doom)
 
     p_upd = sub.add_parser("update", help="host self-update")

--- a/polyhost/cli/polyctl.py
+++ b/polyhost/cli/polyctl.py
@@ -575,8 +575,8 @@ def build_parser():
     p_doom_pack = doom_sub.add_parser(
         "install-pack",
         help="install the executable engine pack to both halves (DoomPack firmware "
-             "flavour; the .plyd must match the firmware build — see doom/PACK_DESIGN.md)")
-    p_doom_pack.add_argument("file", help="path to the doom_pack_vN.plyd engine pack")
+             "flavour; the .plyx must match the firmware build — see doom/PACK_DESIGN.md)")
+    p_doom_pack.add_argument("file", help="path to the doom_pack_vN.plyx engine pack")
     p_doom.set_defaults(func=_cmd_doom)
 
     p_upd = sub.add_parser("update", help="host self-update")

--- a/polyhost/core/poly_core.py
+++ b/polyhost/core/poly_core.py
@@ -1099,6 +1099,42 @@ class PolyCore:
         self.worker.submit("fontpack_flash", _job)
         return True, {"queued": True}
 
+    def install_doomwad(self, path):
+        """Install the doom easter egg's WHX game data (both halves) as a worker job.
+
+        Rides the font-pack transport with the DOOMWAD pseudo bundle — the firmware
+        routes it to the WHX slot at the top of the resource region and bridges the
+        slave's copy in the same pass. Same event stream as a font-pack flash
+        (``fontpack_flash_progress``/``fontpack_flash_done``), so ``polyctl`` and the
+        tray progress surfaces work unchanged. Old firmware without the DOOMWAD
+        target NACKs the BEGIN — reported as a plain error, nothing bricks."""
+        if not self._fw_actions_allowed():
+            return False, "No PolyKybd present (or paused) — cannot flash."
+        try:
+            with open(path, "rb") as f:
+                whx_bytes = f.read()
+        except OSError as e:
+            return False, f"Cannot read game-data file: {e}"
+        ok, msg = hid_fontpack.validate_doomwad(whx_bytes)
+        if not ok:
+            return False, msg
+
+        def _job(cancel):
+            cancel_flag = [False]
+
+            def _progress(pct, m):
+                if cancel.is_set():
+                    cancel_flag[0] = True
+                self.emit("fontpack_flash_progress", {"pct": pct, "msg": m})
+
+            fok, fmsg = hid_fontpack.flash_doomwad(
+                self.keeb.hid, path, progress_cb=_progress, cancel_flag=cancel_flag)
+            self.emit("fontpack_flash_done", {"ok": bool(fok), "msg": fmsg})
+
+        # No coalesce_key: a flash must never be superseded by a later job.
+        self.worker.submit("doomwad_install", _job)
+        return True, {"queued": True}
+
     def flash_fontpack_bundle(self, bundle):
         """Flash one shipped bundle (by id, e.g. ``"emoji"``, or its slot index) to
         its slot — forced, even if the keyboard is already up to date. Resolves the

--- a/polyhost/core/poly_core.py
+++ b/polyhost/core/poly_core.py
@@ -1128,7 +1128,7 @@ class PolyCore:
                 self.emit("fontpack_flash_progress", {"pct": pct, "msg": m})
 
             fok, fmsg = hid_fontpack.flash_doomwad(
-                self.keeb.hid, path, progress_cb=_progress, cancel_flag=cancel_flag)
+                self.keeb.hid, whx_bytes, progress_cb=_progress, cancel_flag=cancel_flag)
             self.emit("fontpack_flash_done", {"ok": bool(fok), "msg": fmsg})
 
         # No coalesce_key: a flash must never be superseded by a later job.
@@ -1163,7 +1163,7 @@ class PolyCore:
                 self.emit("fontpack_flash_progress", {"pct": pct, "msg": m})
 
             fok, fmsg = hid_fontpack.flash_doompack(
-                self.keeb.hid, path, progress_cb=_progress, cancel_flag=cancel_flag)
+                self.keeb.hid, pack_bytes, progress_cb=_progress, cancel_flag=cancel_flag)
             self.emit("fontpack_flash_done", {"ok": bool(fok), "msg": fmsg})
 
         # No coalesce_key: a flash must never be superseded by a later job.

--- a/polyhost/core/poly_core.py
+++ b/polyhost/core/poly_core.py
@@ -1136,7 +1136,7 @@ class PolyCore:
         return True, {"queued": True}
 
     def install_doompack(self, path):
-        """Install the doom easter egg's executable engine pack (.plyd, both
+        """Install the doom easter egg's executable engine pack (.plyx, both
         halves — the slave's lockstep drone runs the same engine) as a worker
         job. The DoomPack half of the shipping-shape split (qmk repo,
         doom/PACK_DESIGN.md): same transport, events and error model as

--- a/polyhost/core/poly_core.py
+++ b/polyhost/core/poly_core.py
@@ -1135,6 +1135,41 @@ class PolyCore:
         self.worker.submit("doomwad_install", _job)
         return True, {"queued": True}
 
+    def install_doompack(self, path):
+        """Install the doom easter egg's executable engine pack (.plyd, both
+        halves — the slave's lockstep drone runs the same engine) as a worker
+        job. The DoomPack half of the shipping-shape split (qmk repo,
+        doom/PACK_DESIGN.md): same transport, events and error model as
+        :meth:`install_doomwad`, with the DOOMPACK pseudo bundle routing it
+        to the engine-pack slot. Old firmware without the target NACKs the
+        BEGIN — plain error, nothing bricks."""
+        if not self._fw_actions_allowed():
+            return False, "No PolyKybd present (or paused) — cannot flash."
+        try:
+            with open(path, "rb") as f:
+                pack_bytes = f.read()
+        except OSError as e:
+            return False, f"Cannot read engine-pack file: {e}"
+        ok, msg = hid_fontpack.validate_doompack(pack_bytes)
+        if not ok:
+            return False, msg
+
+        def _job(cancel):
+            cancel_flag = [False]
+
+            def _progress(pct, m):
+                if cancel.is_set():
+                    cancel_flag[0] = True
+                self.emit("fontpack_flash_progress", {"pct": pct, "msg": m})
+
+            fok, fmsg = hid_fontpack.flash_doompack(
+                self.keeb.hid, path, progress_cb=_progress, cancel_flag=cancel_flag)
+            self.emit("fontpack_flash_done", {"ok": bool(fok), "msg": fmsg})
+
+        # No coalesce_key: a flash must never be superseded by a later job.
+        self.worker.submit("doompack_install", _job)
+        return True, {"queued": True}
+
     def flash_fontpack_bundle(self, bundle):
         """Flash one shipped bundle (by id, e.g. ``"emoji"``, or its slot index) to
         its slot — forced, even if the keyboard is already up to date. Resolves the

--- a/polyhost/device/hid_fontpack.py
+++ b/polyhost/device/hid_fontpack.py
@@ -25,6 +25,14 @@ FONTPACK_CHUNK_SIZE = 56            # payload bytes/chunk (+4-byte offset = 60);
 FONTPACK_MAX_SIZE   = 0x200000      # 2 MB cap; the whole bundle window. Per-bundle, the
                                     # firmware rejects a pack larger than its fixed slot.
 
+# Pseudo bundle id selecting the DOOMWAD target — the doom easter egg's WHX game
+# data slot at the top of the resource region (firmware FONTPACK_BUNDLE_DOOMWAD /
+# FW_TARGET_DOOMWAD). Same BEGIN/CHUNK/COMMIT transport, different fixed slot;
+# COMMIT validates the "IWHX" magic instead of reloading fonts.
+DOOMWAD_BUNDLE_ID = 0x7F
+DOOMWAD_MAGIC     = b"IWHX"
+DOOMWAD_MAX_SIZE  = 0x200000        # the 2 MB WHX slot (flash 0x600000..0x7FFFFF)
+
 # Pack format (base/fontpack.h). The host only needs to parse/validate the header.
 FONTPACK_MAGIC        = b"PlyF"
 FONTPACK_ABI_VERSION  = 1            # must match FONTPACK_ABI_VERSION in the firmware
@@ -158,87 +166,61 @@ def decide_stale_bundles(device_versions: dict, shipped: list) -> list:
     return out
 
 
-def flash_fontpack(hid, pack_path: str, progress_cb=None, cancel_flag: list = None,
-                   bundle_id: int = 0) -> tuple[bool, str]:
-    """Full HID font-pack flash flow: BEGIN -> N*CHUNK -> COMMIT (no reboot).
+def _stream_slot(hid, pack_bytes, bundle_id, what, report, cancelled):
+    """Shared BEGIN -> N*CHUNK -> COMMIT stream to one resource slot (both halves).
 
-    Args:
-        hid:          HidHelper instance.
-        pack_path:    Path to the .plyf font-pack image.
-        progress_cb:  Optional callable(percent: int, message: str).
-        cancel_flag:  Optional single-element list; set cancel_flag[0] = True to abort.
-        bundle_id:    Which bundle slot to flash (index in res/fontpack/bundles.json;
-                      firmware resolves it to a fixed flash slot). 0 by default.
-
-    Returns:
-        (True, success_msg) or (False, error_msg).
+    `what` flavours the progress text ("font pack" / "game data"). Returns
+    (ok, error_msg, commit_reply) — on success error_msg is "" and commit_reply
+    is the raw COMMIT reply (the fontpack caller parses content_version out of it).
     """
-    def report(pct, msg):
-        if progress_cb:
-            progress_cb(pct, msg)
-
-    def cancelled():
-        return cancel_flag is not None and cancel_flag[0]
-
-    with open(pack_path, 'rb') as f:
-        pack_bytes = f.read()
-
-    valid, reason = validate_fontpack(pack_bytes)
-    if not valid:
-        return False, reason
-
     pack_size = len(pack_bytes)
-    pack_crc  = binascii.crc32(pack_bytes) & 0xFFFFFFFF   # whole-pack transport CRC (firmware fw_staging verifies this)
-    _, info   = parse_fontpack_header(pack_bytes)
-
+    pack_crc  = binascii.crc32(pack_bytes) & 0xFFFFFFFF   # whole-image transport CRC (firmware fw_staging verifies this)
     total_chunks = (pack_size + FONTPACK_CHUNK_SIZE - 1) // FONTPACK_CHUNK_SIZE
-    report(0, f"Sending FONTPACK_BEGIN — {pack_size // 1024} KB, "
-              f"content v{info['content_version']}, {info['font_count']} fonts…")
 
     # -- FONTPACK_BEGIN -- (same poll protocol as firmware update: '.'/'~'/'!'/no-reply)
     hid.drain_replies()
     pkt = bytearray([HID_POLYKYBD, CMD_FONTPACK_BEGIN]) + struct.pack('<IIB', pack_size, pack_crc, bundle_id)
     deadline    = time.monotonic() + 90
-    timeout_ms  = 15000   # generous for first send (master erases the pack region)
+    timeout_ms  = 15000   # generous for first send (master erases the slot region)
     begin_ready = False
     erase_start = time.monotonic()
-    # The staging erase (2–4 MB flash region, NOT the running firmware) takes
-    # ~10–15 s; the firmware reports no fine-grained progress, so creep the bar
-    # 1→2 % and show elapsed seconds instead of sitting frozen at a single 1 %.
+    # The slot erase reports no fine-grained progress, so creep the bar 1->2 %
+    # and show elapsed seconds instead of sitting frozen at a single 1 %.
     def _erasing(msg):
         elapsed = int(time.monotonic() - erase_start)
-        report(1, f"{msg} — {elapsed}s elapsed (≈10–15 s)…")
+        report(1, f"{msg} — {elapsed}s elapsed…")
 
     while not begin_ready:
         if cancelled():
             _abort_cleanup(hid)
-            return False, "Flash cancelled by user."
+            return False, "Flash cancelled by user.", None
         if time.monotonic() > deadline:
             _abort_cleanup(hid)
-            return False, ("FONTPACK_BEGIN timed out — keyboard did not finish erasing "
-                           "within 90 s.  Check the USB cable and try again.")
+            return False, (f"BEGIN timed out — keyboard did not finish erasing the {what} "
+                           "region within 90 s.  Check the USB cable and try again."), None
 
         ok, reply = hid.send_and_read(pkt, timeout=timeout_ms)
         timeout_ms = 5000
 
         if not ok or len(reply) < 3:
-            _erasing("Erasing font-pack staging area — keyboard will reconnect when done")
+            _erasing(f"Erasing the {what} region — keyboard will reconnect when done")
             if not hid.wait_for_reconnect(timeout_s=30):
-                return False, ("FONTPACK_BEGIN failed — keyboard did not reconnect "
-                               "within 30 s.  Check the USB cable and try again.")
+                return False, ("BEGIN failed — keyboard did not reconnect "
+                               "within 30 s.  Check the USB cable and try again."), None
             hid.drain_replies()
         elif reply[2] == ord('.'):
             begin_ready = True
         elif reply[2] == ord('~'):
-            _erasing("Erasing font-pack staging area (both halves)")
+            _erasing(f"Erasing the {what} region (both halves)")
             time.sleep(0.3)
         else:
             _abort_cleanup(hid)
             hid.close_interface()
             return False, (
-                "FONTPACK_BEGIN failed — the slave half could not be prepared.\n"
-                "Ensure both keyboard halves are connected and powered on, then try again."
-            )
+                f"BEGIN failed — the keyboard rejected the {what} transfer.\n"
+                "Ensure both keyboard halves are connected and powered on (and the "
+                "firmware supports this transfer), then try again."
+            ), None
 
     report(2, f"Region erased. Sending {total_chunks} chunks…")
 
@@ -253,7 +235,7 @@ def flash_fontpack(hid, pack_path: str, progress_cb=None, cancel_flag: list = No
         if cancelled():
             _abort_cleanup(hid)
             hid.close_interface()
-            return False, "Flash cancelled by user."
+            return False, "Flash cancelled by user.", None
 
         offset    = i * FONTPACK_CHUNK_SIZE
         raw_chunk = pack_bytes[offset:offset + FONTPACK_CHUNK_SIZE]
@@ -290,23 +272,61 @@ def flash_fontpack(hid, pack_path: str, progress_cb=None, cancel_flag: list = No
             _abort_cleanup(hid)
             hid.close_interface()
             return False, (
-                f"FONTPACK_CHUNK failed at offset {offset} after {_CHUNK_ATTEMPTS} attempts — {reason}.\n"
+                f"CHUNK failed at offset {offset} after {_CHUNK_ATTEMPTS} attempts — {reason}.\n"
                 "Ensure both keyboard halves are connected and running the same firmware, "
                 "then try again — the flash resumes from scratch and is safe to repeat."
-            )
+            ), None
         pause = min(0.05 * (2 ** (attempts - 1)), 1.0)
         report(2 + int(96 * (i + 1) / total_chunks),
                f"Chunk {i + 1}/{total_chunks} — retry {attempts}/{_CHUNK_ATTEMPTS - 1} "
                f"(waiting {int(pause * 1000)} ms)…")
         time.sleep(pause)
 
-    # -- FONTPACK_COMMIT -- verifies the staged CRC, re-loads fonts in place (no reboot).
-    report(98, "Verifying the font pack (CRC32) and loading…")
+    # -- FONTPACK_COMMIT -- verifies the staged CRC and finalizes the slot in place.
+    report(98, f"Verifying the {what} (CRC32)…")
     pkt = bytearray([HID_POLYKYBD, CMD_FONTPACK_COMMIT])
     ok, reply = hid.send_and_read(pkt, timeout=8000)
     if not ok or len(reply) < 3 or reply[2] != ord('.'):
         hid.close_interface()
-        return False, "FONTPACK_COMMIT failed — CRC mismatch or pack rejected on keyboard. Try again."
+        return False, f"COMMIT failed — CRC mismatch or the {what} was rejected on the keyboard. Try again.", None
+    return True, "", reply
+
+
+def flash_fontpack(hid, pack_path: str, progress_cb=None, cancel_flag: list = None,
+                   bundle_id: int = 0) -> tuple[bool, str]:
+    """Full HID font-pack flash flow: BEGIN -> N*CHUNK -> COMMIT (no reboot).
+
+    Args:
+        hid:          HidHelper instance.
+        pack_path:    Path to the .plyf font-pack image.
+        progress_cb:  Optional callable(percent: int, message: str).
+        cancel_flag:  Optional single-element list; set cancel_flag[0] = True to abort.
+        bundle_id:    Which bundle slot to flash (index in res/fontpack/bundles.json;
+                      firmware resolves it to a fixed flash slot). 0 by default.
+
+    Returns:
+        (True, success_msg) or (False, error_msg).
+    """
+    def report(pct, msg):
+        if progress_cb:
+            progress_cb(pct, msg)
+
+    def cancelled():
+        return cancel_flag is not None and cancel_flag[0]
+
+    with open(pack_path, 'rb') as f:
+        pack_bytes = f.read()
+
+    valid, reason = validate_fontpack(pack_bytes)
+    if not valid:
+        return False, reason
+    _, info = parse_fontpack_header(pack_bytes)
+
+    report(0, f"Sending FONTPACK_BEGIN — {len(pack_bytes) // 1024} KB, "
+              f"content v{info['content_version']}, {info['font_count']} fonts…")
+    ok, err, reply = _stream_slot(hid, pack_bytes, bundle_id, "font pack", report, cancelled)
+    if not ok:
+        return False, err
 
     cver = struct.unpack_from('<H', bytes(reply), 3)[0] if len(reply) >= 5 else info['content_version']
     report(100, f"Done. Font pack v{cver} loaded on both halves.")
@@ -314,3 +334,48 @@ def flash_fontpack(hid, pack_path: str, progress_cb=None, cancel_flag: list = No
         f"Font pack flashed and loaded successfully (content v{cver}, {info['font_count']} fonts).\n\n"
         "Both halves reloaded the new glyphs immediately — no reboot needed."
     )
+
+
+def validate_doomwad(whx_bytes) -> tuple[bool, str]:
+    """(ok, '') when whx_bytes looks like WHX game data that fits the slot."""
+    data = bytes(whx_bytes)
+    if len(data) < 8:
+        return False, "Game-data file is too small to be a WHX image."
+    if data[:4] != DOOMWAD_MAGIC:
+        return False, f"Bad magic {data[:4]!r} (expected {DOOMWAD_MAGIC!r}); not a WHX game-data image."
+    if len(data) > DOOMWAD_MAX_SIZE:
+        return False, f"Game data too large: {len(data)} bytes (max {DOOMWAD_MAX_SIZE // 1024} KB)."
+    return True, ""
+
+
+def flash_doomwad(hid, whx_path: str, progress_cb=None, cancel_flag: list = None) -> tuple[bool, str]:
+    """Install the doom easter egg's WHX game data to BOTH halves over HID.
+
+    Rides the font-pack BEGIN/CHUNK/COMMIT transport with the DOOMWAD pseudo
+    bundle id — the firmware routes it to the WHX slot at the top of the
+    resource region (the engine's TINY_WAD_ADDR) and the split bridge writes
+    the slave's copy in the same pass, so no BOOTSEL access is needed on
+    either half. The data survives firmware updates (different flash region).
+    """
+    def report(pct, msg):
+        if progress_cb:
+            progress_cb(pct, msg)
+
+    def cancelled():
+        return cancel_flag is not None and cancel_flag[0]
+
+    with open(whx_path, 'rb') as f:
+        whx_bytes = f.read()
+
+    valid, reason = validate_doomwad(whx_bytes)
+    if not valid:
+        return False, reason
+
+    report(0, f"Sending game data — {len(whx_bytes) // 1024} KB…")
+    ok, err, _reply = _stream_slot(hid, whx_bytes, DOOMWAD_BUNDLE_ID, "game data", report, cancelled)
+    if not ok:
+        return False, err
+
+    report(100, "Done. Game data installed on both halves.")
+    return True, ("Game data installed on both halves (it survives firmware updates).\n\n"
+                  "You know the magic word.")

--- a/polyhost/device/hid_fontpack.py
+++ b/polyhost/device/hid_fontpack.py
@@ -25,13 +25,19 @@ FONTPACK_CHUNK_SIZE = 56            # payload bytes/chunk (+4-byte offset = 60);
 FONTPACK_MAX_SIZE   = 0x200000      # 2 MB cap; the whole bundle window. Per-bundle, the
                                     # firmware rejects a pack larger than its fixed slot.
 
-# Pseudo bundle id selecting the DOOMWAD target — the doom easter egg's WHX game
-# data slot at the top of the resource region (firmware FONTPACK_BUNDLE_DOOMWAD /
-# FW_TARGET_DOOMWAD). Same BEGIN/CHUNK/COMMIT transport, different fixed slot;
-# COMMIT validates the "IWHX" magic instead of reloading fonts.
-DOOMWAD_BUNDLE_ID = 0x7F
-DOOMWAD_MAGIC     = b"IWHX"
-DOOMWAD_MAX_SIZE  = 0x200000        # the 2 MB WHX slot (flash 0x600000..0x7FFFFF)
+# Pseudo bundle ids selecting the doom targets — the easter egg's WHX game
+# data and the executable engine pack, both in the upper resource region
+# (firmware FONTPACK_BUNDLE_DOOMWAD/_DOOMPACK, FW_TARGET_DOOMWAD/_DOOMPACK;
+# layout in qmk base/fw_staging.h, design in doom/PACK_DESIGN.md). Same
+# BEGIN/CHUNK/COMMIT transport, different fixed slots; COMMIT validates the
+# magic instead of reloading fonts.
+DOOMWAD_BUNDLE_ID  = 0x7F
+DOOMWAD_MAGIC      = b"IWHX"
+DOOMWAD_MAX_SIZE   = 0x1C0000       # the 1.75 MB WHX slot (flash 0x600000..0x7BFFFF;
+                                    # shrunk from 2 MB when the pack slot was carved)
+DOOMPACK_BUNDLE_ID = 0x7E
+DOOMPACK_MAGIC     = b"PlyX"
+DOOMPACK_MAX_SIZE  = 0x40000        # the 256 KB engine-pack slot (flash 0x7C0000..0x7FFFFF)
 
 # Pack format (base/fontpack.h). The host only needs to parse/validate the header.
 FONTPACK_MAGIC        = b"PlyF"
@@ -379,3 +385,52 @@ def flash_doomwad(hid, whx_path: str, progress_cb=None, cancel_flag: list = None
     report(100, "Done. Game data installed on both halves.")
     return True, ("Game data installed on both halves (it survives firmware updates).\n\n"
                   "You know the magic word.")
+
+
+def validate_doompack(pack_bytes) -> tuple[bool, str]:
+    """(ok, '') when pack_bytes looks like a PlyX engine pack that fits the slot.
+
+    Only the magic and slot fit are checked here — the firmware's loader does
+    the full ABI/CRC/RAM-pairing validation at game entry (a stale pack is
+    refused there and the egg falls back to the fire demo)."""
+    data = bytes(pack_bytes)
+    if len(data) < 64:
+        return False, "Engine-pack file is too small to be a PlyX image."
+    if data[:4] != DOOMPACK_MAGIC:
+        return False, f"Bad magic {data[:4]!r} (expected {DOOMPACK_MAGIC!r}); not a PlyX engine pack."
+    if len(data) > DOOMPACK_MAX_SIZE:
+        return False, f"Engine pack too large: {len(data)} bytes (max {DOOMPACK_MAX_SIZE // 1024} KB)."
+    return True, ""
+
+
+def flash_doompack(hid, plyd_path: str, progress_cb=None, cancel_flag: list = None) -> tuple[bool, str]:
+    """Install the doom easter egg's executable engine pack (.plyd) to BOTH
+    halves over HID — the slave's lockstep drone runs the same engine.
+
+    Same transport as :func:`flash_doomwad`, DOOMPACK pseudo bundle. ⚠️ The
+    pack is RAM-paired with the exact firmware build it was produced with
+    (doom/pack/build_pack.sh); a mismatched pack is harmless — the firmware
+    loader refuses it at game entry — but the egg then runs the fire demo
+    until a matching pack is flashed."""
+    def report(pct, msg):
+        if progress_cb:
+            progress_cb(pct, msg)
+
+    def cancelled():
+        return cancel_flag is not None and cancel_flag[0]
+
+    with open(plyd_path, 'rb') as f:
+        pack_bytes = f.read()
+
+    valid, reason = validate_doompack(pack_bytes)
+    if not valid:
+        return False, reason
+
+    report(0, f"Sending engine pack — {len(pack_bytes) // 1024} KB…")
+    ok, err, _reply = _stream_slot(hid, pack_bytes, DOOMPACK_BUNDLE_ID, "engine pack", report, cancelled)
+    if not ok:
+        return False, err
+
+    report(100, "Done. Engine pack installed on both halves.")
+    return True, ("Engine pack installed on both halves (it survives firmware updates,\n"
+                  "but must match the firmware build it was made for).")

--- a/polyhost/device/hid_fontpack.py
+++ b/polyhost/device/hid_fontpack.py
@@ -354,7 +354,7 @@ def validate_doomwad(whx_bytes) -> tuple[bool, str]:
     return True, ""
 
 
-def flash_doomwad(hid, whx_path: str, progress_cb=None, cancel_flag: list = None) -> tuple[bool, str]:
+def flash_doomwad(hid, whx: str | bytes, progress_cb=None, cancel_flag: list = None) -> tuple[bool, str]:
     """Install the doom easter egg's WHX game data to BOTH halves over HID.
 
     Rides the font-pack BEGIN/CHUNK/COMMIT transport with the DOOMWAD pseudo
@@ -362,6 +362,9 @@ def flash_doomwad(hid, whx_path: str, progress_cb=None, cancel_flag: list = None
     resource region (the engine's TINY_WAD_ADDR) and the split bridge writes
     the slave's copy in the same pass, so no BOOTSEL access is needed on
     either half. The data survives firmware updates (different flash region).
+
+    `whx` is the raw image bytes, or a path for convenience — callers that
+    already validated the contents pass bytes, so the file is read once.
     """
     def report(pct, msg):
         if progress_cb:
@@ -370,8 +373,11 @@ def flash_doomwad(hid, whx_path: str, progress_cb=None, cancel_flag: list = None
     def cancelled():
         return cancel_flag is not None and cancel_flag[0]
 
-    with open(whx_path, 'rb') as f:
-        whx_bytes = f.read()
+    if isinstance(whx, (bytes, bytearray)):
+        whx_bytes = bytes(whx)
+    else:
+        with open(whx, 'rb') as f:
+            whx_bytes = f.read()
 
     valid, reason = validate_doomwad(whx_bytes)
     if not valid:
@@ -403,7 +409,7 @@ def validate_doompack(pack_bytes) -> tuple[bool, str]:
     return True, ""
 
 
-def flash_doompack(hid, plyx_path: str, progress_cb=None, cancel_flag: list = None) -> tuple[bool, str]:
+def flash_doompack(hid, plyx: str | bytes, progress_cb=None, cancel_flag: list = None) -> tuple[bool, str]:
     """Install the doom easter egg's executable engine pack (.plyx) to BOTH
     halves over HID — the slave's lockstep drone runs the same engine.
 
@@ -411,7 +417,10 @@ def flash_doompack(hid, plyx_path: str, progress_cb=None, cancel_flag: list = No
     pack is RAM-paired with the exact firmware build it was produced with
     (doom/pack/build_pack.sh); a mismatched pack is harmless — the firmware
     loader refuses it at game entry — but the egg then runs the fire demo
-    until a matching pack is flashed."""
+    until a matching pack is flashed.
+
+    `plyx` is the raw pack bytes, or a path for convenience — callers that
+    already validated the contents pass bytes, so the file is read once."""
     def report(pct, msg):
         if progress_cb:
             progress_cb(pct, msg)
@@ -419,8 +428,11 @@ def flash_doompack(hid, plyx_path: str, progress_cb=None, cancel_flag: list = No
     def cancelled():
         return cancel_flag is not None and cancel_flag[0]
 
-    with open(plyx_path, 'rb') as f:
-        pack_bytes = f.read()
+    if isinstance(plyx, (bytes, bytearray)):
+        pack_bytes = bytes(plyx)
+    else:
+        with open(plyx, 'rb') as f:
+            pack_bytes = f.read()
 
     valid, reason = validate_doompack(pack_bytes)
     if not valid:

--- a/polyhost/device/hid_fontpack.py
+++ b/polyhost/device/hid_fontpack.py
@@ -403,8 +403,8 @@ def validate_doompack(pack_bytes) -> tuple[bool, str]:
     return True, ""
 
 
-def flash_doompack(hid, plyd_path: str, progress_cb=None, cancel_flag: list = None) -> tuple[bool, str]:
-    """Install the doom easter egg's executable engine pack (.plyd) to BOTH
+def flash_doompack(hid, plyx_path: str, progress_cb=None, cancel_flag: list = None) -> tuple[bool, str]:
+    """Install the doom easter egg's executable engine pack (.plyx) to BOTH
     halves over HID — the slave's lockstep drone runs the same engine.
 
     Same transport as :func:`flash_doomwad`, DOOMPACK pseudo bundle. ⚠️ The
@@ -419,7 +419,7 @@ def flash_doompack(hid, plyd_path: str, progress_cb=None, cancel_flag: list = No
     def cancelled():
         return cancel_flag is not None and cancel_flag[0]
 
-    with open(plyd_path, 'rb') as f:
+    with open(plyx_path, 'rb') as f:
         pack_bytes = f.read()
 
     valid, reason = validate_doompack(pack_bytes)

--- a/polyhost/device/hid_helper.py
+++ b/polyhost/device/hid_helper.py
@@ -1,9 +1,12 @@
+import logging
 import pathlib
 import threading
 import platform
 import os
 import time
 from typing import Any
+
+log = logging.getLogger('PolyHost')
 if platform.system() == 'Windows':
     import ctypes
     ctypes.CDLL(os.path.dirname(os.path.realpath(__file__)) + '\\win-hidapi-0-15\\hidapi.dll')
@@ -196,8 +199,8 @@ class HidHelper:
         if self.remote_console is not None:
             try:
                 self.remote_console.close()
-            except Exception:
-                pass
+            except Exception as e:
+                log.debug("Closing the stale console handle failed: %s", e)
             self.remote_console = None
         # One guard around the whole enumerate+open sequence: hid.enumerate
         # itself can raise on USB churn/permission errors, and this runs from
@@ -209,7 +212,8 @@ class HidHelper:
                                       and j['usage'] == self.settings.HID_CONSOLE_USAGE]
             if console_hid_interfaces:
                 self.remote_console = hid.Device(path=console_hid_interfaces[0]['path'])
-        except Exception:
+        except Exception as e:
+            log.debug("Console reopen failed (enumerate/open): %s", e)
             self.remote_console = None
         return self.remote_console is not None
 

--- a/polyhost/device/hid_helper.py
+++ b/polyhost/device/hid_helper.py
@@ -181,6 +181,35 @@ class HidHelper:
             return bytearray()
         return self.remote_console.read(self.settings.HID_CONSOLE_REPORT_SIZE, timeout=0)
 
+    def console_acquired(self):
+        return self.remote_console is not None
+
+    def reopen_console(self) -> bool:
+        """(Re-)open only the console interface.
+
+        After a firmware apply the device re-enumerates; the reconnect path
+        rebuilds the whole HidHelper, but in the come-back-up race the console
+        interface can be missing from that enumeration while raw HID already
+        works — remote_console then silently stayed None until a replug
+        (field 2026-07-05: "no console log after flashing/apply"). Returns
+        True when a console handle is open afterwards."""
+        if self.remote_console is not None:
+            try:
+                self.remote_console.close()
+            except Exception:
+                pass
+            self.remote_console = None
+        device_interfaces = hid.enumerate(self.settings.VID, self.settings.PID)
+        console_hid_interfaces = [j for j in device_interfaces
+                                  if j['usage_page'] == self.settings.HID_CONSOLE_USAGE_PAGE
+                                  and j['usage'] == self.settings.HID_CONSOLE_USAGE]
+        if console_hid_interfaces:
+            try:
+                self.remote_console = hid.Device(path=console_hid_interfaces[0]['path'])
+            except Exception:
+                self.remote_console = None
+        return self.remote_console is not None
+
     def interface_acquired(self):
         return self.interface is not None
 

--- a/polyhost/device/hid_helper.py
+++ b/polyhost/device/hid_helper.py
@@ -199,15 +199,18 @@ class HidHelper:
             except Exception:
                 pass
             self.remote_console = None
-        device_interfaces = hid.enumerate(self.settings.VID, self.settings.PID)
-        console_hid_interfaces = [j for j in device_interfaces
-                                  if j['usage_page'] == self.settings.HID_CONSOLE_USAGE_PAGE
-                                  and j['usage'] == self.settings.HID_CONSOLE_USAGE]
-        if console_hid_interfaces:
-            try:
+        # One guard around the whole enumerate+open sequence: hid.enumerate
+        # itself can raise on USB churn/permission errors, and this runs from
+        # the background self-heal path where an escaped exception is noise.
+        try:
+            device_interfaces = hid.enumerate(self.settings.VID, self.settings.PID)
+            console_hid_interfaces = [j for j in device_interfaces
+                                      if j['usage_page'] == self.settings.HID_CONSOLE_USAGE_PAGE
+                                      and j['usage'] == self.settings.HID_CONSOLE_USAGE]
+            if console_hid_interfaces:
                 self.remote_console = hid.Device(path=console_hid_interfaces[0]['path'])
-            except Exception:
-                self.remote_console = None
+        except Exception:
+            self.remote_console = None
         return self.remote_console is not None
 
     def interface_acquired(self):

--- a/polyhost/device/poly_kybd.py
+++ b/polyhost/device/poly_kybd.py
@@ -46,6 +46,8 @@ class PolyKybd:
     def __init__(self, settings: DeviceSettings, poly_settings: PolySettings):
         self.log = logging.getLogger('PolyHost')
         self.console_buffer = ""
+        self._console_fail_count = 0
+        self._console_reopen_at = 0.0
         self.all_languages = list()
         self.current_lang = None
         self.hid = None
@@ -125,10 +127,17 @@ class PolyKybd:
 
     def get_console_output(self, flush_and_return=True) -> str | None:
         try:
+            if self.hid and not self.hid.console_acquired():
+                # The reconnect rebuild can race the device's re-enumeration
+                # (post firmware apply) and come up with raw HID working but
+                # no console interface listed yet — self-heal instead of
+                # staying silent until a replug (field 2026-07-05).
+                self._maybe_reopen_console()
             last_line = self.hid.get_console_output()
             while len(last_line) > 0:
                 self.console_buffer += last_line.decode().strip('\x00')
                 last_line = self.hid.get_console_output()
+            self._console_fail_count = 0
         except Exception as e:
             # Never RETURN the exception text — it would be published as if the
             # KEYBOARD had printed it. hidapi's hid_error() on Windows is
@@ -136,12 +145,25 @@ class PolyKybd:
             # rebooting (e.g. mid firmware flash) flooded the log with one bare
             # "Success" line per 250 ms console poll (field 2026-07-04).
             self.log.debug("console read failed: %s", e)
+            self._console_fail_count += 1
+            if self._console_fail_count >= 20:  # ~5 s of failures at 250 ms
+                self._console_fail_count = 0
+                self._maybe_reopen_console()
 
         if flush_and_return:
             console_out = self.console_buffer
             self.console_buffer = ""
             return console_out
         return None
+
+    def _maybe_reopen_console(self):
+        """Throttled console-interface reopen (see get_console_output)."""
+        now = time.monotonic()
+        if now - self._console_reopen_at < 5.0:
+            return
+        self._console_reopen_at = now
+        if self.hid and self.hid.reopen_console():
+            self.log.info("HID console (re)attached")
 
     def query_id(self) -> tuple[bool, str]:
         try:

--- a/polyhost/device/poly_kybd.py
+++ b/polyhost/device/poly_kybd.py
@@ -35,6 +35,12 @@ OS_MIN_PROTOCOL = 7
 # Minimum firmware PROTOCOL_VERSION for the glyph-script get/set command (cmd 30).
 GLYPH_SCRIPT_MIN_PROTOCOL = 9
 
+# Console self-heal (see get_console_output): reopen the console interface after
+# this many consecutive failed reads (~5 s at the 250 ms poll), throttled to at
+# most one reopen attempt per interval.
+CONSOLE_FAIL_REOPEN_THRESHOLD = 20
+CONSOLE_REOPEN_MIN_INTERVAL_S = 5.0
+
 from polyhost.util.dict_util import split_dict
 
 
@@ -146,7 +152,7 @@ class PolyKybd:
             # "Success" line per 250 ms console poll (field 2026-07-04).
             self.log.debug("console read failed: %s", e)
             self._console_fail_count += 1
-            if self._console_fail_count >= 20:  # ~5 s of failures at 250 ms
+            if self._console_fail_count >= CONSOLE_FAIL_REOPEN_THRESHOLD:
                 self._console_fail_count = 0
                 self._maybe_reopen_console()
 
@@ -159,7 +165,7 @@ class PolyKybd:
     def _maybe_reopen_console(self):
         """Throttled console-interface reopen (see get_console_output)."""
         now = time.monotonic()
-        if now - self._console_reopen_at < 5.0:
+        if now - self._console_reopen_at < CONSOLE_REOPEN_MIN_INTERVAL_S:
             return
         self._console_reopen_at = now
         if self.hid and self.hid.reopen_console():

--- a/polyhost/device/poly_kybd.py
+++ b/polyhost/device/poly_kybd.py
@@ -130,7 +130,12 @@ class PolyKybd:
                 self.console_buffer += last_line.decode().strip('\x00')
                 last_line = self.hid.get_console_output()
         except Exception as e:
-            return str(e)
+            # Never RETURN the exception text — it would be published as if the
+            # KEYBOARD had printed it. hidapi's hid_error() on Windows is
+            # famously "Success" for a failed read, so a device that is busy /
+            # rebooting (e.g. mid firmware flash) flooded the log with one bare
+            # "Success" line per 250 ms console poll (field 2026-07-04).
+            self.log.debug("console read failed: %s", e)
 
         if flush_and_return:
             console_out = self.console_buffer

--- a/polyhost/server/control_server.py
+++ b/polyhost/server/control_server.py
@@ -326,6 +326,7 @@ class ControlServer:
             p.M_FONTPACK_SYNC: lambda conn, params: _unwrap(c.sync_fontpack()),
             p.M_FONTPACK_WIPE: lambda conn, params: _unwrap(c.wipe_fontpack()),
             p.M_FONTPACK_BUNDLES: lambda conn, params: _unwrap(c.fontpack_bundle_status()),
+            p.M_DOOM_INSTALL: lambda conn, params: _unwrap(c.install_doomwad(params["path"])),
             p.M_PAUSE_SET: self._cmd_pause_set,
             p.M_MRU_SAVE: self._cmd_mru_save,
             p.M_SETTINGS_GET: lambda conn, params: c.settings_get(params["key"]),

--- a/polyhost/server/control_server.py
+++ b/polyhost/server/control_server.py
@@ -327,6 +327,7 @@ class ControlServer:
             p.M_FONTPACK_WIPE: lambda conn, params: _unwrap(c.wipe_fontpack()),
             p.M_FONTPACK_BUNDLES: lambda conn, params: _unwrap(c.fontpack_bundle_status()),
             p.M_DOOM_INSTALL: lambda conn, params: _unwrap(c.install_doomwad(params["path"])),
+            p.M_DOOM_INSTALL_PACK: lambda conn, params: _unwrap(c.install_doompack(params["path"])),
             p.M_PAUSE_SET: self._cmd_pause_set,
             p.M_MRU_SAVE: self._cmd_mru_save,
             p.M_SETTINGS_GET: lambda conn, params: c.settings_get(params["key"]),

--- a/polyhost/server/protocol.py
+++ b/polyhost/server/protocol.py
@@ -96,6 +96,8 @@ M_FONTPACK_BUNDLES = "fontpack.bundles"  # {} -> {"shipped": bool, "bundles": [{
                                          #        shipped_version,stale}]} (per-bundle device vs shipped)
 M_DOOM_INSTALL = "doom.install"        # {"path": str} -> {"queued": bool}; installs the easter egg's
                                        #   WHX game data (streams fontpack_flash_* events)
+M_DOOM_INSTALL_PACK = "doom.install_pack"  # {"path": str} -> {"queued": bool}; installs the easter
+                                       #   egg's executable engine pack (.plyd, same event stream)
 M_HOST_SHUTDOWN = "host.shutdown"      # {} -> {"shutting_down": True}
 # Inject an external active-window report into remote window tracking (H4c).
 # {"handle": str|int, "name": str, "title": str} -> (ok, payload). Same data the

--- a/polyhost/server/protocol.py
+++ b/polyhost/server/protocol.py
@@ -97,7 +97,7 @@ M_FONTPACK_BUNDLES = "fontpack.bundles"  # {} -> {"shipped": bool, "bundles": [{
 M_DOOM_INSTALL = "doom.install"        # {"path": str} -> {"queued": bool}; installs the easter egg's
                                        #   WHX game data (streams fontpack_flash_* events)
 M_DOOM_INSTALL_PACK = "doom.install_pack"  # {"path": str} -> {"queued": bool}; installs the easter
-                                       #   egg's executable engine pack (.plyd, same event stream)
+                                       #   egg's executable engine pack (.plyx, same event stream)
 M_HOST_SHUTDOWN = "host.shutdown"      # {} -> {"shutting_down": True}
 # Inject an external active-window report into remote window tracking (H4c).
 # {"handle": str|int, "name": str, "title": str} -> (ok, payload). Same data the

--- a/polyhost/server/protocol.py
+++ b/polyhost/server/protocol.py
@@ -94,6 +94,8 @@ M_FONTPACK_SYNC = "fontpack.sync"      # {} -> {"queued": bool}; flashes all sta
 M_FONTPACK_WIPE = "fontpack.wipe"      # {} -> {"queued": bool}; empties all bundle slots
 M_FONTPACK_BUNDLES = "fontpack.bundles"  # {} -> {"shipped": bool, "bundles": [{id,index,device_version,
                                          #        shipped_version,stale}]} (per-bundle device vs shipped)
+M_DOOM_INSTALL = "doom.install"        # {"path": str} -> {"queued": bool}; installs the easter egg's
+                                       #   WHX game data (streams fontpack_flash_* events)
 M_HOST_SHUTDOWN = "host.shutdown"      # {} -> {"shutting_down": True}
 # Inject an external active-window report into remote window tracking (H4c).
 # {"handle": str|int, "name": str, "title": str} -> (ok, payload). Same data the

--- a/tests/device/hid_fontpack_test.py
+++ b/tests/device/hid_fontpack_test.py
@@ -624,5 +624,36 @@ class TestValidateDoomwad(unittest.TestCase):
         self.assertIn("magic", msg)
 
 
+class TestValidateDoompack(unittest.TestCase):
+    """PlyX engine-pack validation for the doom easter egg install (DOOMPACK target)."""
+
+    def test_valid_plyx_accepted(self):
+        from polyhost.device.hid_fontpack import validate_doompack
+        ok, msg = validate_doompack(b"PlyX" + b"\x00" * 100)
+        self.assertTrue(ok, msg)
+
+    def test_bad_magic_rejected(self):
+        from polyhost.device.hid_fontpack import validate_doompack
+        ok, msg = validate_doompack(b"PlyF" + b"\x00" * 100)   # a font pack is not an engine pack
+        self.assertFalse(ok)
+        self.assertIn("magic", msg)
+
+    def test_too_small_rejected(self):
+        from polyhost.device.hid_fontpack import validate_doompack
+        ok, _ = validate_doompack(b"PlyX" + b"\x00" * 10)   # below the 64-byte header
+        self.assertFalse(ok)
+
+    def test_too_large_rejected(self):
+        from polyhost.device.hid_fontpack import validate_doompack, DOOMPACK_MAX_SIZE
+        ok, msg = validate_doompack(b"PlyX" + b"\x00" * DOOMPACK_MAX_SIZE)
+        self.assertFalse(ok)
+        self.assertIn("large", msg)
+
+    def test_doompack_bundle_id_matches_firmware(self):
+        # FONTPACK_BUNDLE_DOOMPACK in qmk base/fw_staging.h — keep in lockstep.
+        from polyhost.device.hid_fontpack import DOOMPACK_BUNDLE_ID
+        self.assertEqual(DOOMPACK_BUNDLE_ID, 0x7E)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/device/hid_fontpack_test.py
+++ b/tests/device/hid_fontpack_test.py
@@ -611,6 +611,18 @@ class TestValidateDoomwad(unittest.TestCase):
         from polyhost.device.hid_fontpack import DOOMWAD_BUNDLE_ID
         self.assertEqual(DOOMWAD_BUNDLE_ID, 0x7F)
 
+    def test_flash_helpers_accept_bytes(self):
+        # install_* passes the already-read (and validated) bytes straight
+        # through, so the file is read once — invalid bytes must be rejected
+        # before any HID traffic (hid=None would explode otherwise).
+        from polyhost.device.hid_fontpack import flash_doomwad, flash_doompack
+        ok, msg = flash_doomwad(None, b"IWAD" + b"\x00" * 100)
+        self.assertFalse(ok)
+        self.assertIn("magic", msg)
+        ok, msg = flash_doompack(None, b"NOPE" + b"\x00" * 100)
+        self.assertFalse(ok)
+        self.assertIn("magic", msg)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/device/hid_fontpack_test.py
+++ b/tests/device/hid_fontpack_test.py
@@ -581,5 +581,36 @@ class TestDecideStaleBundles(unittest.TestCase):
         self.assertEqual(decide_stale_bundles({0: 9, 5: 9}, self._SHIPPED), [])
 
 
+class TestValidateDoomwad(unittest.TestCase):
+    """WHX game-data validation for the doom easter egg install (DOOMWAD target)."""
+
+    def test_valid_whx_accepted(self):
+        from polyhost.device.hid_fontpack import validate_doomwad
+        ok, msg = validate_doomwad(b"IWHX" + b"\x00" * 100)
+        self.assertTrue(ok, msg)
+
+    def test_bad_magic_rejected(self):
+        from polyhost.device.hid_fontpack import validate_doomwad
+        ok, msg = validate_doomwad(b"IWAD" + b"\x00" * 100)   # a plain WAD is not a WHX
+        self.assertFalse(ok)
+        self.assertIn("magic", msg)
+
+    def test_too_small_rejected(self):
+        from polyhost.device.hid_fontpack import validate_doomwad
+        ok, _ = validate_doomwad(b"IWH")
+        self.assertFalse(ok)
+
+    def test_too_large_rejected(self):
+        from polyhost.device.hid_fontpack import validate_doomwad, DOOMWAD_MAX_SIZE
+        ok, msg = validate_doomwad(b"IWHX" + b"\x00" * DOOMWAD_MAX_SIZE)
+        self.assertFalse(ok)
+        self.assertIn("large", msg)
+
+    def test_doomwad_bundle_id_matches_firmware(self):
+        # FONTPACK_BUNDLE_DOOMWAD in qmk base/fw_staging.h — keep in lockstep.
+        from polyhost.device.hid_fontpack import DOOMWAD_BUNDLE_ID
+        self.assertEqual(DOOMWAD_BUNDLE_ID, 0x7F)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/device/poly_kybd_console_test.py
+++ b/tests/device/poly_kybd_console_test.py
@@ -1,0 +1,99 @@
+"""Tests for the HID-console self-heal in PolyKybd.get_console_output.
+
+Covers the two field bugs this logic fixed (2026-07): exception text leaking
+into the console output as if the keyboard printed it (the "Success" flood),
+and the console interface silently staying detached after a firmware apply.
+"""
+import time
+import unittest
+
+from polyhost.device.poly_kybd import (
+    CONSOLE_FAIL_REOPEN_THRESHOLD,
+    CONSOLE_REOPEN_MIN_INTERVAL_S,
+)
+
+from tests.device.poly_kybd_cmd_test import make_keeb
+
+
+class ConsoleStubHid:
+    """Just the console surface of HidHelper that get_console_output touches."""
+
+    def __init__(self, acquired=True, lines=None, raise_on_read=False):
+        self.acquired = acquired
+        self.lines = list(lines or [])
+        self.raise_on_read = raise_on_read
+        self.reopen_calls = 0
+
+    def console_acquired(self):
+        return self.acquired
+
+    def reopen_console(self):
+        self.reopen_calls += 1
+        return False
+
+    def get_console_output(self):
+        if self.raise_on_read:
+            raise OSError("Success")   # hidapi's famously unhelpful Windows error
+        if self.lines:
+            return self.lines.pop(0)
+        return bytearray()
+
+
+def make_console_keeb(**stub_kwargs):
+    keeb, _ = make_keeb()
+    stub = ConsoleStubHid(**stub_kwargs)
+    keeb.hid = stub
+    return keeb, stub
+
+
+class TestConsoleSelfHeal(unittest.TestCase):
+    def test_read_exception_is_not_published_as_output(self):
+        # The exception text must never appear in the returned console output.
+        keeb, _ = make_console_keeb(raise_on_read=True)
+        out = keeb.get_console_output()
+        self.assertEqual(out, "")
+
+    def test_normal_reads_accumulate_and_flush(self):
+        keeb, _ = make_console_keeb(lines=[bytearray(b"hello "), bytearray(b"world")])
+        self.assertEqual(keeb.get_console_output(), "hello world")
+        # Flushed — a second call returns the (now empty) buffer.
+        self.assertEqual(keeb.get_console_output(), "")
+
+    def test_missing_console_triggers_reopen(self):
+        keeb, stub = make_console_keeb(acquired=False)
+        keeb.get_console_output()
+        self.assertEqual(stub.reopen_calls, 1)
+
+    def test_reopen_is_throttled(self):
+        keeb, stub = make_console_keeb(acquired=False)
+        keeb.get_console_output()
+        keeb.get_console_output()   # immediately again — inside the throttle window
+        self.assertEqual(stub.reopen_calls, 1)
+        # Age the last attempt past the interval — the next poll retries.
+        keeb._console_reopen_at = time.monotonic() - CONSOLE_REOPEN_MIN_INTERVAL_S - 0.1
+        keeb.get_console_output()
+        self.assertEqual(stub.reopen_calls, 2)
+
+    def test_fail_count_threshold_triggers_reopen(self):
+        keeb, stub = make_console_keeb(acquired=True, raise_on_read=True)
+        for i in range(CONSOLE_FAIL_REOPEN_THRESHOLD - 1):
+            keeb.get_console_output()
+            keeb._console_reopen_at = 0.0   # isolate the fail-count gate from the throttle
+        self.assertEqual(stub.reopen_calls, 0, "reopen fired before the threshold")
+        keeb.get_console_output()   # the Nth consecutive failure
+        self.assertEqual(stub.reopen_calls, 1)
+
+    def test_successful_read_resets_fail_count(self):
+        keeb, stub = make_console_keeb(acquired=True, raise_on_read=True)
+        for _ in range(CONSOLE_FAIL_REOPEN_THRESHOLD - 1):
+            keeb.get_console_output()
+        stub.raise_on_read = False
+        keeb.get_console_output()               # success — resets the counter
+        self.assertEqual(keeb._console_fail_count, 0)
+        stub.raise_on_read = True
+        keeb.get_console_output()               # one new failure must not reopen
+        self.assertEqual(stub.reopen_calls, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Host-side support for the firmware Doom easter egg (companion PR: thpoll83/qmk_firmware#122):

- **`polyctl doom install <doom1.whx>`** — flashes the shareware game data (WHX, up to 1.75 MB) to its resource-flash slot on both halves over HID, with progress events streamed to the terminal.
- **`polyctl doom install-pack <doom_pack_v1.plyx>`** — flashes the executable engine pack (`PlyX`) to its 256 KB slot. Validates the pack header (magic/size bounds) before sending.
- Both ride the existing fontpack `BEGIN/CHUNK/COMMIT` HID transport via pseudo-bundle IDs (`0x7F` WAD, `0x7E` pack) in `hid_fontpack.py` — no protocol change, `__protocol__` untouched. Plumbed through `PolyCore.install_doompack`, the control-socket method `M_DOOM_INSTALL_PACK`, and the CLI.
- Two unrelated console robustness fixes that fell out of the flash-test loop: self-heal the HID console after a firmware apply, and stop publishing console-read exceptions as output (the "Success" log flood).

## Version bump label

`bump:minor` — new backwards-compatible feature; no `__protocol__` change (the flash transport reuses the existing fontpack commands).

## Testing
- [x] Tested locally against real hardware — WHX and engine-pack installs used across ~20 hardware flash/test rounds of the firmware easter egg; unit tests added in `tests/device/hid_fontpack_test.py`
- [ ] Tested with mock device (if UI changes) — n/a, no UI changes (CLI + core only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C9Uiuz2SNtoTVAdjm6dE8V

---
_Generated by [Claude Code](https://claude.ai/code/session_01C9Uiuz2SNtoTVAdjm6dE8V)_

## Summary by Sourcery

Add host-side support to flash Doom easter egg game data and engine packs over the existing font-pack HID transport, and improve HID console robustness after firmware operations.

New Features:
- Add CLI `polyctl doom install` and `polyctl doom install-pack` commands for installing Doom WHX game data and PlyX engine packs to both keyboard halves over HID.
- Expose new core APIs and server protocol methods to trigger Doom game-data and engine-pack installs using the font-pack flash event stream.
- Introduce validation helpers for Doom WHX and PlyX images to ensure correct magic and size before flashing into dedicated resource slots.

Bug Fixes:
- Self-heal the HID console interface after firmware apply by detecting missing console handles and reopening the console endpoint.
- Stop propagating console read exceptions as user-visible output, reducing misleading "Success" log noise during device reboots or busy states.

Enhancements:
- Refactor font-pack flashing into a reusable `_stream_slot` helper that can be shared by font-pack and Doom installers.
- Route Doom assets via pseudo font-pack bundle IDs matching firmware resource slots without changing the underlying HID protocol.

Tests:
- Add unit tests for Doom WHX validation and bundle-ID consistency in the HID font-pack module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new `doom install` and `doom install-pack` commands for loading Doom-related content from the CLI.
  - Added support for installing Doom content through the device control interface, with progress updates during transfer.

- **Bug Fixes**
  - Improved console reconnect handling so output recovery is more reliable after connection drops.
  - Strengthened content validation to catch invalid, incomplete, or oversized files before upload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->