### PR TITLE
About dialog: version, keyboard metrics, project links & diagnostics

### DIFF
--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -209,6 +209,8 @@ class PolyHost(QApplication):
     def __init__(self, log_level, debug_mode, ignore_version=False,
                  client_mode=False, endpoint=None, connect_retry=False):
         super().__init__(sys.argv)
+        # Wall-clock start, for the About dialog's uptime line.
+        self._start_time = time.monotonic()
         # Tray-only app: keep it out of the macOS Dock (no-op elsewhere).
         from polyhost.util.macos_ui import hide_dock_icon
         hide_dock_icon()
@@ -1125,13 +1127,131 @@ class PolyHost(QApplication):
             subprocess.Popen(["xdg-open", out_dir])
         QMessageBox.information(None, "Mock Dump", f"Saved {len(store)} bitmaps to:\n{out_dir}")
 
+    def _format_uptime(self) -> str:
+        """Human-readable time since this process started (for the About dialog)."""
+        secs = max(0, int(time.monotonic() - self._start_time))
+        d, rem = divmod(secs, 86400)
+        h, rem = divmod(rem, 3600)
+        m, s = divmod(rem, 60)
+        if d:
+            return f"{d}d {h}h {m}m"
+        if h:
+            return f"{h}h {m}m"
+        if m:
+            return f"{m}m {s}s"
+        return f"{s}s"
+
+    def _gather_about_info(self) -> dict:
+        """Collect everything the About dialog + diagnostics text show, in one
+        place. Reads only cached status (no device I/O; works in client mode over
+        RPC too) and never raises — a failed read just yields blanks/defaults."""
+        import platformdirs
+        from PyQt5.QtCore import qVersion
+        try:
+            st = self.core.get_status() or {}
+        except Exception:  # noqa: BLE001 — a status read must never break About
+            st = {}
+        try:
+            n_lang = len(self.core.list_languages() or [])
+        except Exception:  # noqa: BLE001
+            n_lang = 0
+        n_maps = len(getattr(self.core, "mapping", {}) or {})
+        return {
+            "version": __version__,
+            "host_protocol": __protocol__,
+            "mode": "daemon client" if self.client_mode else "standalone",
+            "python": platform.python_version(),
+            "qt": qVersion(),
+            "os": f"{platform.system()} {platform.release()}".strip(),
+            "uptime": self._format_uptime(),
+            "present": bool(st.get("device_present")),
+            "connected": bool(st.get("connected")),
+            "paused": bool(st.get("paused")),
+            "name": st.get("name") or "PolyKybd",
+            "fw": st.get("fw_version") or "?",
+            "hw": st.get("hw_version") or "?",
+            "lang": st.get("current_lang") or "?",
+            "n_lang": n_lang,
+            "kb_proto": st.get("protocol"),
+            "n_maps": n_maps,
+            "config_dir": platformdirs.user_config_dir("PolyHost"),
+            "log_dir": os.getcwd(),
+        }
+
+    @staticmethod
+    def _about_state_word(info: dict) -> str:
+        if info["paused"]:
+            return "paused"
+        if info["connected"]:
+            return "connected"
+        return "present — not connected (protocol/version)"
+
+    def _about_status_html(self, info: dict) -> str:
+        """Keyboard-status block: name, firmware + its protocol (flagged when it
+        mismatches the host), hardware, language count, and connection state.
+        Degrades to 'No keyboard connected' when nothing is present."""
+        if not info["present"]:
+            return ("<b>Keyboard</b><br>"
+                    "<span style='color:gray;'>No keyboard connected.</span>")
+        kb_proto = info["kb_proto"]
+        proto_txt = f"P{kb_proto}" if kb_proto is not None else "P?"
+        if kb_proto is not None and kb_proto != info["host_protocol"]:
+            proto_txt += " <span style='color:#c0392b;'>⚠ mismatch</span>"
+        lang_line = info["lang"] + (
+            f" · {info['n_lang']} languages loaded" if info["n_lang"] else "")
+        rows = [
+            f"<b>Connected keyboard:</b> {info['name']} "
+            f"<span style='color:gray;'>({self._about_state_word(info)})</span>",
+            f"<b>Firmware:</b> {info['fw']} &nbsp;·&nbsp; protocol {proto_txt}",
+            f"<b>Hardware:</b> {info['hw']}",
+            f"<b>Language:</b> {lang_line}",
+        ]
+        return "<div style='line-height:150%;'>" + "<br>".join(rows) + "</div>"
+
+    def _about_env_html(self, info: dict) -> str:
+        """Host environment block: uptime, overlay-mapping count (when known),
+        and the config + log-file locations (handy for support)."""
+        rows = [f"<b>Uptime:</b> {info['uptime']}"]
+        if info["n_maps"]:
+            rows.append(f"<b>Overlay mappings:</b> {info['n_maps']} apps")
+        rows.append(f"<b>Config:</b> {info['config_dir']}")
+        rows.append(f"<b>Logs:</b> {info['log_dir']}")
+        return ("<div style='line-height:150%; color:gray;'>"
+                + "<br>".join(rows) + "</div>")
+
+    def _diagnostics_text(self, info: dict) -> str:
+        """Plain-text version of the About info, for the clipboard button."""
+        lines = [
+            f"PolyKybdHost {info['version']} (HID protocol P{info['host_protocol']})",
+            f"Mode: {info['mode']}  |  Uptime: {info['uptime']}",
+            f"Python {info['python']} · Qt {info['qt']} · {info['os']}",
+        ]
+        if info["present"]:
+            kb_proto = info["kb_proto"]
+            proto = f"P{kb_proto}" if kb_proto is not None else "P?"
+            if kb_proto is not None and kb_proto != info["host_protocol"]:
+                proto += " (MISMATCH)"
+            lines += [
+                f"Keyboard: {info['name']} ({self._about_state_word(info)})",
+                f"  Firmware {info['fw']} · protocol {proto}",
+                f"  Hardware {info['hw']} · Language {info['lang']}"
+                + (f" ({info['n_lang']} loaded)" if info["n_lang"] else ""),
+            ]
+        else:
+            lines.append("Keyboard: not connected")
+        if info["n_maps"]:
+            lines.append(f"Overlay mappings: {info['n_maps']} apps")
+        lines += [f"Config: {info['config_dir']}", f"Logs: {info['log_dir']}"]
+        return "\n".join(lines)
+
     def _build_about_dialog(self) -> QDialog:
