### PR TITLE
Show release notes in the update confirmation dialogs

### DIFF
--- a/polyhost/cli/polyctl.py
+++ b/polyhost/cli/polyctl.py
@@ -399,6 +399,13 @@ def _cmd_update(client, args):
         res = client.call(protocol.M_UPDATE_CHECK) or {}
         if res.get("available"):
             print(f"update available: {res.get('version')}  {res.get('url', '')}".rstrip())
+            if res.get("name"):
+                print(f"  {res['name']}")
+            notes = (res.get("notes") or "").strip()
+            if notes:
+                print("\nRelease notes:")
+                for line in notes.splitlines():
+                    print(f"  {line}")
         else:
             print(f"up to date (host {res.get('version')})")
         return 0

--- a/polyhost/core/poly_core.py
+++ b/polyhost/core/poly_core.py
@@ -1367,7 +1367,8 @@ class PolyCore:
             return False, f"{type(e).__name__}: {e}"
         if rel is None:
             return True, {"available": False, "version": __version__}
-        return True, {"available": True, "version": rel.version, "url": rel.html_url}
+        return True, {"available": True, "version": rel.version, "url": rel.html_url,
+                      "name": getattr(rel, "name", ""), "notes": getattr(rel, "notes", "")}
 
     def install_update(self):
         """Find the latest host release and apply it in the background.

--- a/polyhost/forwarder.py
+++ b/polyhost/forwarder.py
@@ -305,12 +305,12 @@ class PolyForwarder(QApplication):
     def _on_update_available(self, release):
         from polyhost.gui.update_dialog import confirm_update
         self.update_action.setText("Check for updates...")
-        message = (f"Version {release.version} is available.\n\n"
-                   "Download, install, and restart the forwarder now?")
+        message = f"Version {release.version} is available."
         if not confirm_update("Update PolyKybdHost", message,
                               notes=getattr(release, "notes", ""),
                               html_url=getattr(release, "html_url", ""),
-                              release_name=getattr(release, "name", "")):
+                              release_name=getattr(release, "name", ""),
+                              question="Download, install, and restart the forwarder now?"):
             return
         self._run_update_installer(release)
 

--- a/polyhost/forwarder.py
+++ b/polyhost/forwarder.py
@@ -303,12 +303,14 @@ class PolyForwarder(QApplication):
         self._update_checker.start()
 
     def _on_update_available(self, release):
+        from polyhost.gui.update_dialog import confirm_update
         self.update_action.setText("Check for updates...")
-        if QMessageBox.question(
-                None, "Update PolyKybdHost",
-                f"Version {release.version} is available.\n\n"
-                "Download, install, and restart the forwarder now?",
-                QMessageBox.Yes | QMessageBox.No, QMessageBox.Yes) != QMessageBox.Yes:
+        message = (f"Version {release.version} is available.\n\n"
+                   "Download, install, and restart the forwarder now?")
+        if not confirm_update("Update PolyKybdHost", message,
+                              notes=getattr(release, "notes", ""),
+                              html_url=getattr(release, "html_url", ""),
+                              release_name=getattr(release, "name", "")):
             return
         self._run_update_installer(release)
 

--- a/polyhost/gui/update_dialog.py
+++ b/polyhost/gui/update_dialog.py
@@ -20,25 +20,30 @@ from PyQt5.QtWidgets import (
 
 
 def confirm_update(title: str, message: str, notes: str = "", html_url: str = "",
-                   release_name: str = "") -> bool:
+                   release_name: str = "", question: str = "") -> bool:
     """Ask the user to confirm an update, showing release notes when available.
 
