### PR TITLE
Apply GUI self-update via the daemon so the protocol version refreshes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,24 @@ Since the HID-worker refactor (`docs/hid-worker-refactor.md`), the Qt main threa
 ## Key notes
 
 - **Bump `__protocol__` (`polyhost/_version.py`) in lockstep with the firmware PROTOCOL_VERSION** — the reconnect gate (`polyhost/core/decisions.py`) connects **only on an exact match** (`kb_proto == host_protocol`); any mismatch shows *"Protocol mismatch, please update"* and refuses to connect, so the keyboard never reaches the features that bump motivated. **This has been forgotten twice** (host stayed at P3 while firmware features advanced to P4 *idle-style* and P5 *brightness host-auto*, leaving current keyboards rejected). Rule of thumb: whenever you add a firmware-protocol feature threshold (e.g. `IDLE_STYLE_MIN_PROTOCOL`, `_BRIGHTNESS_FLAGS_PROTOCOL` — the `>= N` runtime feature gates), the firmware protocol has advanced to **N**, so `__protocol__` must be set to **N** in the same change. The feature `>= N` gates are layered checks *on top of* the exact-match connect gate — they only ever fire once `__protocol__` already equals the device's protocol.
+- **GUI self-update must be applied by the DAEMON, not the client (daemon-by-default).**
+  In daemon mode the tray GUI is a `--connect` client and a separate `--headless`
+  daemon owns `PolyCore` — and therefore the **protocol gate** (its loaded
+  `_version.__protocol__`). So the tray's "Check for updates → install" routes the
+  install through the daemon over RPC (`RemoteCore.install_update` → `M_UPDATE_INSTALL`
+  → `PolyCore.install_update`), letting the daemon overwrite the files and **re-exec
+  itself** (`headless.py` `_on_update_event`). It must **not** run `UpdateInstaller`
+  in the GUI process: that refreshed only the client while the daemon kept running the
+  pre-update code, so the daemon stayed on the OLD `__protocol__` and went on rejecting
+  the keyboard with *"Protocol mismatch, please update"* until manually restarted
+  (field 2026-07). After the daemon re-execs, `PolyHost._on_update_done` (client mode)
+  waits for the control endpoint to go **down → back LIVE** (`_await_daemon_restart_then_relaunch`)
+  before relaunching the GUI — relaunching immediately would re-attach to the still-up
+  **old** daemon (the bug) or race the re-exec and spawn a second daemon. The daemon's
+  `update_*` **core events are dicts** (`{"pct","msg"}` / `{"relay_path"}` / `{"msg"}`)
+  while the legacy in-GUI `UpdateInstaller` emits tuples/strings — `_on_job_done`
+  normalizes both. The `polyctl update install` path already restarted the daemon
+  correctly; only the tray menu path was broken.
 - **Font-pack bundles (protocol 6+)**: the external-flash font pack ships as **N
   per-family bundles** (`polyhost/res/fontpack/<id>.plyf` + `bundles.json`), not one
   blob. `query_id()` parses the per-bundle `content_version` block the firmware

--- a/polyhost/handler/remote_window.py
+++ b/polyhost/handler/remote_window.py
@@ -7,6 +7,12 @@ from polyhost.handler.common import Flags, find_matching_entry
 
 TCP_PORT = 50162
 BUFFER_SIZE = 1024
+# How long the listener's accept() blocks before re-checking stop_event. This is
+# purely the shutdown-responsiveness knob (accept still returns immediately when a
+# forwarder connects) — `RemoteHandler.close()` joins this thread, so a large value
+# stalls every daemon/GUI quit by that long while accept() waits out its timeout.
+# Kept short so a quit is prompt; the idle re-check cost is one syscall/second.
+RECV_ACCEPT_TIMEOUT = 1.0
 
 
 # Needs to be started as thread
@@ -28,7 +34,7 @@ def receive_from_forwarder(log, on_report, stop_event):
         return
 
     sock.listen(5)