-        """Construct the About dialog (host name/version + project links + OK).
+        """Construct the About dialog (host + keyboard info, project links, and
+        Copy-diagnostics / OK buttons).
 
         Split from :meth:`show_about_dialog` so it can be built and inspected in
         a test without the modal ``exec_()`` blocking. Works in client mode too —
         it only shows info about this host program, no device access."""
-        from PyQt5.QtCore import qVersion
+        info = self._gather_about_info()
 
         dlg = QDialog(None)
         dlg.setWindowTitle("About PolyKybdHost")
@@ -1149,14 +1269,13 @@ class PolyHost(QApplication):
         logo.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         header.addWidget(logo, 0, Qt.AlignTop)
 
-        mode = "daemon client" if self.client_mode else "standalone"
         title_lbl = QLabel(
             f"<div style='font-size:15pt; font-weight:bold;'>PolyKybdHost</div>"
-            f"<div style='margin-top:3px;'>Version {__version__}"
-            f" &nbsp;·&nbsp; HID protocol P{__protocol__}</div>"
+            f"<div style='margin-top:3px;'>Version {info['version']}"
+            f" &nbsp;·&nbsp; HID protocol P{info['host_protocol']}</div>"
             f"<div style='color:gray; margin-top:3px;'>"
-            f"Python {platform.python_version()} · Qt {qVersion()} · "
-            f"{platform.system()} · {mode}</div>")
+            f"Python {info['python']} · Qt {info['qt']} · "
+            f"{platform.system()} · {info['mode']}</div>")
         title_lbl.setTextFormat(Qt.RichText)
         title_lbl.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
         header.addWidget(title_lbl, 1)
@@ -1169,16 +1288,22 @@ class PolyHost(QApplication):
         desc.setWordWrap(True)
         outer.addWidget(desc)
 
-        # Connected-keyboard metrics — a cached, no-I/O status snapshot (works in
-        # client mode over RPC too). Shows the keyboard's own protocol next to the
-        # host's above, so a "Protocol mismatch" is diagnosable right here.
-        status = QLabel(self._about_status_html())
+        # Connected-keyboard metrics — cached snapshot; the keyboard's own protocol
+        # sits next to the host's above, so a mismatch is diagnosable right here.
+        status = QLabel(self._about_status_html(info))
         status.setTextFormat(Qt.RichText)
         status.setWordWrap(True)
         status.setStyleSheet(
             "QLabel { background: rgba(127,127,127,0.12); border-radius: 6px;"
             " padding: 8px 10px; }")
         outer.addWidget(status)
+
+        # Host environment (uptime / overlay mappings / config + log paths).
+        env = QLabel(self._about_env_html(info))
+        env.setTextFormat(Qt.RichText)
+        env.setWordWrap(True)
+        env.setTextInteractionFlags(Qt.TextSelectableByMouse)  # copy the paths
+        outer.addWidget(env)
 
         # Project links — open in the system browser on click. Shown scheme-less
         # (github.com/… , polykybd.org) but href carries the full https URL.
@@ -1199,51 +1324,25 @@ class PolyHost(QApplication):
         links.setTextInteractionFlags(Qt.TextBrowserInteraction)
         outer.addWidget(links)
 
+        # Buttons: Copy diagnostics (left, ActionRole — doesn't close) + OK.
         btn_box = QDialogButtonBox(QDialogButtonBox.Ok)
+        copy_btn = btn_box.addButton("Copy diagnostics", QDialogButtonBox.ActionRole)
+
+        def _copy_diag():
+            self.clipboard().setText(self._diagnostics_text(self._gather_about_info()))
+            copy_btn.setText("Copied ✓")
+            QTimer.singleShot(1500, lambda: copy_btn.setText("Copy diagnostics"))
+        copy_btn.clicked.connect(_copy_diag)
+
         btn_box.accepted.connect(dlg.accept)
         ok_btn = btn_box.button(QDialogButtonBox.Ok)
         if ok_btn is not None:
             ok_btn.setDefault(True)
             ok_btn.setFocus()
-        outer.addWidget(btn_box, 0, Qt.AlignRight)
+        outer.addWidget(btn_box)
 
-        dlg.setMinimumWidth(360)
+        dlg.setMinimumWidth(380)
         return dlg
-
-    def _about_status_html(self) -> str:
-        """Keyboard-status block for the About dialog: name, firmware + its
-        protocol (flagged when it mismatches the host), hardware, and language
-        count. Reads the cached status snapshot (no device I/O); degrades to
-        'No keyboard connected' when nothing is present or the read fails."""
-        try:
-            st = self.core.get_status() or {}
-        except Exception:  # noqa: BLE001 — a status read must never break About
-            st = {}
-        try:
-            n_lang = len(self.core.list_languages() or [])
-        except Exception:  # noqa: BLE001
-            n_lang = 0
-
-        if not st.get("device_present"):
-            return ("<b>Keyboard</b><br>"
-                    "<span style='color:gray;'>No keyboard connected.</span>")
-
-        name = st.get("name") or "PolyKybd"
-        fw = st.get("fw_version") or "?"
-        hw = st.get("hw_version") or "?"
-        lang = st.get("current_lang") or "?"
-        kb_proto = st.get("protocol")
-        proto_txt = f"P{kb_proto}" if kb_proto is not None else "P?"
-        if kb_proto is not None and kb_proto != __protocol__:
-            proto_txt += " <span style='color:#c0392b;'>⚠ mismatch</span>"
-        lang_line = f"{lang}" + (f" · {n_lang} languages loaded" if n_lang else "")
-        rows = [
-            f"<b>Connected keyboard:</b> {name}",
-            f"<b>Firmware:</b> {fw} &nbsp;·&nbsp; protocol {proto_txt}",
-            f"<b>Hardware:</b> {hw}",
-            f"<b>Language:</b> {lang_line}",
-        ]
-        return "<div style='line-height:150%;'>" + "<br>".join(rows) + "</div>"
 
     def show_about_dialog(self):
         """Show the modal About dialog, snapped near the tray icon."""

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -1335,7 +1335,14 @@ class PolyHost(QApplication):
         def _copy_diag():
             self.clipboard().setText(self._diagnostics_text(self._gather_about_info()))
             copy_btn.setText("Copied ✓")
-            QTimer.singleShot(1500, lambda: copy_btn.setText("Copy diagnostics"))
+            # Reset the label after a moment. Parent the timer to the button so
+            # it's destroyed with the dialog — a bare QTimer.singleShot could
+            # otherwise fire into a deleted widget if the dialog is closed within
+            # the delay (RuntimeError on the dead Qt object).
+            reset = QTimer(copy_btn)
+            reset.setSingleShot(True)
+            reset.timeout.connect(lambda: copy_btn.setText("Copy diagnostics"))
+            reset.start(1500)
         copy_btn.clicked.connect(_copy_diag)
 
         btn_box.accepted.connect(dlg.accept)

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -70,6 +70,7 @@ IS_PLASMA = os.getenv("XDG_CURRENT_DESKTOP") == "KDE"
 
 # Project links surfaced in the About dialog.
 POLYKYBD_HOMEPAGE_URL = "https://polykybd.org"
+KOFI_BLOG_URL         = "https://ko-fi.com/polykb"
 SUPPORT_URL           = "https://discord.gg/gW8JescH7M"
 POLYHOST_REPO_URL     = "https://github.com/thpoll83/PolyKybdHost"
 FIRMWARE_REPO_URL     = "https://github.com/thpoll83/qmk_firmware"
@@ -1306,15 +1307,18 @@ class PolyHost(QApplication):
         outer.addWidget(env)
 
         # Project links — open in the system browser on click. Shown scheme-less
-        # (github.com/… , polykybd.org) but href carries the full https URL.
-        def _link(url, emoji):
+        # (github.com/… , polykybd.org) but href carries the full https URL. Links
+        # whose URL doesn't say what they are (Blog, Discord) get a short label.
+        def _link(url, emoji, label=None):
             shown = url.split("://", 1)[-1]
-            return f"{emoji} <a href='{url}'>{shown}</a>"
+            text = f"{label} — {shown}" if label else shown
+            return f"{emoji} <a href='{url}'>{text}</a>"
 
         links = QLabel(
             "<div style='line-height:170%;'>"
             + _link(POLYKYBD_HOMEPAGE_URL, "🌐") + "<br>"
-            + _link(SUPPORT_URL, "💬") + "<br>"
+            + _link(KOFI_BLOG_URL, "📝", "Blog") + "<br>"
+            + _link(SUPPORT_URL, "💬", "Discord") + "<br>"
             + _link(POLYHOST_REPO_URL, "💻") + "<br>"
             + _link(FIRMWARE_REPO_URL, "⌨️") + "<br>"
             + _link(HARDWARE_REPO_URL, "🔧")

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -6,7 +6,6 @@ import subprocess
 import sys
 import threading
 import time
-import webbrowser
 
 from PyQt5.QtCore import QTimer, Qt
 from PyQt5.QtGui import QPalette, QColor
@@ -71,6 +70,7 @@ IS_PLASMA = os.getenv("XDG_CURRENT_DESKTOP") == "KDE"
 
 # Project links surfaced in the About dialog.
 POLYKYBD_HOMEPAGE_URL = "https://polykybd.org"
+SUPPORT_URL           = "https://discord.gg/gW8JescH7M"
 POLYHOST_REPO_URL     = "https://github.com/thpoll83/PolyKybdHost"
 FIRMWARE_REPO_URL     = "https://github.com/thpoll83/qmk_firmware"
 HARDWARE_REPO_URL     = "https://github.com/thpoll83/PolyKybd"
@@ -350,9 +350,8 @@ class PolyHost(QApplication):
                                             "Quit && stop background daemon", parent=self)
             # noinspection PyUnresolvedReferences
             self.exit_with_daemon.triggered.connect(self.quit_app_and_daemon)
-        self.support = QAction(get_icon("support.svg"), "Get Support", parent=self)
-        # noinspection PyUnresolvedReferences
-        self.support.triggered.connect(self.open_support)
+        # "Get Support" is no longer a separate menu item — its Discord link now
+        # lives in the About dialog (keeps the tray menu shorter).
         self.about = QAction(get_icon("home.svg"), "About", parent=self)
         # noinspection PyUnresolvedReferences
         self.about.triggered.connect(self.show_about_dialog)
@@ -502,7 +501,6 @@ class PolyHost(QApplication):
                 dump_action.triggered.connect(self.dump_mock_bitmaps)
                 debug_menu.addAction(dump_action)
 
-        self.menu.addAction(self.support)
         self.menu.addAction(self.about)
         self.menu.addAction(self.exit)
         if self.exit_with_daemon is not None:
@@ -704,7 +702,6 @@ class PolyHost(QApplication):
         self.log_dialog.setEnabled(True)
         self.update_action.setEnabled(True)
         self.status.setEnabled(True)
-        self.support.setEnabled(True)
         self.about.setEnabled(True)
         self.exit.setEnabled(True)
         if self.exit_with_daemon is not None:
@@ -1128,10 +1125,6 @@ class PolyHost(QApplication):
             subprocess.Popen(["xdg-open", out_dir])
         QMessageBox.information(None, "Mock Dump", f"Saved {len(store)} bitmaps to:\n{out_dir}")
 
-    @staticmethod
-    def open_support():
-        webbrowser.open("https://discord.gg/gW8JescH7M", new=0, autoraise=True)
-
     def _build_about_dialog(self) -> QDialog:
         """Construct the About dialog (host name/version + project links + OK).
 
