### PR TITLE
fix(forwarder): restart reliably after a self-update, like PolyHost mode

### DIFF
--- a/polyhost/forwarder.py
+++ b/polyhost/forwarder.py
@@ -124,6 +124,11 @@ class PolyForwarder(QApplication):
         self.win = None
         self.prev_win = None
         self.is_closing = False
+        # Set when a self-update lands: main_app re-execs into the new version
+        # *after* exec_() returns (from a clean, fully-unwound event loop),
+        # mirroring how the headless daemon restarts — rather than calling
+        # os.execv from inside a live Qt slot with the tray/timer still up.
+        self.wants_restart = False
         self.title = None
         self.last_update_msec = 0
 
@@ -359,13 +364,15 @@ class PolyForwarder(QApplication):
             self._update_progress.setValue(percent)
 
     def _on_update_done(self):
-        from polyhost.services.updater import restart_app
         if self._update_progress is not None:
             self._update_progress.close()
             self._update_progress = None
         self.log.info("Update applied, restarting forwarder...")
+        # Re-exec from a clean state after the event loop exits (see
+        # `wants_restart` and main_app), not with os.execv from inside this
+        # slot while the tray/timer are still live — exactly like the daemon.
+        self.wants_restart = True
         self.quit_app()
-        restart_app()
 
     def _on_relay_needed(self, relay_path):
         if self._update_progress is not None:
@@ -393,6 +400,12 @@ class PolyForwarder(QApplication):
         if self._report_client is not None:
             self._report_client.close()
             self._report_client = None
+        # Tear the tray icon down before the loop exits so a re-exec (update
+        # restart) doesn't leave a stale icon behind / a doubled tray.
+        try:
+            self.tray.hide()
+        except Exception:  # noqa: BLE001 — tray teardown must never block quit
+            pass
         self.quit()
 
     def active_window_reporter(self):

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -60,7 +60,7 @@ from polyhost.services.unicode_cache import UnicodeCache
 from polyhost._version import __version__, __protocol__
 
 from polyhost.services.updater import (
-    UpdateChecker, UpdateInstaller, FwUpDownloader, restart_app,
+    UpdateChecker, UpdateInstaller, FwUpDownloader,
     get_last_check_time, set_last_check_time)
 from polyhost.gui.hid_fw_up_dialog import HidFwUpDialog
 from polyhost.gui.dialog_util import position_near_tray
@@ -338,6 +338,9 @@ class PolyHost(QApplication):
 
         self.setQuitOnLastWindowClosed(False)
         self.is_closing = False
+        # Set when a self-update lands: main_app re-execs after exec_() returns
+        # (clean, fully-unwound loop) instead of os.execv from inside a slot.
+        self.wants_restart = False
         self.debug_mode = debug_mode
 
         # Create the menu
@@ -1720,8 +1723,11 @@ class PolyHost(QApplication):
             self._await_daemon_restart_then_relaunch()
             return
         self.log.info("Update applied, restarting...")
+        # Re-exec after the event loop unwinds (main_app checks wants_restart),
+        # not with os.execv from inside this slot while the tray/worker are
+        # still live — same clean-restart pattern as the forwarder + daemon.
+        self.wants_restart = True
         self.quit_app()
