### PR TITLE
docs: fix stale IDLE_STYLE_DOOM name in IdleStyle docstring

### DIFF
--- a/polyhost/device/command_ids.py
+++ b/polyhost/device/command_ids.py
@@ -86,7 +86,7 @@ class IdleStyle(Enum):
     pulse (dismissed by the first key press); firmware without the doom build (or
     older than the feature) falls back to / NACKs it — surfaced as a plain error.
     (Named for the cheat code, matching the tray/CLI label; the firmware calls the
-    same value IDLE_STYLE_DOOM internally — the wire value 2 is what's shared.)
+    same value IDLE_STYLE_IDDQD internally — the wire value 2 is what's shared.)
     """
     PULSE = 0
     JITTER = 1


### PR DESCRIPTION
## Summary
One-line docstring correction. `IdleStyle.IDDQD`'s docstring said the firmware "calls the same value `IDLE_STYLE_DOOM` internally", but the firmware enum is `IDLE_STYLE_IDDQD` (`qmk_firmware` `state.h`) — leftover wording from the earlier doom→IDDQD host rename. No code change: the shared wire value (`2`) and `IdleStyle.IDDQD` are already correct and consistent across `command_ids.py`, `protocol.py`, and the firmware's cmd-28 range check. Found during a cross-repo audit for naming/version drift.

## Version bump label
*(none — docstring-only, patch bump)*

## Testing
- [ ] Tested locally against real hardware
- [ ] Tested with mock device (if UI changes)

_No behavioral change — comment/docstring only, so no runtime test applies._

---
_Generated by [Claude Code](https://claude.ai/code/session_01C9Uiuz2SNtoTVAdjm6dE8V)_