-    sock.settimeout(10.0)
+    sock.settimeout(RECV_ACCEPT_TIMEOUT)
     log.info("Remote listener started on port %d", TCP_PORT)
 
     while not stop_event.is_set():

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -1407,6 +1407,23 @@ class PolyHost(QApplication):
             f"Downloading v{release.version}…", "PolyKybdHost Update",
             tray_icon=self.tray)
 
+        if self.client_mode:
+            # Daemon-by-default (H4b): the daemon owns the device AND the
+            # protocol gate (its loaded `_version.__protocol__`), so it must be
+            # the process that overwrites the files and re-execs. A GUI-side
+            # install would refresh only this client — the daemon would keep
+            # running the pre-update code and stay on the OLD protocol, so it
+            # would go on rejecting the keyboard with "Protocol mismatch, please
+            # update" until manually restarted (the field-reported bug). Drive
+            # the daemon's installer over RPC instead; its update_* events stream
+            # back through RemoteCore to the same _on_job_done handlers, and the
+            # daemon re-execs itself on completion (see _on_update_done). The
+            # `release` is re-resolved daemon-side, so it isn't passed here.
+            ok, payload = self.core.install_update()
+            if not ok:
+                self._on_update_failed(str(payload))
+            return
+
         b = self.bridge
         self._update_installer = UpdateInstaller(
             release,
@@ -1432,9 +1449,63 @@ class PolyHost(QApplication):
         if self._update_progress is not None:
             self._update_progress.close()
             self._update_progress = None
+        if self.client_mode:
+            # The daemon applied the update in-process and re-execs itself
+            # (headless.py `_on_update_event`), so it comes up on the new code
+            # and the new protocol. This GUI just has to reconnect — but wait
+            # for the daemon to actually go down and rebind first: restarting now
+            # would re-attach to the still-live OLD daemon (leaving the daemon on
+            # the old protocol — the bug), and racing its re-exec risks spawning
+            # a second daemon. See _await_daemon_restart_then_relaunch.
+            self.log.info("Update applied by the daemon; waiting for it to restart…")
+            self._await_daemon_restart_then_relaunch()
+            return
         self.log.info("Update applied, restarting...")
         self.quit_app()
         restart_app()
+
+    def _await_daemon_restart_then_relaunch(self):
+        """Client mode: after a daemon-driven self-update, the daemon re-execs
+        itself. Poll the control endpoint until it has gone down (old daemon
+        tearing down) and come back LIVE (new daemon bound on the updated code),
+        then relaunch this GUI so it reconnects to the fresh daemon and runs the
+        new GUI code too. Requiring the observed down→up transition is what stops
+        us re-attaching to the still-up old daemon; polling until LIVE is what
+        stops the relaunch from race-spawning a competing daemon."""
+        from polyhost.server import instance as inst
+        address = getattr(self.core, "_address", None)
+        authkey = getattr(self.core, "_authkey", None)
+        interval_ms = 400
+        state = {"saw_down": False, "elapsed_ms": 0}
+
+        def _relaunch(reason):
+            self.log.info("Relaunching GUI to reconnect to the core daemon (%s).", reason)
+            self.quit_app()
+            restart_app()
+
+        def poll():
+            if self.is_closing:
+                return
+            try:
+                outcome = inst.probe_existing(address, authkey, timeout=0.3)
+            except Exception:  # noqa: BLE001 — a probe error means "not reachable"
+                outcome = inst.STALE
+            if not state["saw_down"]:
+                if outcome != inst.LIVE:
+                    state["saw_down"] = True
+            elif outcome == inst.LIVE:
+                _relaunch("daemon back up on the new version")
+                return
+            state["elapsed_ms"] += interval_ms
+            if state["elapsed_ms"] >= 30000:
+                # Never observed the clean transition (daemon slow, or it never
+                # dropped). Relaunch anyway — main_app will spawn a daemon if
+                # none is live, so we still end up on the new code.
+                _relaunch("timed out waiting for the daemon restart")
+                return
+            QTimer.singleShot(interval_ms, poll)
+
+        QTimer.singleShot(interval_ms, poll)
 
     def _on_relay_needed(self, relay_path: str):
         """Windows: some files (e.g. hidapi.dll) were locked by the running process.
@@ -1442,6 +1513,19 @@ class PolyHost(QApplication):
         A relay script was written that will copy them once we exit and release
         the handles, then relaunch the app.  All non-DLL files were already copied.
         """
+        if self.client_mode:
+            # The daemon ran the installer, so the daemon owns this relay — its
+            # own headless `_on_update_event` spawns the relay script, which
+            # copies the daemon's locked files after it exits and relaunches the
+            # daemon. This GUI must NOT spawn the relay too; it only needs to
+            # reconnect once the daemon is back, exactly like the clean path.
+            self.log.info("Daemon staged a locked-file relay (%s); "
+                          "waiting for it to restart.", relay_path)
+            if self._update_progress is not None:
+                self._update_progress.close()
+                self._update_progress = None
+            self._await_daemon_restart_then_relaunch()
+            return
         self.log.info("Relay restart needed for locked files: %s", relay_path)
         if self._update_progress is not None:
             self._update_progress.setLabelText("Restarting to complete update…")
@@ -1783,13 +1867,20 @@ class PolyHost(QApplication):
             if self._update_check_error is not None:
                 self._update_check_error(result)
         elif name == "update_progress":
-            self._on_update_progress(*result)
+            # Local UpdateInstaller emits a (pct, msg) tuple; the daemon's core
+            # event (client mode) carries a {"pct","msg"} dict — accept both.
+            if isinstance(result, dict):
+                self._on_update_progress(result.get("pct", -1), result.get("msg", ""))
+            else:
+                self._on_update_progress(*result)
         elif name == "update_finished_ok":
             self._on_update_done()
         elif name == "update_relay_needed":
-            self._on_relay_needed(result)
+            path = result.get("relay_path") if isinstance(result, dict) else result
+            self._on_relay_needed(path)
         elif name == "update_failed":
-            self._on_update_failed(result)
+            msg = result.get("msg") if isinstance(result, dict) else result
+            self._on_update_failed(msg)
         elif name == "fw_download_progress":
             self._on_fw_download_progress(*result)
         elif name == "fw_download_done":

--- a/tests/cli/polyctl_test.py
+++ b/tests/cli/polyctl_test.py
@@ -298,7 +298,9 @@ class FwFlashUpdateTest(unittest.TestCase):
         rc, out, _ = run_streaming(["fontpack", "flash", "fonts.plyf"],
                                    protocol.M_FONTPACK_FLASH, {"queued": True}, events)
         self.assertEqual(rc, 0)
-        self.assertIn("flash complete", out)
+        # Per-bundle op prints "flashing bundle <id>: complete — <msg>".
+        self.assertIn("complete", out)
+        self.assertIn("loaded v7", out)
 
     def test_fontpack_flash_failure_returns_nonzero(self):
         events = [("fontpack_flash_done", {"ok": False, "msg": "crc mismatch"})]

--- a/tests/gui/cmd_menu_test.py
+++ b/tests/gui/cmd_menu_test.py
@@ -36,9 +36,13 @@ class TestUpdateEnabled(unittest.TestCase):
     def test_fw_actions_collected(self):
         cm, _menu = _build()
         texts = [a.text() for a in cm._fw_actions]
-        self.assertEqual(len(texts), 4)
+        # The font-pack ops (submenu action + Sync + Wipe) ride the same
+        # protocol-independent HID staging transport as the firmware flash, so
+        # they belong in _fw_actions too (usable during a protocol mismatch).
+        self.assertEqual(len(texts), 7)
         for expected in ("Flash + Apply", "Flash Firmware only",
-                         "Apply Staged Firmware", "Activate Bootloader"):
+                         "Apply Staged Firmware", "Font Pack",
+                         "Sync", "Wipe", "Activate Bootloader"):
             self.assertTrue(any(expected in t for t in texts), expected)
 
     def test_protocol_mismatch_keeps_fw_actions_enabled(self):