@@ -1156,12 +1149,14 @@ class PolyHost(QApplication):
         logo.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         header.addWidget(logo, 0, Qt.AlignTop)
 
+        mode = "daemon client" if self.client_mode else "standalone"
         title_lbl = QLabel(
             f"<div style='font-size:15pt; font-weight:bold;'>PolyKybdHost</div>"
             f"<div style='margin-top:3px;'>Version {__version__}"
             f" &nbsp;·&nbsp; HID protocol P{__protocol__}</div>"
             f"<div style='color:gray; margin-top:3px;'>"
-            f"Python {platform.python_version()} · Qt {qVersion()} · {platform.system()}</div>")
+            f"Python {platform.python_version()} · Qt {qVersion()} · "
+            f"{platform.system()} · {mode}</div>")
         title_lbl.setTextFormat(Qt.RichText)
         title_lbl.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
         header.addWidget(title_lbl, 1)
@@ -1174,14 +1169,31 @@ class PolyHost(QApplication):
         desc.setWordWrap(True)
         outer.addWidget(desc)
 
-        # Project links — open in the system browser on click.
+        # Connected-keyboard metrics — a cached, no-I/O status snapshot (works in
+        # client mode over RPC too). Shows the keyboard's own protocol next to the
+        # host's above, so a "Protocol mismatch" is diagnosable right here.
+        status = QLabel(self._about_status_html())
+        status.setTextFormat(Qt.RichText)
+        status.setWordWrap(True)
+        status.setStyleSheet(
+            "QLabel { background: rgba(127,127,127,0.12); border-radius: 6px;"
+            " padding: 8px 10px; }")
+        outer.addWidget(status)
+
+        # Project links — open in the system browser on click. Shown scheme-less
+        # (github.com/… , polykybd.org) but href carries the full https URL.
+        def _link(url, emoji):
+            shown = url.split("://", 1)[-1]
+            return f"{emoji} <a href='{url}'>{shown}</a>"
+
         links = QLabel(
-            "<div style='line-height:160%;'>"
-            f"🌐 <a href='{POLYKYBD_HOMEPAGE_URL}'>polykybd.org — Homepage</a><br>"
-            f"💻 <a href='{POLYHOST_REPO_URL}'>Host software (PolyKybdHost)</a><br>"
-            f"⌨️ <a href='{FIRMWARE_REPO_URL}'>Firmware (qmk_firmware)</a><br>"
-            f"🔧 <a href='{HARDWARE_REPO_URL}'>Hardware (PolyKybd)</a>"
-            "</div>")
+            "<div style='line-height:170%;'>"
+            + _link(POLYKYBD_HOMEPAGE_URL, "🌐") + "<br>"
+            + _link(SUPPORT_URL, "💬") + "<br>"
+            + _link(POLYHOST_REPO_URL, "💻") + "<br>"
+            + _link(FIRMWARE_REPO_URL, "⌨️") + "<br>"
+            + _link(HARDWARE_REPO_URL, "🔧")
+            + "</div>")
         links.setTextFormat(Qt.RichText)
         links.setOpenExternalLinks(True)
         links.setTextInteractionFlags(Qt.TextBrowserInteraction)
