### PR TITLE
Recognize the PolyKybd Split42 (PID 0x2008) on the host

### DIFF
--- a/polyhost/core/poly_core.py
+++ b/polyhost/core/poly_core.py
@@ -782,6 +782,11 @@ class PolyCore:
         update only (never AUTO_ON): if the user has taken manual control on the
         keyboard the firmware ignores it, so a background tick can't override a
         deliberate choice. Engaging auto is a deliberate act (see _engage)."""
+        # Skip while disconnected: there is no keyboard to set, and the compute
+        # step does live network lookups (irradiance/location) that would run
+        # for nothing on the 10-min tick.
+        if not self.connected:
+            return
         if self.poly_settings.get("brightness_set_daylight_dependent"):
             val = self._compute_daylight_value()
             flags = self._BR_FLAG_VOLATILE if self._brightness_flags_supported() else 0

--- a/polyhost/device/99-hid.rules
+++ b/polyhost/device/99-hid.rules
@@ -1,1 +1,7 @@
+# PolyKybd raw-HID access (non-root). One line per known product ID — keep in
+# sync with DeviceSettings.KNOWN_PIDS. After editing, reinstall + reload:
+#   sudo cp polyhost/device/99-hid.rules /etc/udev/rules.d/99-hid.rules
+#   sudo udevadm control --reload-rules && sudo udevadm trigger
+# then replug the keyboard.
 SUBSYSTEM=="hidraw", ATTRS{idVendor}=="2021", ATTRS{idProduct}=="2007", MODE="0666"
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="2021", ATTRS{idProduct}=="2008", MODE="0666"

--- a/polyhost/device/device_settings.py
+++ b/polyhost/device/device_settings.py
@@ -6,6 +6,12 @@ class DeviceSettings:
     """All settings that are defined by the keyboard, not by software"""
     _vid = 0x2021
     _pid = 0x2007
+    # Known PolyKybd product IDs we support. The USB PID identifies the variant
+    # (0x2007 = Split72, 0x2008 = Split42); the raw-HID usage page only picks the
+    # 64-byte raw interface apart from the other HID interfaces, it does NOT
+    # identify the device — so enumeration matches on this explicit allow-list.
+    # Add a line here for each new variant.
+    _known_pids = (0x2007, 0x2008)
 
     _hid_report_size_in_bytes = 64
     _hid_console_report_size_in_bytes = 64
@@ -59,8 +65,13 @@ class DeviceSettings:
 
     @property
     def PID(self):
-        """Product ID"""
+        """Product ID (primary variant; use KNOWN_PIDS for enumeration matching)"""
         return self._pid
+
+    @property
+    def KNOWN_PIDS(self):
+        """All PolyKybd product IDs the host recognizes (variant allow-list)"""
+        return self._known_pids
 
     @property
     def MATRIX_ROWS(self):

--- a/polyhost/device/hid_helper.py
+++ b/polyhost/device/hid_helper.py
@@ -154,7 +154,8 @@ class HidHelper:
         self.settings = settings
         self.lock = threading.Lock()
 
-        device_interfaces = hid.enumerate(self.settings.VID, self.settings.PID)
+        device_interfaces = [i for i in hid.enumerate(self.settings.VID, 0)
+                             if i['product_id'] in self.settings.KNOWN_PIDS]
         raw_hid_interfaces = [i for i in device_interfaces if i['usage_page'] == self.settings.HID_RAW_USAGE_PAGE and i['usage'] == self.settings.HID_RAW_USAGE]
 
         if len(raw_hid_interfaces) != 0:
@@ -206,7 +207,8 @@ class HidHelper:
         # itself can raise on USB churn/permission errors, and this runs from
         # the background self-heal path where an escaped exception is noise.
         try:
-            device_interfaces = hid.enumerate(self.settings.VID, self.settings.PID)
+            device_interfaces = [i for i in hid.enumerate(self.settings.VID, 0)
+                                  if i['product_id'] in self.settings.KNOWN_PIDS]
             console_hid_interfaces = [j for j in device_interfaces
                                       if j['usage_page'] == self.settings.HID_CONSOLE_USAGE_PAGE
                                       and j['usage'] == self.settings.HID_CONSOLE_USAGE]
@@ -398,7 +400,8 @@ class HidHelper:
 
         deadline = time.monotonic() + timeout_s
         while time.monotonic() < deadline:
-            interfaces = hid.enumerate(self.settings.VID, self.settings.PID)
+            interfaces = [i for i in hid.enumerate(self.settings.VID, 0)
+                          if i['product_id'] in self.settings.KNOWN_PIDS]
             raw = [i for i in interfaces
                    if i['usage_page'] == self.settings.HID_RAW_USAGE_PAGE
                    and i['usage'] == self.settings.HID_RAW_USAGE]

--- a/polyhost/device/poly_kybd.py
+++ b/polyhost/device/poly_kybd.py
@@ -303,6 +303,10 @@ class PolyKybd:
         # flags (protocol >= 5, firmware base/com.h): bit0 VOLATILE (daylight,
         # not persisted), bit1 AUTO_ON, bit2 AUTO_OFF. flags=0 is the legacy
         # persisted set; pre-v5 firmware ignores the extra byte.
+        if self.hid is None:
+            # No open device (e.g. the daylight periodic firing while
+            # disconnected). Fail like the send path instead of AttributeError.
+            return False, "No Interface"
         self.log.info("Setting Display Brightness to %d (flags 0x%x)...", brightness, flags)
         return self.hid.send_and_read_validate(
             compose_cmd(Cmd.SET_BRIGHTNESS, max(0, min(50, int(brightness))), flags & 0xFF))

--- a/polyhost/device/poly_kybd.py
+++ b/polyhost/device/poly_kybd.py
@@ -303,9 +303,14 @@ class PolyKybd:
         # flags (protocol >= 5, firmware base/com.h): bit0 VOLATILE (daylight,
         # not persisted), bit1 AUTO_ON, bit2 AUTO_OFF. flags=0 is the legacy
         # persisted set; pre-v5 firmware ignores the extra byte.
-        if self.hid is None:
+        if self.hid is None or self.hid.interface is None:
             # No open device (e.g. the daylight periodic firing while
             # disconnected). Fail like the send path instead of AttributeError.
+            # Covers both disconnected states with one consistent str result:
+            # self.hid is None (no helper at all) and self.hid.interface is None
+            # (helper present but no raw interface — send_and_read_validate would
+            # otherwise return a bytearray "No Interface", inconsistent + not
+            # JSON-serializable for the core event payload).
             return False, "No Interface"
         self.log.info("Setting Display Brightness to %d (flags 0x%x)...", brightness, flags)
         return self.hid.send_and_read_validate(

--- a/polyhost/device/serial_helper.py
+++ b/polyhost/device/serial_helper.py
@@ -10,7 +10,7 @@ class SerialHelper:
         ports = serial.tools.list_ports.comports()
         for port in ports:
             if port.vid is not None and port.pid is not None:
-                if port.vid == self.settings.VID and port.pid == self.settings.PID:
+                if port.vid == self.settings.VID and port.pid in self.settings.KNOWN_PIDS:
                     return port.device
         return None
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -179,7 +179,13 @@ case "$(uname -s)" in
             echo "!! Could not detect a package manager - install hidapi (libhidapi-hidraw0) yourself."
         fi
         echo ">> Installing udev rule for non-root HID access"
-        sudo cp polyhost/device/99-hid.rules /etc/udev/rules.d/99-hid.rules
+        # Written inline so the installer is self-contained. Keep the PID lines
+        # in sync with polyhost/device/99-hid.rules and DeviceSettings.KNOWN_PIDS
+        # (0x2007 = Split72, 0x2008 = Split42) — one line per known variant.
+        sudo tee /etc/udev/rules.d/99-hid.rules >/dev/null <<'UDEV_RULE'
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="2021", ATTRS{idProduct}=="2007", MODE="0666"
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="2021", ATTRS{idProduct}=="2008", MODE="0666"
+UDEV_RULE
         sudo udevadm control --reload-rules && sudo udevadm trigger
         echo ">> Replug the keyboard so the new udev rule takes effect."
         ;;

--- a/tests/device/device_settings_test.py
+++ b/tests/device/device_settings_test.py
@@ -11,6 +11,13 @@ class TestDeviceSettings(unittest.TestCase):
         self.assertEqual(self.s.VID, 0x2021)
         self.assertEqual(self.s.PID, 0x2007)
 
+    def test_known_pids_cover_both_variants(self):
+        # Enumeration matches on this allow-list, not the single PID: Split72
+        # (0x2007) and Split42 (0x2008) must both be recognized.
+        self.assertIn(0x2007, self.s.KNOWN_PIDS)  # Split72
+        self.assertIn(0x2008, self.s.KNOWN_PIDS)  # Split42
+        self.assertIn(self.s.PID, self.s.KNOWN_PIDS)
+
     def test_matrix_dimensions(self):
         self.assertEqual(self.s.MATRIX_ROWS, 10)
         self.assertEqual(self.s.MATRIX_COLUMNS, 8)

--- a/tests/device/poly_kybd_cmd_test.py
+++ b/tests/device/poly_kybd_cmd_test.py
@@ -8,6 +8,7 @@ the HID worker-thread / command-queue refactoring.
 Invariant asserted throughout: after any PolyKybd call returns, the HID lock
 must be free — a held lock here means a leaked lock in production.
 """
