### PR TITLE
publish_release.py: publish the newest prepared tag (fix version drift)

### DIFF
--- a/.claude/skills/polykybd-github-release/SKILL.md
+++ b/.claude/skills/polykybd-github-release/SKILL.md
@@ -180,12 +180,16 @@ branch is an accumulating changelog archive — don't reuse or clear old files.
    python scripts/publish_release.py            # publish
    python scripts/publish_release.py --dry-run  # preview title+body, change nothing
    ```
-   It auto-detects the repo, reads the current version (→ tag) from the default branch,
-   pulls the staged `<TAG>.md` from the `release-notes` branch, and creates+publishes the
-   release via the GitHub API. Firmware: publishing fires `release: published` → CI builds
-   and attaches `.bin`/`.uf2` (the doom engine pack `.plyx` is built but deliberately NOT
-   attached — it would reveal the easter egg). Auth: `GH_TOKEN`/`GITHUB_TOKEN` or
-   `gh auth token`. Tell the user to run it in each repo after you've staged the notes.
+   It auto-detects the repo and publishes the **newest prepared `<TAG>.md` on the
+   `release-notes` branch** — the branch is the source of truth for what's ready, so it's
+   robust to the version auto-bump every PR merge causes (the tree drifts ahead of the
+   prepared release; the branch does not). `--tag <TAG>` targets a specific prepared tag.
+   It creates+publishes via the GitHub API; firmware publishing fires `release: published`
+   → CI builds and attaches `.bin`/`.uf2` (the doom engine pack `.plyx` is built but
+   deliberately NOT attached — it would reveal the easter egg). Auth: `GH_TOKEN`/
+   `GITHUB_TOKEN` or `gh auth token`. Tell the user to run it in each repo after you've
+   staged the notes. ⚠️ **Merging the notes/tooling PR bumps the version past the prepared
+   one** — that's expected; the script still publishes the prepared tag from the branch.
    - **Alternatives** (if they prefer): the GitHub UI — Draft a new release → pick the tag →
      leave the body **empty** → Publish; CI's `release: published` run then fills the
      crafted title+notes from the branch (`gh release edit`) and, for firmware, attaches

--- a/scripts/publish_release.py
+++ b/scripts/publish_release.py
@@ -115,9 +115,25 @@ def api(token, method, path, payload=None):
             return e.code, {"message": e.read().decode(errors="replace")}
 
 
+def prepared_tags(prefix):
+    """All prepared <prefix><X.Y.Z>.md files on the release-notes branch,
+    as (version_tuple, tag) sorted ascending."""
+    r = run(["git", "ls-tree", "--name-only", "origin/release-notes"])
+    out = []
+    for name in r.stdout.splitlines():
+        if not (name.startswith(prefix) and name.endswith(".md")):
+            continue
+        m = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)", name[len(prefix):-3])
+        if m:
+            out.append(((int(m[1]), int(m[2]), int(m[3])), name[:-3]))
+    out.sort()
+    return out
+
+
 def main():
     ap = argparse.ArgumentParser(description="Publish the prepared PolyKybd release.")
     ap.add_argument("--dry-run", action="store_true", help="show what would happen, change nothing")
+    ap.add_argument("--tag", help="publish a specific prepared tag instead of the newest one")
     args = ap.parse_args()
 
     root = repo_root()
@@ -126,20 +142,39 @@ def main():
     # Fetch the refs we read from (best-effort; fall back to whatever is local).
     run(["git", "fetch", "origin", default_branch, "release-notes"])
 
-    vtext = show(f"origin/{default_branch}:{vpath}")
-    if vtext is None:
-        with open(os.path.join(root, vpath), encoding="utf-8") as fh:
-            vtext = fh.read()
-    version = parse_version(kind, vtext)
-    tag = tag_prefix + version
+    # The release-notes branch is the source of truth for *what is ready to
+    # publish* — NOT the tree version, which drifts forward on every PR merge
+    # (each merge auto-bumps the version, so the tree is usually ahead of the
+    # prepared release by the time you publish). Pick the newest prepared tag.
+    if args.tag:
+        tag = args.tag
+        notes = show(f"origin/release-notes:{tag}.md")
+        if not notes or not notes.strip():
+            die(f"no prepared notes for {tag} on the release-notes branch "
+                f"(expected release-notes:{tag}.md).")
+    else:
+        prepared = prepared_tags(tag_prefix)
+        if not prepared:
+            die("no prepared release notes on the release-notes branch "
+                f"(no {tag_prefix}<X.Y.Z>.md files).\n"
+                "  Draft + stage them first with the polykybd-github-release skill.")
+        tag = prepared[-1][1]
+        notes = show(f"origin/release-notes:{tag}.md")
+        if len(prepared) > 1:
+            others = ", ".join(t for _, t in prepared[:-1])
+            print(f"note: newest prepared tag is {tag}. Others on the branch: {others}")
+            print(f"      (use --tag to publish a specific one.)")
 
-    notes = show(f"origin/release-notes:{tag}.md")
-    if not notes or not notes.strip():
-        die(
-            f"no prepared notes for {tag} on the release-notes branch "
-            f"(expected release-notes:{tag}.md).\n"
-            f"  Draft + stage them first with the polykybd-github-release skill."
-        )
+    # Informational: warn if the tree has already bumped past this tag.
+    vtext = show(f"origin/{default_branch}:{vpath}")
+    if vtext:
+        try:
+            tree_tag = tag_prefix + parse_version(kind, vtext)
+            if tree_tag != tag:
+                print(f"note: default branch is at {tree_tag}; publishing prepared {tag} "
+                      f"(the difference is post-prep merges, typically release tooling).")
+        except SystemExit:
+            pass
     lines = notes.splitlines()
     title = re.sub(r"^#\s*", "", lines[0]).strip()
     body = "\n".join(lines[1:]).strip("\n")


### PR DESCRIPTION
## Summary

Follow-up to the release-publishing PR (#104). Fixes a version-drift bug: `publish_release.py` derived the tag from the **tree** version, but every PR merge auto-bumps the version — so after merging #104 the tree was at `v0.9.27` while the prepared release is `v0.9.26`, and the script errored (`no prepared notes for v0.9.27`).

Fix: the **`release-notes` branch is the source of truth for what's ready to publish**, so the script now publishes the **newest prepared `v<X.Y.Z>.md`** found there (not the tree version). Adds `--tag <TAG>` to publish a specific prepared tag, and prints a note when the tree has bumped past the prepared tag (the difference is post-prep merges, i.e. release tooling — the product is unchanged). Byte-identical to the firmware repo's copy (auto-detects).

Skill updated to match.

## Version bump label

*(none)* — tooling only.

## Testing
- [x] `python scripts/publish_release.py --dry-run` now selects the prepared `v0.9.26` from the branch and notes the tree is at `v0.9.27`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HRMsh3rzy2XbYjDaTGh7iF

---
_Generated by [Claude Code](https://claude.ai/code/session_01HRMsh3rzy2XbYjDaTGh7iF)_