@@ -1197,6 +1209,41 @@ class PolyHost(QApplication):
 
         dlg.setMinimumWidth(360)
         return dlg
+
+    def _about_status_html(self) -> str:
+        """Keyboard-status block for the About dialog: name, firmware + its
+        protocol (flagged when it mismatches the host), hardware, and language
+        count. Reads the cached status snapshot (no device I/O); degrades to
+        'No keyboard connected' when nothing is present or the read fails."""
+        try:
+            st = self.core.get_status() or {}
+        except Exception:  # noqa: BLE001 — a status read must never break About
+            st = {}
+        try:
+            n_lang = len(self.core.list_languages() or [])
+        except Exception:  # noqa: BLE001
+            n_lang = 0
+
+        if not st.get("device_present"):
+            return ("<b>Keyboard</b><br>"
+                    "<span style='color:gray;'>No keyboard connected.</span>")
+
+        name = st.get("name") or "PolyKybd"
+        fw = st.get("fw_version") or "?"
+        hw = st.get("hw_version") or "?"
+        lang = st.get("current_lang") or "?"
+        kb_proto = st.get("protocol")
+        proto_txt = f"P{kb_proto}" if kb_proto is not None else "P?"
+        if kb_proto is not None and kb_proto != __protocol__:
+            proto_txt += " <span style='color:#c0392b;'>⚠ mismatch</span>"
+        lang_line = f"{lang}" + (f" · {n_lang} languages loaded" if n_lang else "")
+        rows = [
+            f"<b>Connected keyboard:</b> {name}",
+            f"<b>Firmware:</b> {fw} &nbsp;·&nbsp; protocol {proto_txt}",
+            f"<b>Hardware:</b> {hw}",
+            f"<b>Language:</b> {lang_line}",
+        ]
+        return "<div style='line-height:150%;'>" + "<br>".join(rows) + "</div>"
 
     def show_about_dialog(self):
         """Show the modal About dialog, snapped near the tray icon."""

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -57,7 +57,7 @@ from polyhost.input.macos_helper import MacOSInputHelper
 from polyhost.input.win_helper import WindowsInputHelper
 from polyhost.services.lang_regions import LANG_REGION, LANG_REGION_ORDER, LANG_REGION_OVERRIDE
 from polyhost.services.unicode_cache import UnicodeCache
