### PR TITLE
Doom attract screensaver: host support for the 3rd idle style (IdleStyle.DOOM)

### DIFF
--- a/polyhost/cli/polyctl.py
+++ b/polyhost/cli/polyctl.py
@@ -504,7 +504,7 @@ def build_parser():
     p_idle_style.add_argument(
         "style", nargs="?", choices=list(_IDLE_STYLE_VALUES.keys()), default=None,
         help="omit to print the current style; 'pulse' = legacy, 'jitter' = move the "
-             "legend, 'doom' = attract-demo screensaver (doom-enabled firmware)")
+             "legend, 'iddqd' = attract-demo screensaver (doom-enabled firmware)")
     p_idle_style.set_defaults(func=_cmd_idle_style)
 
     p_glyph_script = sub.add_parser(

--- a/polyhost/cli/polyctl.py
+++ b/polyhost/cli/polyctl.py
@@ -19,7 +19,7 @@ import argparse
 import json
 import sys
 
-from polyhost.device.command_ids import GlyphScript  # stdlib-only (Enum), no Qt
+from polyhost.device.command_ids import GlyphScript, IdleStyle  # stdlib-only (Enum), no Qt
 from polyhost.server import protocol
 
 
@@ -159,7 +159,8 @@ def _cmd_idle(client, args):
     return 0
 
 
-_IDLE_STYLE_NAMES = {0: "pulse", 1: "jitter", 2: "doom"}
+# Derived from the shared IdleStyle enum so new styles appear automatically.
+_IDLE_STYLE_NAMES = {s.value: s.name.lower() for s in IdleStyle}
 _IDLE_STYLE_VALUES = {v: k for k, v in _IDLE_STYLE_NAMES.items()}
 
 
@@ -501,7 +502,7 @@ def build_parser():
     p_idle_style = sub.add_parser(
         "idle-style", help="get or set the idle anti-burn-in style (firmware v4+)")
     p_idle_style.add_argument(
-        "style", nargs="?", choices=["pulse", "jitter", "doom"], default=None,
+        "style", nargs="?", choices=list(_IDLE_STYLE_VALUES.keys()), default=None,
         help="omit to print the current style; 'pulse' = legacy, 'jitter' = move the "
              "legend, 'doom' = attract-demo screensaver (doom-enabled firmware)")
     p_idle_style.set_defaults(func=_cmd_idle_style)

--- a/polyhost/cli/polyctl.py
+++ b/polyhost/cli/polyctl.py
@@ -159,7 +159,7 @@ def _cmd_idle(client, args):
     return 0
 
 
-_IDLE_STYLE_NAMES = {0: "pulse", 1: "jitter"}
+_IDLE_STYLE_NAMES = {0: "pulse", 1: "jitter", 2: "doom"}
 _IDLE_STYLE_VALUES = {v: k for k, v in _IDLE_STYLE_NAMES.items()}
 
 
@@ -501,8 +501,9 @@ def build_parser():
     p_idle_style = sub.add_parser(
         "idle-style", help="get or set the idle anti-burn-in style (firmware v4+)")
     p_idle_style.add_argument(
-        "style", nargs="?", choices=["pulse", "jitter"], default=None,
-        help="omit to print the current style; 'pulse' = legacy, 'jitter' = move the legend")
+        "style", nargs="?", choices=["pulse", "jitter", "doom"], default=None,
+        help="omit to print the current style; 'pulse' = legacy, 'jitter' = move the "
+             "legend, 'doom' = attract-demo screensaver (doom-enabled firmware)")
     p_idle_style.set_defaults(func=_cmd_idle_style)
 
     p_glyph_script = sub.add_parser(

--- a/polyhost/device/command_ids.py
+++ b/polyhost/device/command_ids.py
@@ -82,9 +82,13 @@ class IdleStyle(Enum):
 
     PULSE is the legacy contrast-only breathing; JITTER additionally relocates the
     key legend by a small random offset each pulse cycle so the lit pixels migrate.
+    DOOM runs the doom easter egg's attract demo as a screensaver instead of the
+    pulse (dismissed by the first key press); firmware without the doom build (or
+    older than the feature) falls back to / NACKs it — surfaced as a plain error.
     """
     PULSE = 0
     JITTER = 1
+    DOOM = 2
 
 
 class GlyphScript(Enum):

--- a/polyhost/device/command_ids.py
+++ b/polyhost/device/command_ids.py
@@ -82,13 +82,15 @@ class IdleStyle(Enum):
 
     PULSE is the legacy contrast-only breathing; JITTER additionally relocates the
     key legend by a small random offset each pulse cycle so the lit pixels migrate.
-    DOOM runs the doom easter egg's attract demo as a screensaver instead of the
+    IDDQD runs the doom easter egg's attract demo as a screensaver instead of the
     pulse (dismissed by the first key press); firmware without the doom build (or
     older than the feature) falls back to / NACKs it — surfaced as a plain error.
+    (Named for the cheat code, matching the tray/CLI label; the firmware calls the
+    same value IDLE_STYLE_DOOM internally — the wire value 2 is what's shared.)
     """
     PULSE = 0
     JITTER = 1
-    DOOM = 2
+    IDDQD = 2
 
 
 class GlyphScript(Enum):

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -410,9 +410,9 @@ class PolyHost(QApplication):
         self.idle_jitter_action.setData(IdleStyle.JITTER.value)
         # Attract-demo screensaver: needs doom-enabled firmware — an unsupported
         # keyboard NACKs the set, surfaced by change_idle_style's error path.
-        self.idle_doom_action = QAction("Doom (attract demo)", parent=self, checkable=True)
-        self.idle_doom_action.setData(IdleStyle.DOOM.value)
-        for act in (self.idle_pulse_action, self.idle_jitter_action, self.idle_doom_action):
+        self.idle_iddqd_action = QAction("IDDQD (attract demo)", parent=self, checkable=True)
+        self.idle_iddqd_action.setData(IdleStyle.IDDQD.value)
+        for act in (self.idle_pulse_action, self.idle_jitter_action, self.idle_iddqd_action):
             idle_group.addAction(act)
             # noinspection PyUnresolvedReferences
             act.triggered.connect(self.change_idle_style)
@@ -1195,7 +1195,7 @@ class PolyHost(QApplication):
         ok, value = self.core.get_idle_style()
         self.idle_pulse_action.setChecked(bool(ok) and value == IdleStyle.PULSE.value)
         self.idle_jitter_action.setChecked(bool(ok) and value == IdleStyle.JITTER.value)
-        self.idle_doom_action.setChecked(bool(ok) and value == IdleStyle.DOOM.value)
+        self.idle_iddqd_action.setChecked(bool(ok) and value == IdleStyle.IDDQD.value)
 
     def change_idle_style(self):
         value = self.sender().data()

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -408,7 +408,11 @@ class PolyHost(QApplication):
         self.idle_pulse_action.setData(IdleStyle.PULSE.value)
         self.idle_jitter_action = QAction("Jitter (move legend)", parent=self, checkable=True)
         self.idle_jitter_action.setData(IdleStyle.JITTER.value)
-        for act in (self.idle_pulse_action, self.idle_jitter_action):
+        # Attract-demo screensaver: needs doom-enabled firmware — an unsupported
+        # keyboard NACKs the set, surfaced by change_idle_style's error path.
+        self.idle_doom_action = QAction("Doom (attract demo)", parent=self, checkable=True)
+        self.idle_doom_action.setData(IdleStyle.DOOM.value)
+        for act in (self.idle_pulse_action, self.idle_jitter_action, self.idle_doom_action):
             idle_group.addAction(act)
             # noinspection PyUnresolvedReferences
             act.triggered.connect(self.change_idle_style)
@@ -1191,6 +1195,7 @@ class PolyHost(QApplication):
         ok, value = self.core.get_idle_style()
         self.idle_pulse_action.setChecked(bool(ok) and value == IdleStyle.PULSE.value)
         self.idle_jitter_action.setChecked(bool(ok) and value == IdleStyle.JITTER.value)
+        self.idle_doom_action.setChecked(bool(ok) and value == IdleStyle.DOOM.value)
 
     def change_idle_style(self):
         value = self.sender().data()

--- a/polyhost/server/protocol.py
+++ b/polyhost/server/protocol.py
@@ -55,7 +55,7 @@ M_LANG_LIST = "lang.list"              # {} -> [code, ...]
 M_LANG_SET = "lang.set"                # {"lang": "deDE"} -> (ok, payload)
 M_BRIGHTNESS_SET = "brightness.set"    # {"value": 0..50} -> (ok, payload)
 M_IDLE_SET = "idle.set"                # {"idle": bool} -> (ok, payload)
-M_IDLE_STYLE_SET = "idle.style.set"    # {"value": 0|1} -> (ok, payload)  (0=pulse, 1=jitter)
+M_IDLE_STYLE_SET = "idle.style.set"    # {"value": 0|1|2} -> (ok, payload)  (0=pulse, 1=jitter, 2=doom attract)
 M_IDLE_STYLE_GET = "idle.style.get"    # {} -> (ok, value)
 M_GLYPH_SCRIPT_SET = "glyph.script.set"  # {"value": 0|1|...} -> (ok, payload)  (0=standard, 1=tengwar)
 M_GLYPH_SCRIPT_GET = "glyph.script.get"  # {} -> (ok, value)

--- a/polyhost/server/protocol.py
+++ b/polyhost/server/protocol.py
@@ -55,7 +55,7 @@ M_LANG_LIST = "lang.list"              # {} -> [code, ...]
 M_LANG_SET = "lang.set"                # {"lang": "deDE"} -> (ok, payload)
 M_BRIGHTNESS_SET = "brightness.set"    # {"value": 0..50} -> (ok, payload)
 M_IDLE_SET = "idle.set"                # {"idle": bool} -> (ok, payload)
-M_IDLE_STYLE_SET = "idle.style.set"    # {"value": 0|1|2} -> (ok, payload)  (0=pulse, 1=jitter, 2=doom attract)
+M_IDLE_STYLE_SET = "idle.style.set"    # {"value": 0|1|2} -> (ok, payload)  (0=pulse, 1=jitter, 2=iddqd attract demo)
 M_IDLE_STYLE_GET = "idle.style.get"    # {} -> (ok, value)
 M_GLYPH_SCRIPT_SET = "glyph.script.set"  # {"value": 0|1|...} -> (ok, payload)  (0=standard, 1=tengwar)
 M_GLYPH_SCRIPT_GET = "glyph.script.get"  # {} -> (ok, value)

--- a/tests/device/poly_kybd_idle_style_test.py
+++ b/tests/device/poly_kybd_idle_style_test.py
@@ -17,7 +17,7 @@ class TestIdleStyleEncoding(unittest.TestCase):
         # Lockstep with the firmware's poly_idle_style (state.h) — append-only.
         self.assertEqual(IdleStyle.PULSE.value, 0)
         self.assertEqual(IdleStyle.JITTER.value, 1)
-        self.assertEqual(IdleStyle.DOOM.value, 2)
+        self.assertEqual(IdleStyle.IDDQD.value, 2)
 
     def test_compose_set_jitter(self):
         result = compose_cmd(Cmd.IDLE_STYLE, IdleStyle.JITTER.value)

--- a/tests/device/poly_kybd_idle_style_test.py
+++ b/tests/device/poly_kybd_idle_style_test.py
@@ -14,8 +14,10 @@ class TestIdleStyleEncoding(unittest.TestCase):
         self.assertEqual(Cmd.IDLE_STYLE.value, 28)
 
     def test_idle_style_enum_values(self):
+        # Lockstep with the firmware's poly_idle_style (state.h) — append-only.
         self.assertEqual(IdleStyle.PULSE.value, 0)
         self.assertEqual(IdleStyle.JITTER.value, 1)
+        self.assertEqual(IdleStyle.DOOM.value, 2)
 
     def test_compose_set_jitter(self):
         result = compose_cmd(Cmd.IDLE_STYLE, IdleStyle.JITTER.value)


### PR DESCRIPTION
## Summary

Host support for the firmware's new third anti-burn-in idle style (companion firmware PR: thpoll83/qmk_firmware#122). When idle, a doom-enabled keyboard can now run the Doom easter egg's attract demo as a chrome-free screensaver, dismissed by the first key press.

- `IdleStyle.DOOM = 2` (`command_ids.py`) — append-only, byte-identical to the firmware's `poly_idle_style`.
- `polyctl idle-style doom` (with help text).
- Tray **Idle Anti-Burn-In** submenu gains **"Doom (attract demo)"**.
- `M_IDLE_STYLE_SET` protocol-constant comment updated for the new value.

The set rides the existing cmd 28 path — **no `__protocol__` bump** (idle-style is already v4). A keyboard without the doom build NACKs / falls back to the pulse at runtime, surfaced by the existing `change_idle_style` error path. The enum-lockstep unit test is extended to assert the new value.

## Version bump label

`bump:minor` — new backwards-compatible feature; no `__protocol__` change.

## Testing
- [x] Tested locally against real hardware — the `idle-style doom` set + firmware v47 screensaver were validated on a split72 (the delivered test firmware).
- [ ] Tested with mock device (if UI changes) — n/a for the CLI/enum change; the tray action mirrors the existing pulse/jitter radio items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C9Uiuz2SNtoTVAdjm6dE8V

---
_Generated by [Claude Code](https://claude.ai/code/session_01C9Uiuz2SNtoTVAdjm6dE8V)_

## Summary by Sourcery

Introduce host-side support for a Doom attract-demo idle style, wiring it through the CLI, tray menu actions, protocol constants, and associated tests while preserving compatibility with existing firmware behavior.

New Features:
- Add support for a third idle anti-burn-in style, Doom, across CLI, host UI, and device protocol.

Enhancements:
- Extend idle-style documentation and protocol comments to describe the new Doom attract-demo behavior and firmware fallback.
- Update idle-style enum lockstep test to cover the new Doom value to ensure alignment with firmware.

Tests:
- Expand idle-style enum tests to assert the Doom style value and maintain protocol compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new idle style option, **Doom (attract demo)**, across the app.
  * The tray menu and CLI now let you select this additional mode alongside Pulse and Jitter.

* **Bug Fixes**
  * Idle style status now stays in sync when Doom is active, so the current selection is reflected correctly in the interface.

* **Tests**
  * Updated coverage to include the new idle style value and ensure the supported options remain consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->