+import types
 import unittest
 from unittest import mock
 from unittest.mock import MagicMock
@@ -257,6 +258,18 @@ class TestSimpleCommandPayloads(unittest.TestCase, LockCheckMixin):
         ok, reply = keeb.set_brightness(24, 0x1)
         self.assertFalse(ok)
         self.assertEqual(reply, "No Interface")
+
+    def test_brightness_no_interface_returns_str_not_bytearray(self):
+        # Second disconnected state: HidHelper present but no open raw interface.
+        # Must short-circuit with the same str "No Interface" — not fall through
+        # to send_and_read_validate(), which returns a bytearray "No Interface"
+        # (inconsistent result type + not JSON-serializable for the event payload).
+        keeb = PolyKybd(DeviceSettings(), StubPolySettings())
+        keeb.hid = types.SimpleNamespace(interface=None)
+        ok, reply = keeb.set_brightness(24, 0x1)
+        self.assertFalse(ok)
+        self.assertEqual(reply, "No Interface")
+        self.assertIsInstance(reply, str)
 
 
 class TestSendOnlyCommands(unittest.TestCase, LockCheckMixin):

--- a/tests/device/poly_kybd_cmd_test.py
+++ b/tests/device/poly_kybd_cmd_test.py
@@ -249,6 +249,15 @@ class TestSimpleCommandPayloads(unittest.TestCase, LockCheckMixin):
     def test_brightness_clipped_to_min_0(self):
         self.assertEqual(self._payload('set_brightness', -5)[2], 0)
 