-from polyhost._version import __version__
+from polyhost._version import __version__, __protocol__
 
 from polyhost.services.updater import (
     UpdateChecker, UpdateInstaller, FwUpDownloader, restart_app,
@@ -68,6 +68,12 @@ from polyhost.gui.worker_bridge import WorkerBridge
 from polyhost.server.control_server import ControlServer
 
 IS_PLASMA = os.getenv("XDG_CURRENT_DESKTOP") == "KDE"
+
+# Project links surfaced in the About dialog.
+POLYKYBD_HOMEPAGE_URL = "https://polykybd.org"
+POLYHOST_REPO_URL     = "https://github.com/thpoll83/PolyKybdHost"
+FIRMWARE_REPO_URL     = "https://github.com/thpoll83/qmk_firmware"
+HARDWARE_REPO_URL     = "https://github.com/thpoll83/PolyKybd"
 
 UPDATE_CYCLE_MSEC = 250
 RECONNECT_CYCLE_MSEC = 1000
@@ -349,7 +355,7 @@ class PolyHost(QApplication):
         self.support.triggered.connect(self.open_support)
         self.about = QAction(get_icon("home.svg"), "About", parent=self)
         # noinspection PyUnresolvedReferences
-        self.about.triggered.connect(self.open_about)
+        self.about.triggered.connect(self.show_about_dialog)
 
         self.settings_dialog = QAction(get_icon("settings.svg"), "Settings...", parent=self)
         # noinspection PyUnresolvedReferences
@@ -1126,9 +1132,77 @@ class PolyHost(QApplication):
     def open_support():
         webbrowser.open("https://discord.gg/gW8JescH7M", new=0, autoraise=True)
 
-    @staticmethod
-    def open_about():
-        webbrowser.open("https://ko-fi.com/polykb", new=0, autoraise=True)
+    def _build_about_dialog(self) -> QDialog:
+        """Construct the About dialog (host name/version + project links + OK).
+
+        Split from :meth:`show_about_dialog` so it can be built and inspected in
+        a test without the modal ``exec_()`` blocking. Works in client mode too —
+        it only shows info about this host program, no device access."""
+        from PyQt5.QtCore import qVersion
+
+        dlg = QDialog(None)
+        dlg.setWindowTitle("About PolyKybdHost")
+        dlg.setWindowIcon(get_icon("pcolor.png"))
+
+        outer = QVBoxLayout(dlg)
+        outer.setContentsMargins(20, 18, 20, 14)
+        outer.setSpacing(12)
+
+        # Header: app logo + name / version / build info.
+        header = QHBoxLayout()
+        header.setSpacing(14)
+        logo = QLabel()
+        logo.setPixmap(get_icon("pcolor.png").pixmap(64, 64))
+        logo.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        header.addWidget(logo, 0, Qt.AlignTop)
+
+        title_lbl = QLabel(
+            f"<div style='font-size:15pt; font-weight:bold;'>PolyKybdHost</div>"
+            f"<div style='margin-top:3px;'>Version {__version__}"
+            f" &nbsp;·&nbsp; HID protocol P{__protocol__}</div>"
+            f"<div style='color:gray; margin-top:3px;'>"
+            f"Python {platform.python_version()} · Qt {qVersion()} · {platform.system()}</div>")
+        title_lbl.setTextFormat(Qt.RichText)
+        title_lbl.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+        header.addWidget(title_lbl, 1)
+        outer.addLayout(header)
+
+        desc = QLabel(
+            "Host software for the PolyKybd split keyboard with per-keycap "
+            "OLED displays — tracks the active window and pushes overlays, "
+            "language and keymap updates to the keyboard.")
+        desc.setWordWrap(True)
+        outer.addWidget(desc)
+
+        # Project links — open in the system browser on click.
+        links = QLabel(
+            "<div style='line-height:160%;'>"
+            f"🌐 <a href='{POLYKYBD_HOMEPAGE_URL}'>polykybd.org — Homepage</a><br>"
+            f"💻 <a href='{POLYHOST_REPO_URL}'>Host software (PolyKybdHost)</a><br>"
+            f"⌨️ <a href='{FIRMWARE_REPO_URL}'>Firmware (qmk_firmware)</a><br>"
+            f"🔧 <a href='{HARDWARE_REPO_URL}'>Hardware (PolyKybd)</a>"
+            "</div>")
+        links.setTextFormat(Qt.RichText)
+        links.setOpenExternalLinks(True)
+        links.setTextInteractionFlags(Qt.TextBrowserInteraction)
+        outer.addWidget(links)
+
+        btn_box = QDialogButtonBox(QDialogButtonBox.Ok)
+        btn_box.accepted.connect(dlg.accept)
+        ok_btn = btn_box.button(QDialogButtonBox.Ok)
+        if ok_btn is not None:
+            ok_btn.setDefault(True)
+            ok_btn.setFocus()
+        outer.addWidget(btn_box, 0, Qt.AlignRight)
+
+        dlg.setMinimumWidth(360)
+        return dlg
+
+    def show_about_dialog(self):
+        """Show the modal About dialog, snapped near the tray icon."""
+        dlg = self._build_about_dialog()
+        QTimer.singleShot(0, lambda: position_near_tray(dlg, self.tray))
+        dlg.exec_()
 
     def send_shortcuts(self):
         file_name = QFileDialog.getOpenFileName(None, 'Open file', '', "Image files (*.jpg *.gif *.png *.bmp *.jpeg)")

--- a/tests/gui/host_client_test.py
+++ b/tests/gui/host_client_test.py
@@ -90,7 +90,8 @@ def _smoke_default():
         about = app._build_about_dialog()
         blob = " ".join(l.text() for l in about.findChildren(QLabel))
         has_links = all(u in blob for u in (
-            "polykybd.org", "discord.gg", "github.com/thpoll83/PolyKybdHost",
+            "polykybd.org", "ko-fi.com/polykb", "Blog", "Discord", "discord.gg",
+            "github.com/thpoll83/PolyKybdHost",
             "github.com/thpoll83/qmk_firmware", "github.com/thpoll83/PolyKybd"))
         # Status block renders either "No keyboard connected" or a "Connected
         # keyboard" line depending on whether HID enumeration finds a device.

--- a/tests/gui/host_client_test.py
+++ b/tests/gui/host_client_test.py
@@ -95,8 +95,16 @@ def _smoke_default():
         # Status block renders either "No keyboard connected" or a "Connected
         # keyboard" line depending on whether HID enumeration finds a device.
         has_status = "eyboard" in blob
-        has_ok = about.findChild(QDialogButtonBox).button(QDialogButtonBox.Ok) is not None
-        print("ABOUT_OK", (_ver in blob) and has_links and has_status and has_ok)
+        # Environment metrics: uptime + config/log paths.
+        has_env = ("Uptime" in blob) and ("Config" in blob) and ("Logs" in blob)
+        bb = about.findChild(QDialogButtonBox)
+        has_ok = bb.button(QDialogButtonBox.Ok) is not None
+        has_copy = any(b.text().startswith("Copy diagnostics") for b in bb.buttons())
+        # Diagnostics text (clipboard payload) carries the version + a Config line.
+        diag = app._diagnostics_text(app._gather_about_info())
+        has_diag = (_ver in diag) and ("Config:" in diag)
+        print("ABOUT_OK", (_ver in blob) and has_links and has_status
+              and has_env and has_ok and has_copy and has_diag)
         about.deleteLater()
         app.quit_app()
     print("SMOKE OK")

--- a/tests/gui/host_client_test.py
+++ b/tests/gui/host_client_test.py
@@ -44,6 +44,7 @@ class TestPolyHostModes(unittest.TestCase):
         self.assertIn("SMOKE OK", proc.stdout)
         self.assertIn("CORE_TYPE PolyCore", proc.stdout)
         self.assertIn("DAEMON_QUIT_ACTION absent", proc.stdout)
+        self.assertIn("ABOUT_OK True", proc.stdout)
 
     def test_client_mode_connects_and_renders(self):
         proc = _run_smoke("client")
@@ -79,6 +80,18 @@ def _smoke_default():
         assert app.keeb is not None and app.worker is not None and app.cmdMenu is not None
         # In-process Quit already stops everything; no separate daemon-quit entry.
         print("DAEMON_QUIT_ACTION", "absent" if app.exit_with_daemon is None else "present")
+        # About dialog: builds (without the modal exec_ blocking), shows the host
+        # version, and links to homepage + all three repos.
+        from PyQt5.QtWidgets import QLabel, QDialogButtonBox
+        from polyhost._version import __version__ as _ver
+        about = app._build_about_dialog()
+        blob = " ".join(l.text() for l in about.findChildren(QLabel))
+        has_links = all(u in blob for u in (
+            "polykybd.org", "github.com/thpoll83/PolyKybdHost",
+            "github.com/thpoll83/qmk_firmware", "github.com/thpoll83/PolyKybd"))
+        has_ok = about.findChild(QDialogButtonBox).button(QDialogButtonBox.Ok) is not None
+        print("ABOUT_OK", (_ver in blob) and has_links and has_ok)
+        about.deleteLater()
         app.quit_app()
     print("SMOKE OK")
 

--- a/tests/gui/host_client_test.py
+++ b/tests/gui/host_client_test.py
@@ -61,6 +61,7 @@ class TestPolyHostModes(unittest.TestCase):
         self.assertIn("LAYOUT_OK layers=9", proc.stdout)
         self.assertIn("DAEMON_QUIT_ACTION present", proc.stdout)
         self.assertIn("UPDATE_ROUTED_TO_DAEMON True", proc.stdout)
+        self.assertIn("CLIENT_ABOUT_OK True", proc.stdout)
         self.assertIn("SERVER_RUNNING True", proc.stdout)
 
 
@@ -210,6 +211,22 @@ def _smoke_client():
             if app._update_progress is not None:
                 app._update_progress.close()
                 app._update_progress = None
+            # About dialog over the RemoteCore path (client mode): builds and
+            # renders the daemon's status snapshot (get_status/list_languages via
+            # RPC), the links, and the Copy-diagnostics button — the standalone
+            # smoke covers the in-process core; this covers the client core.
+            from PyQt5.QtWidgets import QLabel as _QLabel, QDialogButtonBox as _QBB
+            about = app._build_about_dialog()
+            cblob = " ".join(l.text() for l in about.findChildren(_QLabel))
+            c_links = all(u in cblob for u in (
+                "polykybd.org", "discord.gg", "github.com/thpoll83/PolyKybdHost"))
+            c_bb = about.findChild(_QBB)
+            c_copy = any(b.text().startswith("Copy diagnostics") for b in c_bb.buttons())
+            c_diag = "Config:" in app._diagnostics_text(app._gather_about_info())
+            print("CLIENT_ABOUT_OK",
+                  (__version__ in cblob) and c_links and ("eyboard" in cblob)
+                  and c_copy and c_diag)
+            about.deleteLater()
             app.quit_app()
         print("SERVER_RUNNING", srv._running)
     finally:

--- a/tests/gui/host_client_test.py
+++ b/tests/gui/host_client_test.py
@@ -44,6 +44,7 @@ class TestPolyHostModes(unittest.TestCase):
         self.assertIn("SMOKE OK", proc.stdout)
         self.assertIn("CORE_TYPE PolyCore", proc.stdout)
         self.assertIn("DAEMON_QUIT_ACTION absent", proc.stdout)
+        self.assertIn("SUPPORT_ACTION absent", proc.stdout)
         self.assertIn("ABOUT_OK True", proc.stdout)
 
     def test_client_mode_connects_and_renders(self):
@@ -80,17 +81,22 @@ def _smoke_default():
         assert app.keeb is not None and app.worker is not None and app.cmdMenu is not None
         # In-process Quit already stops everything; no separate daemon-quit entry.
         print("DAEMON_QUIT_ACTION", "absent" if app.exit_with_daemon is None else "present")
+        # "Get Support" was folded into the About dialog — no separate menu item.
+        print("SUPPORT_ACTION", "absent" if not hasattr(app, "support") else "present")
         # About dialog: builds (without the modal exec_ blocking), shows the host
-        # version, and links to homepage + all three repos.
+        # version, and links to homepage + support + all three repos.
         from PyQt5.QtWidgets import QLabel, QDialogButtonBox
         from polyhost._version import __version__ as _ver
         about = app._build_about_dialog()
         blob = " ".join(l.text() for l in about.findChildren(QLabel))
         has_links = all(u in blob for u in (
-            "polykybd.org", "github.com/thpoll83/PolyKybdHost",
+            "polykybd.org", "discord.gg", "github.com/thpoll83/PolyKybdHost",
             "github.com/thpoll83/qmk_firmware", "github.com/thpoll83/PolyKybd"))
+        # Status block renders either "No keyboard connected" or a "Connected
+        # keyboard" line depending on whether HID enumeration finds a device.
+        has_status = "eyboard" in blob
         has_ok = about.findChild(QDialogButtonBox).button(QDialogButtonBox.Ok) is not None
-        print("ABOUT_OK", (_ver in blob) and has_links and has_ok)
+        print("ABOUT_OK", (_ver in blob) and has_links and has_status and has_ok)
         about.deleteLater()
         app.quit_app()
     print("SMOKE OK")


### PR DESCRIPTION
## Summary

Replaces the "About" tray menu item (which just opened a Ko-fi page in the browser) with a real, informative About dialog, and folds the separate "Get Support" item into it to shorten the tray menu.

The dialog shows:
- **App logo, name, version and HID protocol** (`__version__` / `__protocol__`, so it stays accurate across bumps), plus a build-info line: Python · Qt · OS · run mode (standalone / daemon client).
- **Connected-keyboard metrics** from the cached status snapshot (no device I/O; works in client mode over RPC too): name + connection state, firmware **and its protocol** (flagged red **"⚠ mismatch"** when it differs from the host's — surfacing a "Protocol mismatch" right in the dialog), hardware version, and current language + count. Falls back to "No keyboard connected".
- **Host environment**: uptime, overlay-mapping count (when known), and the config + log-file locations (selectable, handy for support).
- **Project links**, shown scheme-less (`polykybd.org`, `discord.gg/…`, `github.com/thpoll83/…`) with the full `https://` URL in the href, opening in the system browser: homepage, Discord support, and the host / firmware / hardware repos.
- **Buttons**: **Copy diagnostics** (puts a plain-text summary on the clipboard for pasting into a support chat) and **OK**.

Display and clipboard are built from a single `_gather_about_info()` so they can't drift. The dialog is split into a testable `_build_about_dialog()` + a `show_about_dialog()` that positions it near the tray and `exec_()`s it. It works in client (daemon) mode too — it only reads host/status info, no device control.

Screenshots (connected with a deliberate P10-vs-P11 mismatch, and disconnected) are in the session; the connected view shows the red mismatch flag and the full metrics + Copy button.

**Changed:** `polyhost/host.py` (new dialog + helpers; removed the unused `open_support`/`webbrowser`); `tests/gui/host_client_test.py` (asserts the dialog builds with version, keyboard status, env metrics, all five links, the Copy button and the diagnostics text, and that the old Get-Support menu item is gone).

## Version bump label

Suggest **`bump:minor`** — this is a new, backwards-compatible feature (no protocol or firmware change; `__protocol__` unchanged).

## Testing
- [ ] Tested locally against real hardware
- [x] Tested with mock device (if UI changes)

Full unit suite under `xvfb`: **940 pass, 1 skip, 0 failures**. Verified visually by rendering the dialog (connected + disconnected) to PNG. Real-hardware check of the live keyboard metrics still pending on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U3kzsZWTsebxxwPWqVMsHv

---
_Generated by [Claude Code](https://claude.ai/code/session_01U3kzsZWTsebxxwPWqVMsHv)_

## Summary by Sourcery

Replace the tray menu’s external About/Support links with an in-app About dialog that surfaces host, keyboard, and environment diagnostics plus project links.

New Features:
- Add a rich About dialog showing app version, HID protocol, host build info, connected-keyboard metrics, environment details, and project links.
- Provide a Copy diagnostics button that copies a plain-text summary of host and keyboard state for support use.
- Include host uptime, overlay mapping count, and config/log locations in the About view.

Enhancements:
- Unify About dialog display and diagnostics clipboard text via a shared data-gathering helper to keep information consistent.
- Shorten the tray menu by folding the separate Get Support action into the About dialog and removing the unused webbrowser-based handlers.

Tests:
- Extend GUI smoke tests to verify absence of the old Support action and to assert that the About dialog renders expected content, links, buttons, and diagnostics text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an in-app **About** dialog from the tray menu with app details, status information, environment info, and helpful project links.
  * Added a copyable diagnostics view so users can easily share troubleshooting information.

* **Bug Fixes**
  * Updated the tray menu so **Get Support** is no longer a separate item; support links are now available directly in the About dialog.
  * The About action now opens a modal dialog instead of launching an external browser page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->