--- a/tests/gui/host_client_test.py
+++ b/tests/gui/host_client_test.py
@@ -58,6 +58,7 @@ class TestPolyHostModes(unittest.TestCase):
         self.assertIn("LANG_MENU_BUILT True", proc.stdout)
         self.assertIn("LAYOUT_OK layers=9", proc.stdout)
         self.assertIn("DAEMON_QUIT_ACTION present", proc.stdout)
+        self.assertIn("UPDATE_ROUTED_TO_DAEMON True", proc.stdout)
         self.assertIn("SERVER_RUNNING True", proc.stdout)
 
 
@@ -122,6 +123,10 @@ def _smoke_client():
         def settings_list(self):
             return {"brightness": 25}
 
+        def install_update(self):
+            self.install_update_called = True
+            return (True, {"queued": True, "version": "9.9.9"})
+
     addr = os.path.join(tempfile.mkdtemp(), "ctl.sock")
     key = protocol.load_or_create_authkey()
     lg = logging.getLogger("smoke")
@@ -161,6 +166,22 @@ def _smoke_client():
             app.layout_dialog.close()
             # Client mode offers an explicit "stop the daemon too" entry.
             print("DAEMON_QUIT_ACTION", "present" if app.exit_with_daemon is not None else "absent")
+            # A self-update in client mode must be driven through the daemon over
+            # RPC (so the daemon re-execs onto the new protocol), NOT via a local
+            # in-GUI UpdateInstaller thread. Drive _run_update_installer directly
+            # (a real install would end in restart_app/os.execv, which we avoid by
+            # not emitting the terminal update_finished_ok event here).
+            core.install_update_called = False
+            rel = type("Rel", (), {"version": "9.9.9", "published_at": ""})()
+            app._run_update_installer(rel)
+            for _ in range(20):
+                app.processEvents()
+                time.sleep(0.02)
+            print("UPDATE_ROUTED_TO_DAEMON",
+                  getattr(core, "install_update_called", False) and app._update_installer is None)
+            if app._update_progress is not None:
+                app._update_progress.close()
+                app._update_progress = None
             app.quit_app()
         print("SERVER_RUNNING", srv._running)
     finally:

--- a/tests/headless/headless_entry_test.py
+++ b/tests/headless/headless_entry_test.py
@@ -71,7 +71,9 @@ class TestHeadlessHost(unittest.TestCase):
 
     def test_run_loop_exits_on_request_stop(self):
         # Drive the real run() wait-loop on a thread and confirm request_stop
-        # makes it return (and tear down) promptly.
+        # makes it return (and tear down) promptly. Guards against a slow-quit
+        # regression — e.g. the remote-window listener's accept() timeout, which
+        # `close()` waits out on the join (see remote_window.RECV_ACCEPT_TIMEOUT).
         import threading
         from polyhost.headless import HeadlessHost
         host = HeadlessHost(_quiet())
@@ -181,7 +183,7 @@ class TestRunHeadlessLogging(unittest.TestCase):
         tmp = tempfile.mkdtemp(prefix="poly_dlog_")
 
         class _StubHost:
-            def __init__(self, log, ignore_version=False):
+            def __init__(self, log, ignore_version=False, allow_key_injection=False):
                 log.info("stub daemon up")
 
             def run(self):


### PR DESCRIPTION
## Summary

Fixes the reported bug where, after a successful in-app update, PolyKybdHost still believed it was running the previous protocol version until it was fully stopped and restarted.

**Root cause.** In daemon-by-default mode the tray GUI is a `--connect` client and a separate `--headless` daemon owns `PolyCore` — and therefore the **protocol gate** (its loaded `_version.__protocol__`). The tray's "Check for updates → install" ran `UpdateInstaller` **in the GUI process** and then restarted only the GUI, which re-attached to the still-running old daemon. The daemon kept its pre-update `__protocol__` in memory, so it went on rejecting the keyboard with *"Protocol mismatch, please update"* until the daemon process itself was manually restarted. (`polyctl update install` never had this bug — it drives the daemon, which re-execs itself.)