+    def test_brightness_no_device_returns_failure_not_crash(self):
+        # The daylight periodic can fire while disconnected (hid is None);
+        # set_brightness must fail gracefully instead of raising AttributeError.
+        keeb = PolyKybd(DeviceSettings(), StubPolySettings())
+        keeb.hid = None
+        ok, reply = keeb.set_brightness(24, 0x1)
+        self.assertFalse(ok)
+        self.assertEqual(reply, "No Interface")
+
 
 class TestSendOnlyCommands(unittest.TestCase, LockCheckMixin):
     """Bootloader / handedness reset the device immediately: send, no ACK wait."""


### PR DESCRIPTION
## Summary
Teaches the host to recognize the new **PolyKybd Split42** variant, which enumerates with USB **PID `0x2008`** (Split72 is `0x2007`). Previously the host matched a single hard-coded PID, so a Split42 was never found by HID/serial enumeration and never got a udev rule.

- **Variant allow-list** (`device_settings.py`): add `DeviceSettings.KNOWN_PIDS = (0x2007, 0x2008)` and a `KNOWN_PIDS` property. The raw-HID usage page only separates the 64-byte raw interface from the other HID interfaces — it does **not** identify the device — so enumeration now matches on this explicit PID allow-list instead of one fixed `PID`.
- **HID enumeration** (`hid_helper.py`): the three `hid.enumerate(VID, PID)` sites (connect, console attach, post-flash re-enumerate wait) now enumerate `VID` broadly and filter to `KNOWN_PIDS`, so either variant is discovered.
- **Serial enumeration** (`serial_helper.py`): the QMK-console serial port match uses `pid in KNOWN_PIDS`.
- **udev** (`99-hid.rules` + `scripts/install.sh`): add the `0x2008` hidraw rule for non-root access; `install.sh` now writes both PID lines inline (self-contained installer) and documents keeping them in sync with `KNOWN_PIDS`.
- **Disconnect-safe daylight brightness** (`poly_core.py`, `poly_kybd.py`): the 10-min daylight-brightness periodic could fire while disconnected — `PolyCore._daylight_tick` now returns early when `not self.connected` (also avoids the live irradiance/location network lookups for nothing), and `PolyKybd.set_brightness()` guards `self.hid is None`, failing like the send path (`False, "No Interface"`) instead of raising `AttributeError`.

No wire-protocol change — this is variant discovery/permissions only, so no `__protocol__` bump.

## Version bump label
Suggest **`bump:minor`** — adds support for a new hardware variant (backwards-compatible feature). No protocol change, so no `bump:protocol`.

## Testing
- [x] Tested with mock device — `tests/device/device_settings_test.py` (KNOWN_PIDS allow-list) and `tests/device/poly_kybd_cmd_test.py` (set_brightness with no open device) extended; full `tests.device` suite: **86 passed**.
- [ ] Tested locally against real hardware — pending on the physical Split42 (hardware bring-up in progress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QeEo7SamJAXEykbNebEdvL)_

## Summary by Sourcery

Add support for multiple PolyKybd variants by recognizing both Split72 and Split42 product IDs and improving robustness of brightness control when the keyboard is disconnected.

New Features:
- Support host-side enumeration and permissions for the PolyKybd Split42 variant via a product ID allow-list used across HID, serial, and udev matching.

Bug Fixes:
- Prevent daylight-driven brightness updates from attempting to operate while the keyboard is disconnected, avoiding errors and unnecessary network lookups.
- Ensure set_brightness fails gracefully when no HID interface is open instead of raising an AttributeError.

Enhancements:
- Centralize recognized product IDs in DeviceSettings via a KNOWN_PIDS property and use it consistently for device discovery.

Build:
- Inline udev rule installation in the setup script to install non-root HID access rules for all supported product IDs and document keeping them in sync with DeviceSettings.

Tests:
- Extend device settings and PolyKybd command tests to cover the product ID allow-list and brightness behavior with no connected device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting and connecting to multiple supported keyboard variants.
  * Improved Linux HID permissions for supported keyboard models.

* **Bug Fixes**
  * Brightness updates now skip disconnected keyboards without unnecessary processing.
  * Brightness commands fail gracefully instead of crashing when no keyboard interface is available.

* **Documentation**
  * Added guidance for configuring and reloading HID permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->