-    ``message`` is the short lead paragraph (version, date, the action question) —
-    it is shown verbatim above the notes so callers keep full control of the
-    wording. ``notes`` is the release-notes markdown; when empty this degrades to
-    a compact yes/no box. ``html_url`` (when set) adds a "full release notes" link.
-    ``release_name`` is the GitHub release title, shown as a heading over the notes
-    when it adds information beyond the version.
+    ``message`` is the short lead paragraph (version, date, any caveats) shown
+    above the notes. ``question`` is the call to action ("Download and flash
+    now?") — it is placed right above the Yes/No buttons so the decision sits
+    next to the buttons rather than scrolled away above the notes. ``notes`` is
+    the release-notes markdown; when empty this degrades to a compact yes/no box.
+    ``html_url`` (when set) adds a "full release notes" link. ``release_name`` is
+    the GitHub release title, shown as a heading over the notes when it adds
+    information beyond the version.
 
     Returns True if the user accepts (Yes), False otherwise. Must run on the Qt
     main thread.
     """
     notes = (notes or "").strip()
+    question = (question or "").strip()
     if not notes:
-        # Nothing extra to show — keep the classic compact confirmation.
+        # Nothing extra to show — keep the classic compact confirmation. The
+        # question rejoins the message so the one-line box still asks it.
         from PyQt5.QtWidgets import QMessageBox
+        text = f"{message}\n\n{question}" if question else message
         return QMessageBox.question(
-            None, title, message,
+            None, title, text,
             QMessageBox.Yes | QMessageBox.No, QMessageBox.Yes) == QMessageBox.Yes
 
     dlg = QDialog(None)
@@ -91,6 +96,13 @@ def confirm_update(title: str, message: str, notes: str = "", html_url: str = ""
         link.setOpenExternalLinks(True)
         link.setTextInteractionFlags(Qt.TextBrowserInteraction)
         outer.addWidget(link)
+
+    # The call to action sits right above the buttons, so the decision is next
+    # to Yes/No rather than scrolled off the top above the notes.
+    if question:
+        q_lbl = QLabel(question)
+        q_lbl.setWordWrap(True)
+        outer.addWidget(q_lbl)
 
     btn_box = QDialogButtonBox(QDialogButtonBox.Yes | QDialogButtonBox.No)
     btn_box.accepted.connect(dlg.accept)

--- a/polyhost/gui/update_dialog.py
+++ b/polyhost/gui/update_dialog.py
@@ -1,0 +1,103 @@
+"""Shared confirm-update dialog that surfaces release notes.
+
+Both the tray GUI (``host.py``) and the forwarder (``forwarder.py``) offer to
+install a new host release / flash new firmware. When the GitHub release carries
+notes (the API ``body``), show them in a scrollable, read-only pane so the user
+knows what the update brings before committing — otherwise fall back to a plain
+one-line confirmation. Qt-only, no device or network access here.
+"""
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QHBoxLayout,
+    QLabel,
+    QSizePolicy,
+    QStyle,
+    QTextBrowser,
+    QVBoxLayout,
+)
+
+
+def confirm_update(title: str, message: str, notes: str = "", html_url: str = "",
+                   release_name: str = "") -> bool:
+    """Ask the user to confirm an update, showing release notes when available.
+
+    ``message`` is the short lead paragraph (version, date, the action question) —
+    it is shown verbatim above the notes so callers keep full control of the
+    wording. ``notes`` is the release-notes markdown; when empty this degrades to
+    a compact yes/no box. ``html_url`` (when set) adds a "full release notes" link.
+    ``release_name`` is the GitHub release title, shown as a heading over the notes
+    when it adds information beyond the version.
+
+    Returns True if the user accepts (Yes), False otherwise. Must run on the Qt
+    main thread.
+    """
+    notes = (notes or "").strip()
+    if not notes:
+        # Nothing extra to show — keep the classic compact confirmation.
+        from PyQt5.QtWidgets import QMessageBox
+        return QMessageBox.question(
+            None, title, message,
+            QMessageBox.Yes | QMessageBox.No, QMessageBox.Yes) == QMessageBox.Yes
+
+    dlg = QDialog(None)
+    dlg.setWindowTitle(title)
+    dlg.setWindowFlag(Qt.WindowStaysOnTopHint, True)
+    dlg.setMinimumSize(540, 480)
+
+    outer = QVBoxLayout(dlg)
+    outer.setContentsMargins(16, 16, 16, 12)
+    outer.setSpacing(10)
+
+    # Icon + lead message row.
+    row = QHBoxLayout()
+    row.setSpacing(12)
+    icon_lbl = QLabel()
+    px = dlg.style().standardPixmap(QStyle.SP_MessageBoxQuestion)
+    if not px.isNull():
+        icon_lbl.setPixmap(px)
+    icon_lbl.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+    row.addWidget(icon_lbl, 0, Qt.AlignTop)
+    msg_lbl = QLabel(message)
+    msg_lbl.setWordWrap(True)
+    msg_lbl.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+    row.addWidget(msg_lbl, 1)
+    outer.addLayout(row)
+
+    # "What's new" heading (+ the release title when it adds information).
+    heading = "What's new"
+    release_name = (release_name or "").strip()
+    if release_name:
+        heading = f"What's new — {release_name}"
+    hdr_lbl = QLabel(heading)
+    hdr_lbl.setStyleSheet("font-weight: bold;")
+    outer.addWidget(hdr_lbl)
+
+    # Scrollable, read-only notes. Prefer rendered markdown (Qt >= 5.14),
+    # falling back to plain text on older Qt where setMarkdown is absent.
+    browser = QTextBrowser()
+    browser.setOpenExternalLinks(True)
+    if hasattr(browser, "setMarkdown"):
+        browser.setMarkdown(notes)
+    else:
+        browser.setPlainText(notes)
+    browser.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+    outer.addWidget(browser, 1)
+
+    if html_url:
+        link = QLabel(f'<a href="{html_url}">View full release notes on GitHub</a>')
+        link.setOpenExternalLinks(True)
+        link.setTextInteractionFlags(Qt.TextBrowserInteraction)
+        outer.addWidget(link)
+
+    btn_box = QDialogButtonBox(QDialogButtonBox.Yes | QDialogButtonBox.No)
+    btn_box.accepted.connect(dlg.accept)
+    btn_box.rejected.connect(dlg.reject)
+    yes_btn = btn_box.button(QDialogButtonBox.Yes)
+    if yes_btn is not None:
+        yes_btn.setDefault(True)
+        yes_btn.setFocus()
+    outer.addWidget(btn_box, 0, Qt.AlignRight)
+
+    return dlg.exec_() == QDialog.Accepted

--- a/polyhost/gui/update_dialog.py
+++ b/polyhost/gui/update_dialog.py
@@ -72,6 +72,7 @@ def confirm_update(title: str, message: str, notes: str = "", html_url: str = ""
         heading = f"What's new — {release_name}"
     hdr_lbl = QLabel(heading)
     hdr_lbl.setStyleSheet("font-weight: bold;")
+    hdr_lbl.setWordWrap(True)  # long release titles must wrap, not clip
     outer.addWidget(hdr_lbl)
 
     # Scrollable, read-only notes. Prefer rendered markdown (Qt >= 5.14),

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -1622,12 +1622,12 @@ class PolyHost(QApplication):
     def _prompt_and_install(self, release):
         date_str = _fmt_release_date(release.published_at)
         info = f"Released: {date_str}\n" if date_str else ""
-        message = (f"Version {release.version} is available.\n{info}\n"
-                   "Download, install, and restart now?")
+        message = f"Version {release.version} is available.\n{info}"
         if not confirm_update("Update PolyKybdHost", message,
                               notes=getattr(release, "notes", ""),
                               html_url=getattr(release, "html_url", ""),
-                              release_name=getattr(release, "name", "")):
+                              release_name=getattr(release, "name", ""),
+                              question="Download, install, and restart now?"):
             return
         self._run_update_installer(release)
 
@@ -1877,12 +1877,12 @@ class PolyHost(QApplication):
         date_str = _fmt_release_date(release.published_at)
         info = f"Released: {date_str}\n" if date_str else ""
         message = (f"Firmware {release.version} is available.\n{info}\n"
-                   "Both halves update over HID and reboot automatically.\n\n"
-                   "Download and flash now?")
+                   "Both halves update over HID and reboot automatically.")
         if not confirm_update("Update PolyKybd Firmware", message,
                               notes=getattr(release, "notes", ""),
                               html_url=getattr(release, "html_url", ""),
-                              release_name=getattr(release, "name", "")):
+                              release_name=getattr(release, "name", ""),
+                              question="Download and flash now?"):
             return
         self._run_fw_up_downloader(release)
 

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -183,13 +183,20 @@ def _msgbox(icon, title: str, text: str,
         return QMessageBox.Cancel
 
 
-def _progress_dlg(label: str, title: str, tray_icon=None) -> QProgressDialog:
+def _progress_dlg(label: str, title: str, tray_icon=None, on_cancel=None) -> QProgressDialog:
     dlg = QProgressDialog(label, None, 0, 100, None)
     dlg.setWindowTitle(title)
     dlg.setWindowFlag(Qt.WindowStaysOnTopHint, True)
     dlg.setMinimumDuration(0)
     dlg.setAutoClose(False)
-    dlg.setCancelButton(None)
+    if on_cancel is not None:
+        # Keep the dialog on screen after Cancel is pressed (showing "Cancelling…")
+        # until the worker actually stops and the caller closes it.
+        dlg.setAutoReset(False)
+        dlg.setCancelButtonText("Cancel")
+        dlg.canceled.connect(on_cancel)
+    else:
+        dlg.setCancelButton(None)
     dlg.setValue(0)
     dlg.setFixedSize(_UPD_DLG_W, _UPD_DLG_H)
     lbl = dlg.findChild(QLabel)
@@ -486,6 +493,9 @@ class PolyHost(QApplication):
         self._pending_fw_release = None
         self._fw_up_downloader = None
         self._fw_up_progress = None
+        # Mutable one-element cancel flag shared with the firmware-download thread
+        # (set True to abort the GitHub .bin download); None while no download runs.
+        self._fw_download_cancel = None
         self._await_manual_fw_prompt = False
         # Set in client mode to the downloaded temp .bin that the daemon flashes
         # asynchronously — cleaned up on the terminal flash event (_on_flash_done).
@@ -1891,28 +1901,64 @@ class PolyHost(QApplication):
             return
 
         self.firmware_update_action.setEnabled(False)
+        self._fw_download_cancel = [False]
         self._fw_up_progress = _progress_dlg(
             f"Downloading firmware v{release.version}…", "Firmware Update",
-            tray_icon=self.tray)
+            tray_icon=self.tray, on_cancel=self._on_fw_download_cancel)
 
         b = self.bridge
         self._fw_up_downloader = FwUpDownloader(
             release,
             on_progress=lambda pct, msg: b.job_done.emit("fw_download_progress", (pct, msg)),
             on_finished=lambda ok, err, path: b.job_done.emit("fw_download_done", (ok, err, path)),
+            cancel_flag=self._fw_download_cancel,
         )
         self._fw_up_downloader.start()
 
+    def _on_fw_download_cancel(self):
+        """User pressed Cancel while the .bin was downloading from GitHub.
+
+        Nothing has been sent to the keyboard at this stage, so cancelling is
+        always safe. Flag the download thread — it aborts on the next chunk and
+        fires fw_download_done, where _on_fw_download_done resets the UI."""
+        if self._fw_download_cancel is not None:
+            self._fw_download_cancel[0] = True
+        if self._fw_up_progress is not None:
+            self._fw_up_progress.setLabelText("Cancelling…")
+
     def _on_fw_download_progress(self, percent: int, message: str):
         if self._fw_up_progress is None:
+            return
+        # Don't overwrite the "Cancelling…" label with late download progress.
+        if self._fw_download_cancel is not None and self._fw_download_cancel[0]:
             return
         self._fw_up_progress.setLabelText(message)
         self._fw_up_progress.setValue(percent)
 
     def _on_fw_download_done(self, ok: bool, error: str, bin_path: str):
+        cancelled = bool(self._fw_download_cancel and self._fw_download_cancel[0])
+        self._fw_download_cancel = None
         if self._fw_up_progress is not None:
             self._fw_up_progress.close()
             self._fw_up_progress = None
+
+        if cancelled:
+            # Discard any partial temp file and return to the pre-download state.
+            # Nothing reached the keyboard, so no device cleanup is needed.
+            if bin_path and os.path.exists(bin_path):
+                try:
+                    os.unlink(bin_path)
+                except OSError:
+                    pass
+            self.log.info("Firmware download cancelled by user.")
+            if self._pending_fw_release is not None:
+                self.firmware_update_action.setText(
+                    f"Update firmware to v{self._pending_fw_release.version}…")
+                self.firmware_update_action.setVisible(True)
+                self.firmware_update_action.setEnabled(self._fw_actions_allowed())
+            else:
+                self._reset_fw_update_action()
+            return
 
         if not ok:
             self.firmware_update_action.setEnabled(True)

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -28,6 +28,7 @@ from PyQt5.QtWidgets import (
 
 from polyhost.device.command_ids import IdleStyle, GlyphScript
 from polyhost.gui.get_icon import get_icon
+from polyhost.gui.update_dialog import confirm_update
 
 # Tray labels for the Glyph Script submenu. Generic names (no franchise
 # branding — trademark caveat on the fictional scripts); the fonts themselves
@@ -1621,10 +1622,12 @@ class PolyHost(QApplication):
     def _prompt_and_install(self, release):
         date_str = _fmt_release_date(release.published_at)
         info = f"Released: {date_str}\n" if date_str else ""
-        if _msgbox(QMessageBox.Question, "Update PolyKybdHost",
-                   f"Version {release.version} is available.\n{info}\n"
-                   "Download, install, and restart now?",
-                   QMessageBox.Yes | QMessageBox.No, QMessageBox.Yes) != QMessageBox.Yes:
+        message = (f"Version {release.version} is available.\n{info}\n"
+                   "Download, install, and restart now?")
+        if not confirm_update("Update PolyKybdHost", message,
+                              notes=getattr(release, "notes", ""),
+                              html_url=getattr(release, "html_url", ""),
+                              release_name=getattr(release, "name", "")):
             return
         self._run_update_installer(release)
 
@@ -1873,11 +1876,13 @@ class PolyHost(QApplication):
             return
         date_str = _fmt_release_date(release.published_at)
         info = f"Released: {date_str}\n" if date_str else ""
-        if _msgbox(QMessageBox.Question, "Update PolyKybd Firmware",
-                   f"Firmware {release.version} is available.\n{info}\n"
+        message = (f"Firmware {release.version} is available.\n{info}\n"
                    "Both halves update over HID and reboot automatically.\n\n"
-                   "Download and flash now?",
-                   QMessageBox.Yes | QMessageBox.No, QMessageBox.Yes) != QMessageBox.Yes:
+                   "Download and flash now?")
+        if not confirm_update("Update PolyKybd Firmware", message,
+                              notes=getattr(release, "notes", ""),
+                              html_url=getattr(release, "html_url", ""),
+                              release_name=getattr(release, "name", "")):
             return
         self._run_fw_up_downloader(release)
 

--- a/polyhost/services/updater.py
+++ b/polyhost/services/updater.py
@@ -96,8 +96,14 @@ EXCLUDES = (
 )
 
 
-ReleaseInfo   = namedtuple("ReleaseInfo",   ["tag", "version", "tarball_url", "html_url", "published_at"])
-FwUpReleaseInfo = namedtuple("FwUpReleaseInfo", ["tag", "version", "bin_url", "uf2_url", "html_url", "published_at"])
+# ``name`` (GitHub release title) and ``notes`` (the release-notes markdown, i.e.
+# the API ``body``) carry the human-readable "what's in this update" text through
+# to the confirmation dialogs. They default to "" so the web-fallback paths (which
+# can't cheaply fetch the body) and existing positional constructions still work.
+ReleaseInfo   = namedtuple("ReleaseInfo",   ["tag", "version", "tarball_url", "html_url", "published_at", "name", "notes"],
+                           defaults=("", ""))
+FwUpReleaseInfo = namedtuple("FwUpReleaseInfo", ["tag", "version", "bin_url", "uf2_url", "html_url", "published_at", "name", "notes"],
+                             defaults=("", ""))
 
 
 class UpdateCheckError(RuntimeError):
@@ -279,6 +285,8 @@ def check_latest() -> Optional[ReleaseInfo]:
                     tarball_url=host["tarball_url"],
                     html_url=host.get("html_url", ""),
                     published_at=host.get("published_at", ""),
+                    name=host.get("name", ""),
+                    notes=host.get("notes", ""),
                 )
         except (KeyError, InvalidVersion) as e:
             log.warning("Corrupt ETag cache for host update — discarding: %s", e)
@@ -302,6 +310,8 @@ def check_latest() -> Optional[ReleaseInfo]:
         tarball_url = data["tarball_url"]
         html_url = data.get("html_url", "")
         published_at = data.get("published_at", "")
+        rel_name = data.get("name", "") or ""
+        notes = data.get("body", "") or ""
     except (ValueError, KeyError) as e:
         raise UpdateCheckError(f"Malformed GitHub response: {e}") from e
 
@@ -319,6 +329,8 @@ def check_latest() -> Optional[ReleaseInfo]:
         "tarball_url": tarball_url,
         "html_url": html_url,
         "published_at": published_at,
+        "name": rel_name,
+        "notes": notes,
     }
     _save_etag_cache(cache)
 
@@ -328,7 +340,8 @@ def check_latest() -> Optional[ReleaseInfo]:
 
     log.info("Update check: new version available: %s -> %s", __version__, latest)
     return ReleaseInfo(tag=tag, version=str(latest), tarball_url=tarball_url,
-                       html_url=html_url, published_at=published_at)
+                       html_url=html_url, published_at=published_at,
+                       name=rel_name, notes=notes)
 
 
 def check_fw_latest(current_version: str) -> Optional[FwUpReleaseInfo]:
@@ -369,6 +382,8 @@ def check_fw_latest(current_version: str) -> Optional[FwUpReleaseInfo]:
                     uf2_url=fw.get("uf2_url", ""),
                     html_url=fw.get("html_url", ""),
                     published_at=fw.get("published_at", ""),
+                    name=fw.get("name", ""),
+                    notes=fw.get("notes", ""),
                 )
         except (KeyError, InvalidVersion) as e:
             log.warning("Corrupt ETag cache for firmware update — discarding: %s", e)
@@ -390,6 +405,8 @@ def check_fw_latest(current_version: str) -> Optional[FwUpReleaseInfo]:
         html_url = data.get("html_url", "")
         assets = data.get("assets", [])
         published_at = data.get("published_at", "")
+        rel_name = data.get("name", "") or ""
+        notes = data.get("body", "") or ""
     except (ValueError, KeyError) as e:
         raise UpdateCheckError(f"Malformed GitHub response: {e}") from e
 
@@ -412,6 +429,8 @@ def check_fw_latest(current_version: str) -> Optional[FwUpReleaseInfo]:
         "uf2_url": uf2_url or "",
         "html_url": html_url,
         "published_at": published_at,
+        "name": rel_name,
+        "notes": notes,
     }
     _save_etag_cache(cache)
 
@@ -425,7 +444,8 @@ def check_fw_latest(current_version: str) -> Optional[FwUpReleaseInfo]:
 
     log.info("Firmware update check: new version available: %s -> %s", current_version, latest)
     return FwUpReleaseInfo(tag=tag, version=str(latest), bin_url=bin_url,
-                           uf2_url=uf2_url or "", html_url=html_url, published_at=published_at)
+                           uf2_url=uf2_url or "", html_url=html_url, published_at=published_at,
+                           name=rel_name, notes=notes)
 
 
 def _safe_extract(tar: tarfile.TarFile, dest: Path) -> None:

--- a/polyhost/services/updater.py
+++ b/polyhost/services/updater.py
@@ -117,6 +117,10 @@ class NotWritableError(RuntimeError):
     """Raised when the install directory cannot be modified (e.g. system site-packages)."""
 
 
+class _DownloadCancelled(Exception):
+    """Internal: the user aborted a firmware download via its cancel flag."""
+
+
 def get_install_root() -> Path:
     """Return the directory we'd overwrite (parent of the `polyhost` package)."""
     root = Path(polyhost.__file__).resolve().parent.parent
@@ -772,11 +776,18 @@ class FwUpDownloader(threading.Thread):
     """
 
     def __init__(self, release: FwUpReleaseInfo, *,
-                 on_progress=None, on_finished=None):
+                 on_progress=None, on_finished=None, cancel_flag: list = None):
         super().__init__(daemon=True)
         self.release = release
         self._on_progress = on_progress
         self._on_finished = on_finished
+        # Optional single-element list; set cancel_flag[0] = True to abort. The
+        # download only writes to a temp file — nothing reaches the keyboard —
+        # so aborting mid-download is always safe.
+        self._cancel_flag = cancel_flag
+
+    def _cancelled(self) -> bool:
+        return self._cancel_flag is not None and self._cancel_flag[0]
 
     def run(self):
         tmp_path = None
@@ -796,6 +807,8 @@ class FwUpDownloader(threading.Thread):
                     total = int(r.headers.get("Content-Length") or 0)
                     written = 0
                     for chunk in r.iter_content(DOWNLOAD_CHUNK):
+                        if self._cancelled():
+                            raise _DownloadCancelled()
                         if not chunk:
                             continue
                         tmp.write(chunk)
@@ -805,6 +818,13 @@ class FwUpDownloader(threading.Thread):
                             _fire(self._on_progress, pct, f"Downloading firmware… {written // 1024} / {total // 1024} KB")
                         else:
                             _fire(self._on_progress, 0, f"Downloading firmware… {written // 1024} KB")
+        except _DownloadCancelled:
+            # Expected user abort — clean up the partial file quietly (no traceback).
+            if tmp_path and os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+            log.info("Firmware download cancelled by user.")
+            _fire(self._on_finished, False, "Download cancelled.", "")
+            return
         except Exception as e:  # noqa: BLE001
             log.exception("Firmware download failed")
             if tmp_path and os.path.exists(tmp_path):

--- a/tests/services/updater_test.py
+++ b/tests/services/updater_test.py
@@ -854,6 +854,38 @@ class TestFwUpDownloader(unittest.TestCase):
             self.assertIn("nope", err)
             self.assertFalse(bin_path.exists(), "partial download must be unlinked")
 
+    def test_cancel_aborts_and_unlinks(self):
+        # Cancel flag set before the first chunk: the download aborts, the
+        # partial temp file is removed, and it finishes not-ok (not an error
+        # traceback path — it's a clean cancel).
+        rec = _Recorder()
+        rel = updater.FwUpReleaseInfo("PolyKybd-fw-v0.9.0", "0.9.0",
+                                      "https://example.com/fw.bin", "", "html", "")
+        cancel = [True]
+        dl = updater.FwUpDownloader(
+            rel,
+            on_progress=rec.make("progress"),
+            on_finished=rec.make("finished"),
+            cancel_flag=cancel,
+        )
+        with tempfile.TemporaryDirectory() as td:
+            ctx = self._stream_response([b"abc", b"def"], total=6)
+            bin_path = Path(td) / "fw.bin"
+            raw = open(bin_path, "wb")
+            fh = _NamedFile(raw, str(bin_path))
+            with mock.patch.object(updater.requests, "get", return_value=ctx), \
+                 mock.patch.object(updater.tempfile, "NamedTemporaryFile") as mock_ntf:
+                mock_ntf.return_value.__enter__.return_value = fh
+                try:
+                    dl.run()
+                finally:
+                    raw.close()
+            ok, err, path = rec.args_for("finished")[0]
+            self.assertFalse(ok)
+            self.assertEqual(path, "")
+            self.assertIn("cancel", err.lower())
+            self.assertFalse(bin_path.exists(), "cancelled download must be unlinked")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/services/updater_test.py
+++ b/tests/services/updater_test.py
@@ -134,6 +134,42 @@ class TestCheckLatest(unittest.TestCase):
              mock.patch.object(updater.requests, "get", return_value=_make_response(304)):
             self.assertIsNone(updater.check_latest())
 
+    def test_parses_release_name_and_notes(self):
+        # The release title (name) and notes (API body) flow through to the
+        # confirmation dialog — parse and surface them.
+        payload = _release_json("v0.8.0")
+        payload["name"] = "PolyKybdHost 0.8.0"
+        payload["body"] = "## Fixes\n- fixed a thing"
+        with mock.patch.object(updater, "__version__", "0.7.2"), \
+             mock.patch.object(updater.requests, "get",
+                               return_value=_make_response(200, payload)):
+            release = updater.check_latest()
+        self.assertEqual(release.name, "PolyKybdHost 0.8.0")
+        self.assertEqual(release.notes, "## Fixes\n- fixed a thing")
+
+    def test_missing_name_and_body_default_to_empty(self):
+        # Releases without a title/body must not blow up; notes/name become "".
+        with mock.patch.object(updater, "__version__", "0.7.2"), \
+             mock.patch.object(updater.requests, "get",
+                               return_value=_make_response(200, _release_json("v0.8.0"))):
+            release = updater.check_latest()
+        self.assertEqual(release.name, "")
+        self.assertEqual(release.notes, "")
+
+    def test_notes_survive_304_from_cache(self):
+        # A 304 must reconstruct name/notes from the cache, not KeyError on the
+        # older cache shape that lacks them.
+        self.mock_load.return_value = {"host": {
+            "etag": '"abc"', "tag": "v1.2.3", "version": "1.2.3",
+            "tarball_url": "https://example.com/t", "html_url": "", "published_at": "",
+            "name": "PolyKybdHost 1.2.3", "notes": "cached notes",
+        }}
+        with mock.patch.object(updater, "__version__", "0.0.1"), \
+             mock.patch.object(updater.requests, "get", return_value=_make_response(304)):
+            release = updater.check_latest()
+        self.assertEqual(release.name, "PolyKybdHost 1.2.3")
+        self.assertEqual(release.notes, "cached notes")
+
 
 def _redirect_response(location):
     resp = mock.Mock()
@@ -331,6 +367,16 @@ class TestCheckFwLatest(unittest.TestCase):
         with mock.patch.object(updater.requests, "get",
                                return_value=self._resp(200, _fw_release_json("PolyKybd-fw-v0.8.1"))):
             self.assertIsNone(updater.check_fw_latest("0.8.1"))
+
+    def test_parses_firmware_name_and_notes(self):
+        payload = _fw_release_json("PolyKybd-fw-v0.8.3")
+        payload["name"] = "PolyKybd Firmware 0.8.3"
+        payload["body"] = "New idle-jitter style"
+        with mock.patch.object(updater.requests, "get",
+                               return_value=self._resp(200, payload)):
+            release = updater.check_fw_latest("0.8.1")
+        self.assertEqual(release.name, "PolyKybd Firmware 0.8.3")
+        self.assertEqual(release.notes, "New idle-jitter style")
 
     def test_newer_without_bin_returns_none(self):
         # A newer release that has no .bin asset cannot be flashed over HID.


### PR DESCRIPTION
## Summary

The host-update and firmware-update confirmation dialogs previously showed only the version number and release date, so users had no idea what an update actually brought before committing to install/flash it. This PR surfaces the GitHub release notes right in the confirmation dialog.

- **`services/updater.py`** — carry the GitHub release title (`name`) and notes (API `body`) through `ReleaseInfo` / `FwUpReleaseInfo`. The two new fields default to `""`, so the rate-limit web-fallback paths and existing positional constructions keep working. Both the host check (`check_latest`) and firmware check (`check_fw_latest`) now parse and cache them, including on the ETag 304 cached path.
- **`gui/update_dialog.py`** (new) — a shared `confirm_update()` dialog that renders the notes (markdown when Qt ≥ 5.14, plain text otherwise) in a scrollable pane, with a "What's new — <release title>" heading and a "View full release notes on GitHub" link. The call-to-action question sits right above the Yes/No buttons so it stays visible next to the buttons on a long changelog. When a release has no notes, it degrades transparently to the old compact yes/no box.
- **`host.py` / `forwarder.py`** — route the host-install and firmware-flash confirmations through `confirm_update()`.
- **`polyctl` / `poly_core`** — surface `name` + `notes` in the `update check` RPC payload and CLI output.

## Version bump label

`bump:minor` — user-visible feature (release notes in the update dialog), backwards-compatible.

## Testing
- [ ] Tested locally against real hardware
- [x] Tested with mock device (if UI changes)

Automated: 58 `updater` unit tests pass (added 4 covering `name`/`notes` parsing + 304-cache reconstruction); the real `PolyHost` GUI-construction test passes under xvfb in both default and `--connect` client mode; the dialog was rendered offscreen against the live v0.9.26 release notes to confirm markdown rendering, scrolling, the GitHub link, and the question-above-buttons layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Update checks now show release titles and full release notes when available.
  * Update confirmation dialogs for app and firmware updates now include richer release details and a link to view the full changelog.
  * Multi-line release notes are displayed in a clearer, more readable format.

* **Bug Fixes**
  * Fixed update prompts so they no longer fall through to the “up to date” message after an available update is found.
  * Preserved release details for cached update responses, keeping update info consistent across checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->