### PR TITLE
publish_release.py: fix UnicodeDecodeError on Windows (force UTF-8)

### DIFF
--- a/scripts/publish_release.py
+++ b/scripts/publish_release.py
@@ -34,7 +34,11 @@ import urllib.request
 
 
 def run(cmd):
-    return subprocess.run(cmd, capture_output=True, text=True)
+    # Force UTF-8: git output (release notes) is UTF-8, but on Windows the
+    # default is the locale codec (cp1252), which raises UnicodeDecodeError on
+    # emoji/em-dashes and silently drops the output.
+    return subprocess.run(cmd, capture_output=True, text=True,
+                          encoding="utf-8", errors="replace")
 
 
 def die(msg):
@@ -135,6 +139,13 @@ def main():
     ap.add_argument("--dry-run", action="store_true", help="show what would happen, change nothing")
     ap.add_argument("--tag", help="publish a specific prepared tag instead of the newest one")
     args = ap.parse_args()
+
+    # Print UTF-8 (emoji in the notes) even on a cp1252 Windows console.
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")
+        except Exception:
+            pass
 
     root = repo_root()
     kind, vpath, default_branch, tag_prefix = detect(root)


### PR DESCRIPTION
## Summary

Fixes `publish_release.py` crashing on Windows. Python's `subprocess` decoded git's output with the locale codec (cp1252), which raised `UnicodeDecodeError` on the emoji/em-dashes in the release notes — so the notes read back as `None` and the script crashed (`AttributeError: 'NoneType' object has no attribute 'splitlines'`).

- Force `encoding="utf-8", errors="replace"` on all git subprocess calls.
- Reconfigure `stdout`/`stderr` to UTF-8 so the emoji body also prints on a cp1252 console.

Byte-identical to the firmware repo's copy. Verified: `python scripts/publish_release.py --dry-run` runs clean.

## Version bump label

*(none)* — tooling only.

## Testing
- [x] `--dry-run` prints the parsed title/body cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HRMsh3rzy2XbYjDaTGh7iF

---
_Generated by [Claude Code](https://claude.ai/code/session_01HRMsh3rzy2XbYjDaTGh7iF)_