**Fix.** Route the install through the daemon in client mode (`RemoteCore.install_update` → `M_UPDATE_INSTALL` → `PolyCore.install_update`), so the daemon overwrites the files and **re-execs itself** onto the new code/protocol (`headless.py` `_on_update_event`, the same path `polyctl` already used correctly). After the daemon re-execs, the GUI waits for the control endpoint to go **down → back LIVE** before relaunching, so it neither re-attaches to the old daemon nor race-spawns a second one. `_on_job_done` now normalizes the daemon's dict-shaped `update_*` events alongside the local installer's tuples/strings.

Also greens four pre-existing, unrelated unit-test failures found while verifying (three were drifted assertions; the fourth caught a real ~10 s slow-quit in the remote-window listener, fixed at the source with a shorter `accept()` re-check timeout — which also cut the suite from ~69 s to ~24 s).

**Changed:**
- `polyhost/host.py` — client-mode install routes through the daemon; `_await_daemon_restart_then_relaunch`; dict/tuple `update_*` payload normalization; relay path defers to the daemon.
- `polyhost/handler/remote_window.py` — `RECV_ACCEPT_TIMEOUT = 1.0` so `close()` (and every daemon/GUI quit) returns promptly.
- Tests: new client-mode "update routed to daemon" assertion in the GUI harness; refreshed the three drifted assertions (fw-action set, fontpack CLI output, headless stub signature).
- `CLAUDE.md` — documents that GUI self-update must be applied by the daemon.

## Version bump label

Patch bump (default). Bug fix in the update mechanism — no HID protocol change (`__protocol__` stays 11; no matching firmware PR needed).

## Testing
- [ ] Tested locally against real hardware
- [x] Tested with mock device (if UI changes)

Full unit suite under `xvfb`: **940 pass, 1 skip, 0 failures**. The GUI client-mode harness (`tests/gui/host_client_test.py`) now asserts a self-update is routed to the daemon (`UPDATE_ROUTED_TO_DAEMON True`) with no local `UpdateInstaller`. Real-hardware verification of the end-to-end daemon re-exec still pending on a keyboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U3kzsZWTsebxxwPWqVMsHv

---
_Generated by [Claude Code](https://claude.ai/code/session_01U3kzsZWTsebxxwPWqVMsHv)_

## Summary by Sourcery

Route GUI-initiated self-updates through the daemon in client mode so the daemon re-execs onto the new code and refreshed protocol before the GUI reconnects.

New Features:
- Add client-mode update flow that waits for the daemon to restart (down→live) before relaunching the GUI to reconnect to the updated core.

Bug Fixes:
- Fix daemon-by-default tray update path so protocol version refreshes correctly and no longer requires manual daemon restart after a GUI-driven self-update.
- Prevent slow shutdowns by reducing the remote-window listener accept timeout, making daemon/GUI quits return promptly.

Enhancements:
- Normalize update event payloads so GUI handlers accept both local installer tuple/string results and daemon-driven dict-shaped events.
- Include font-pack operations in the firmware action menu so they remain available even under protocol mismatch.

Documentation:
- Document in CLAUDE.md that GUI self-updates in daemon mode must be applied by the daemon via RPC and not by a local UpdateInstaller.

Tests:
- Extend the GUI client-mode harness to assert that self-updates are routed through the daemon rather than a local installer.
- Update CLI font-pack streaming tests to reflect per-bundle completion messaging.
- Adjust headless daemon entry tests for the new stub host signature and to guard against slow-quit regressions tied to remote-window shutdown behaviour.