-        restart_app()
 
     def _await_daemon_restart_then_relaunch(self):
         """Client mode: after a daemon-driven self-update, the daemon re-execs
@@ -1739,8 +1745,8 @@ class PolyHost(QApplication):
 
         def _relaunch(reason):
             self.log.info("Relaunching GUI to reconnect to the core daemon (%s).", reason)
+            self.wants_restart = True
             self.quit_app()
-            restart_app()
 
         def poll():
             if self.is_closing:

--- a/polyhost/main_app.py
+++ b/polyhost/main_app.py
@@ -322,7 +322,19 @@ def main(launch_monotonic=None, post_bootstrap_monotonic=None):
             raise
 
     slog.info("Handoff complete; entering the Qt event loop.")
-    sys.exit(app.exec_())
+    rc = app.exec_()
+    # A self-update that lands mid-session asks for a re-exec into the freshly
+    # installed version. Do it here — after the event loop has fully unwound —
+    # rather than calling os.execv from inside a Qt slot with the tray/timer
+    # still live (the forwarder used to, and a transient execv failure then
+    # left it dead with no relaunch). This mirrors the headless daemon, which
+    # re-execs only after its run loop ends. `restart_app()` re-execs (or, on
+    # failure, spawns a detached child) and never returns.
+    if getattr(app, "wants_restart", False):
+        from polyhost.services.updater import restart_app
+        del app  # let the QApplication release its X/tray/D-Bus resources first
+        restart_app()
+    sys.exit(rc)
 
 
 def _spawned_daemon_flags(args):

--- a/polyhost/services/updater.py
+++ b/polyhost/services/updater.py
@@ -614,14 +614,27 @@ def apply_update(extracted_dir: Path, install_root: Path, line_cb=None) -> list:
 
 
 def restart_app() -> None:
-    """Re-exec the app. Uses subprocess+exit on Windows (execv argv issues)."""
+    """Re-exec the app. Uses subprocess+exit on Windows (execv argv issues).
+
+    On POSIX we prefer ``os.execv`` (replaces the process in place), but it can
+    fail transiently — e.g. ``ETXTBSY`` right after ``pip install -e .`` rewrote
+    the package files, or under resource pressure. Because callers invoke this
+    *after* they have already asked the app to quit, a raised ``execv`` would
+    otherwise leave the app dead with no relaunch ("not starting up again after
+    the update"). So fall back to spawning a detached child + exiting, which
+    always brings the app back.
+    """
     args = [sys.executable, "-m", "polyhost", *sys.argv[1:]]
     log.info("Restarting: %s", args)
     if sys.platform == "win32":
         subprocess.Popen(args, close_fds=False)
         sys.exit(0)
-    else:
+    try:
         os.execv(sys.executable, args)
+    except OSError as e:
+        log.warning("os.execv failed (%s); falling back to a subprocess relaunch.", e)
+        subprocess.Popen(args, close_fds=False)
+        sys.exit(0)
 
 
 def _fire(cb, *args):

--- a/tests/services/updater_test.py
+++ b/tests/services/updater_test.py
@@ -635,6 +635,48 @@ class _Recorder:
         return [args for n, args in self.calls if n == name]
 
 
+class TestRestartApp(unittest.TestCase):
+    """restart_app() re-execs the app, and must always bring it back.
+
+    On POSIX it prefers os.execv, but a transient execv failure (e.g. ETXTBSY
+    right after pip rewrote the package) must fall back to a subprocess relaunch
+    + exit — otherwise a caller that already asked the app to quit would die
+    with no restart ("not starting up again after the update").
+    """
+
+    def test_execv_used_on_posix(self):
+        with mock.patch.object(updater.sys, "platform", "linux"), \
+             mock.patch.object(updater.os, "execv") as execv, \
+             mock.patch.object(updater.subprocess, "Popen") as popen:
+            updater.restart_app()
+        execv.assert_called_once()
+        popen.assert_not_called()
+
+    def test_execv_failure_falls_back_to_subprocess(self):
+        with mock.patch.object(updater.sys, "platform", "linux"), \
+             mock.patch.object(updater.os, "execv",
+                               side_effect=OSError(26, "Text file busy")), \
+             mock.patch.object(updater.subprocess, "Popen") as popen, \
+             mock.patch.object(updater.sys, "exit",
+                               side_effect=SystemExit) as sys_exit:
+            with self.assertRaises(SystemExit):
+                updater.restart_app()
+        popen.assert_called_once()
+        sys_exit.assert_called_once_with(0)
+
+    def test_windows_uses_subprocess(self):
+        with mock.patch.object(updater.sys, "platform", "win32"), \
+             mock.patch.object(updater.os, "execv") as execv, \
+             mock.patch.object(updater.subprocess, "Popen") as popen, \
+             mock.patch.object(updater.sys, "exit",
+                               side_effect=SystemExit) as sys_exit:
+            with self.assertRaises(SystemExit):
+                updater.restart_app()
+        execv.assert_not_called()
+        popen.assert_called_once()
+        sys_exit.assert_called_once_with(0)
+
+
 class TestUpdateChecker(unittest.TestCase):
     """The threaded checker maps check_latest/check_fw_latest results to callbacks.
 


### PR DESCRIPTION
## Summary

The PolyForwarder failed to come back after applying a self-update ("not starting up again after the update is applied", reported on GNOME).

**Root cause:** the forwarder re-execed by calling `restart_app()` → `os.execv()` **directly inside the `_on_update_done` Qt slot** — with the event loop, the active-window `QTimer`, the tray icon and the report client all still live, and *after* it had already called `self.quit()`. `os.execv` can fail transiently (most notably `ETXTBSY` right after the update's `pip install -e .` rewrote the package files, or under momentary resource pressure); when it raises, the app has already been told to quit, so it exits and **never relaunches**.

PolyHost normal mode doesn't hit this because it runs daemon-by-default: the daemon re-execs from a **clean, fully-unwound state** (`run()` → `stop()` → `restart_app()` *after* the loop ends), never from inside a live slot.

This makes the GUI apps behave the same way:

- **`updater.restart_app()`** — on POSIX, fall back to a detached `subprocess.Popen` + exit when `os.execv` raises, so an execv hiccup can never leave the app dead with no relaunch.
- **forwarder + host** — on a self-update, set a `wants_restart` flag and quit; `main_app` performs the re-exec **after `exec_()` returns** (clean, unwound loop), mirroring the headless daemon. Covers the in-process host path and the client-mode daemon-await relaunch too, so every GUI restart path is identical.
- **`forwarder.quit_app()`** — hide the tray icon before the loop exits so a re-exec can't leave a stale / doubled tray behind.

## Version bump label

*(none)* — bug fix, patch bump.

## Testing
- [ ] Tested locally against real hardware
- [ ] Tested with mock device (if UI changes)

Added `TestRestartApp` covering `restart_app`'s execv-success, execv-failure fallback, and Windows subprocess paths. Full runnable (non-Qt) suite green: `updater_test` + `main_app_test`, 65 tests. The GUI/forwarder restart wiring needs a display so it wasn't exercised here beyond byte-compile + the Qt-free `updater`/`main_app` logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JY7NtiNus2XBZpEnfH9SQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011JY7NtiNus2XBZpEnfH9SQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved self-update restart reliability across Windows and POSIX systems.
  - Applications now shut down through the normal event-loop flow before relaunching.
  - Added a fallback restart method when the preferred relaunch process is unavailable.
  - System tray icons are hidden during shutdown to prevent lingering indicators.
- **Tests**
  - Added coverage for platform-specific restart behavior and fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->