### PR TITLE
Range-connect + per-feature protocol gating

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,8 @@ Since the HID-worker refactor (`docs/hid-worker-refactor.md`), the Qt main threa
   too old… please update the keyboard firmware"*). Within range it connects regardless of
   match: `== __protocol__` is the fully-supported case (`sync.svg`), a **lower** device
   protocol connects with *"— some features need a firmware update"* (`sync_problem.svg`),
-  and a **higher** one connects with *"— update the host app for full support"*. Each
+  and a **higher** one (newer firmware than the host) **prompts** — see the newer-firmware
+  note below. Each
   feature is then gated individually by **`FEATURE_MIN_PROTOCOL`** (`device/poly_kybd.py`)
   via the pure `protocol_supports(protocol, feature)` + `PolyKybd.supports()/capabilities()`;
   the GUI (`host.py` `self.supports()`, fed by the `capabilities` dict on `status_changed`/
@@ -124,11 +125,32 @@ Since the HID-worker refactor (`docs/hid-worker-refactor.md`), the Qt main threa
   `>= OVERLAY_PACKED_HEADER_MIN_PROTOCOL (11)` sends the packed 4-byte header, below it the
   pre-v11 5-byte `[id, cmd, keycode, modifier, segment]` form — so overlays work on an older
   keyboard too. Compressed/ROI headers never changed. For a device **newer** than the host
-  we send our newest-known (packed) form and accept that a *future* breaking change to an
-  existing command is unknown to us (the newer-firmware trade-off — the host still connects).
+  (only reachable via the "ignore" newer-firmware choice) we send our newest-known (packed)
+  form and accept that a *future* breaking change to an existing command is unknown to us.
   If you add another wire-format-breaking change to an existing command, add a
   `FEATURE_MIN_PROTOCOL` entry + an encode-branch here; a *new* command just needs a
   `supports()` gate.
+- **Newer firmware than the host PROMPTS the user (session policy, default safe).** When
+  `kb_proto > __protocol__`, blindly trusting a newer firmware for wire-format-sensitive
+  commands is risky, so instead of silently connecting the host asks (dialog
+  `polyhost/gui/newer_firmware_dialog.py`, three choices): **Safe mode** (connect but
+  restrict to the stable set — firmware-update + Debugging; the default and the
+  dismiss/close outcome), **Check for updates** (run the host-app update check via the
+  `_on_update_clicked` idiom with `force=True`; install if a matching release is found, else
+  fall back to safe), or **Connect anyway** (full connect, newest-known formats). The choice
+  is a **session-only** core policy `PolyCore._newer_fw_policy` (like `ignore_version`; keyed
+  to the protocol it was chosen for so a re-flash re-asks) set via
+  `set_newer_firmware_policy(choice)` → `M_SET_NEWER_FW_POLICY` (RemoteCore mirror) →
+  drops `last_applied_connected` so the next probe re-applies. Safe mode is
+  `decide_reconnect_apply`'s newer branch: `connected=True` (so the probe doesn't churn) but
+  `compatible=False`/`safe_mode=True`, `tick_window_tracking` skips overlay/OS traffic while
+  `safe_mode`, and the status carries `safe_mode` + `newer_fw_pending` (with capabilities
+  reported all-False, so feature menus grey out). The GUI drives the dialog off that status
+  seam in **both** in-process (`_apply_reconnect_result`) and `--connect` client
+  (`_render_remote_status`) paths — `_maybe_prompt_newer_firmware`, once per protocol per
+  session. `--ignore-version` still forces a full connect (wins over the safe default). A
+  headless daemon with no GUI defaults to safe; drive it with `polyctl newer-policy
+  [ignore|safe]`.
 - **Still bump `__protocol__` (`polyhost/_version.py`) in lockstep with the firmware
   PROTOCOL_VERSION.** It now defines the host's *newest-known* protocol (the fully-supported
   "match" and the newest wire format the host emits), **not** a hard connect gate. Rule of

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,43 @@ Since the HID-worker refactor (`docs/hid-worker-refactor.md`), the Qt main threa
 
 ## Key notes
 
-- **Bump `__protocol__` (`polyhost/_version.py`) in lockstep with the firmware PROTOCOL_VERSION** — the reconnect gate (`polyhost/core/decisions.py`) connects **only on an exact match** (`kb_proto == host_protocol`); any mismatch shows *"Protocol mismatch, please update"* and refuses to connect, so the keyboard never reaches the features that bump motivated. **This has been forgotten twice** (host stayed at P3 while firmware features advanced to P4 *idle-style* and P5 *brightness host-auto*, leaving current keyboards rejected). Rule of thumb: whenever you add a firmware-protocol feature threshold (e.g. `IDLE_STYLE_MIN_PROTOCOL`, `_BRIGHTNESS_FLAGS_PROTOCOL` — the `>= N` runtime feature gates), the firmware protocol has advanced to **N**, so `__protocol__` must be set to **N** in the same change. The feature `>= N` gates are layered checks *on top of* the exact-match connect gate — they only ever fire once `__protocol__` already equals the device's protocol.
+- **Version handling is RANGE-connect + per-feature gating (not exact-match).** The
+  reconnect gate (`polyhost/core/decisions.py` `decide_reconnect_apply`) connects to any
+  firmware whose protocol is **≥ `MIN_SUPPORTED_PROTOCOL`** (= 2, the packed-lang-list
+  floor — below it the host can't even enumerate languages, so it refuses with *"Firmware
+  too old… please update the keyboard firmware"*). Within range it connects regardless of
+  match: `== __protocol__` is the fully-supported case (`sync.svg`), a **lower** device
+  protocol connects with *"— some features need a firmware update"* (`sync_problem.svg`),
+  and a **higher** one connects with *"— update the host app for full support"*. Each
+  feature is then gated individually by **`FEATURE_MIN_PROTOCOL`** (`device/poly_kybd.py`)
+  via the pure `protocol_supports(protocol, feature)` + `PolyKybd.supports()/capabilities()`;
+  the GUI (`host.py` `self.supports()`, fed by the `capabilities` dict on `status_changed`/
+  `status.get`) disables the Idle-Style / Glyph-Script submenus a keyboard is too old for,
+  the CLI's `set_*` still returns the device-layer "too old" error, and `polyctl status`
+  lists supported/unsupported features. This replaced the old exact-match gate that greyed
+  out the **whole** menu on any mismatch (which had "been forgotten twice", leaving current
+  keyboards rejected).
+- **Wire-format-divergent commands are ENCODED for the device's protocol, not blocked.**
+  The only core command whose wire format ever changed is the **plain-overlay upload**
+  (P11 packed the modifier+segment into one header byte). `send_overlay_for_keycode`
+  (`device/poly_kybd.py`) branches on `self.protocol_version`:
+  `>= OVERLAY_PACKED_HEADER_MIN_PROTOCOL (11)` sends the packed 4-byte header, below it the
+  pre-v11 5-byte `[id, cmd, keycode, modifier, segment]` form — so overlays work on an older
+  keyboard too. Compressed/ROI headers never changed. For a device **newer** than the host
+  we send our newest-known (packed) form and accept that a *future* breaking change to an
+  existing command is unknown to us (the newer-firmware trade-off — the host still connects).
+  If you add another wire-format-breaking change to an existing command, add a
+  `FEATURE_MIN_PROTOCOL` entry + an encode-branch here; a *new* command just needs a
+  `supports()` gate.
+- **Still bump `__protocol__` (`polyhost/_version.py`) in lockstep with the firmware
+  PROTOCOL_VERSION.** It now defines the host's *newest-known* protocol (the fully-supported
+  "match" and the newest wire format the host emits), **not** a hard connect gate. Rule of
+  thumb unchanged: when you add a firmware-protocol feature threshold (e.g.
+  `IDLE_STYLE_MIN_PROTOCOL`, `GLYPH_SCRIPT_MIN_PROTOCOL`, `OVERLAY_PACKED_HEADER_MIN_PROTOCOL`),
+  the firmware protocol advanced to **N**, so set `__protocol__` to **N** and add the feature
+  to `FEATURE_MIN_PROTOCOL` in the same change. Forgetting it now only downgrades the status
+  to "update the host app" and disables that one feature (the keyboard still connects), rather
+  than rejecting the keyboard outright.
 - **GUI self-update must be applied by the DAEMON, not the client (daemon-by-default).**
   In daemon mode the tray GUI is a `--connect` client and a separate `--headless`
   daemon owns `PolyCore` — and therefore the **protocol gate** (its loaded
@@ -110,8 +146,10 @@ Since the HID-worker refactor (`docs/hid-worker-refactor.md`), the Qt main threa
   → `PolyCore.install_update`), letting the daemon overwrite the files and **re-exec
   itself** (`headless.py` `_on_update_event`). It must **not** run `UpdateInstaller`
   in the GUI process: that refreshed only the client while the daemon kept running the
-  pre-update code, so the daemon stayed on the OLD `__protocol__` and went on rejecting
-  the keyboard with *"Protocol mismatch, please update"* until manually restarted
+  pre-update code, so the daemon stayed on the OLD `__protocol__` and its `FEATURE_MIN_PROTOCOL`
+  table (historically it *rejected* the keyboard with *"Protocol mismatch, please update"*;
+  under the range-connect model it instead keeps the keyboard on the old capability set —
+  newer features disabled, status stuck on "update the host app") until manually restarted
   (field 2026-07). After the daemon re-execs, `PolyHost._on_update_done` (client mode)
   waits for the control endpoint to go **down → back LIVE** (`_await_daemon_restart_then_relaunch`)
   before relaunching the GUI — relaunching immediately would re-attach to the still-up
@@ -320,8 +358,10 @@ Since the HID-worker refactor (`docs/hid-worker-refactor.md`), the Qt main threa
   `__protocol__` bump** — just a new `GlyphScript` value + `GLYPH_SCRIPT_LABELS` entry +
   the shipped font. The `__protocol__` 9→10 bump happened once, to establish that
   open-ended contract (pre-v10 firmware NACKed unknown indices); don't bump it again for
-  more scripts. The exact-match connect gate still pins host↔firmware to the same
-  protocol, within which the script set is free to grow.
+  more scripts. `GLYPH_SCRIPT_MIN_PROTOCOL=9` is a `FEATURE_MIN_PROTOCOL` entry (see the
+  range-connect note above), so the Glyph-Script menu is disabled on a pre-v9 keyboard but
+  the rest of the app still connects; within a glyph-script-capable device the script set is
+  free to grow.
 - **Linux HID permissions**: `polyhost/device/99-hid.rules` must be installed as a udev rule for non-root HID access.
 - **Venv**: always use `PolyKybdHost/.venv/bin/python` — system `python3` lacks numpy, PyQt5, and other runtime deps. 
   - **Note on multiple venvs**: This project shares a workspace with `qmk_firmware/`. The QMK build uses a separate global venv (`~/.qmk_venv`) installed by the session setup script. The two venvs are **completely isolated and do not interfere** — each has its own Python executable and `site-packages`. When you activate `source .venv/bin/activate` in PolyKybdHost, it activates *this* project's venv; QMK commands via the global alias (e.g., `qmk compile`) still use the separate `~/.qmk_venv` and will not conflict with PolyKybdHost's dependencies.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,19 @@ Since the HID-worker refactor (`docs/hid-worker-refactor.md`), the Qt main threa
   lists supported/unsupported features. This replaced the old exact-match gate that greyed
   out the **whole** menu on any mismatch (which had "been forgotten twice", leaving current
   keyboards rejected).
+- **Every new device-facing command MUST be version-gated — no exceptions.** When you add a
+  HID command that the firmware only understands from protocol **N**: add a
+  `FEATURE_MIN_PROTOCOL` entry (`device/poly_kybd.py`); guard the `PolyKybd` setter with
+  `self.supports("<feature>")` (return the "firmware too old" error when unsupported) and the
+  getter likewise; gate the GUI menu in `host.py` `managed_connection_status` via
+  `self.supports(...)`; surface it in `polyctl`; and bump `__protocol__` + the firmware
+  `PROTOCOL_VERSION` to **N** in the same change. If the command *changes an existing
+  command's wire format*, ALSO add an encode-branch on `self.protocol_version` (see the
+  plain-overlay upload below). An **ungated** command silently connects then NACKs at
+  runtime on an older keyboard instead of cleanly disabling — the exact failure the
+  range-connect model exists to prevent, and the kind of gate that "has been forgotten
+  twice". The capability tests in `tests/device/poly_kybd_capabilities_test.py` are the
+  pattern to extend.
 - **Wire-format-divergent commands are ENCODED for the device's protocol, not blocked.**
   The only core command whose wire format ever changed is the **plain-overlay upload**
   (P11 packed the modifier+segment into one header byte). `send_overlay_for_keycode`
@@ -388,6 +401,14 @@ Since the HID-worker refactor (`docs/hid-worker-refactor.md`), the Qt main threa
 - **Venv**: always use `PolyKybdHost/.venv/bin/python` — system `python3` lacks numpy, PyQt5, and other runtime deps. 
   - **Note on multiple venvs**: This project shares a workspace with `qmk_firmware/`. The QMK build uses a separate global venv (`~/.qmk_venv`) installed by the session setup script. The two venvs are **completely isolated and do not interfere** — each has its own Python executable and `site-packages`. When you activate `source .venv/bin/activate` in PolyKybdHost, it activates *this* project's venv; QMK commands via the global alias (e.g., `qmk compile`) still use the separate `~/.qmk_venv` and will not conflict with PolyKybdHost's dependencies.
   - **In a fresh remote/web container the `.venv` does not exist yet** — create it and install the test deps: `python3 -m venv .venv && .venv/bin/pip install numpy pyserial hid platformdirs pyyaml pillow`, plus the hidapi **system** libs `sudo apt-get install -y libhidapi-hidraw0 libhidapi-libusb0` (the `hid` module raises `ImportError: Unable to load any of the following libraries:libhidapi-*` without them). That set is enough to run the device/unit tests (`tests.device.*`); GUI tests additionally need an X server (see below).
+  - **To run the WHOLE suite** (not just `tests.device.*` — do this after any change touching
+    `core/`, `gui/`, or `cli/`) you also need `requests packaging pynput pvlib geocoder PyQt5`
+    (pip) **and** `xvfb x11-xserver-utils` (apt), run under `xvfb-run -a .venv/bin/python -m
+    unittest discover -s ./tests -p "*_test.py"`. Without those deps `services/updater`,
+    `sunlight_helper`, `langcode_flag`, `win_helper_parse`, and the `host_client`
+    GUI-subprocess tests **ERROR and masquerade as failures** — they are missing-dependency
+    env failures, not regressions (confirm by `git stash` + re-running on the pristine tree).
+    A fully green run prints `OK (skipped=N)` with the env-gated tests skipped, not errored.
 - **`hid_reconnect_retries` is clamped to ≥1 in `PolyKybd.connect()`** (`max(1, …)`, `device/poly_kybd.py`): `connect()` runs on every ~1 s reconnect probe, and with the setting at 0 the `range(retries)` GET_ID loop was skipped entirely, so it blindly re-enumerated the HID interface every probe — `Re-enumerating HID after 0 failed attempts…` log spam plus handle churn that can clip in-flight overlay transfers. **Nothing in the codebase writes this key** (grep-verified) — a 0/negative value is a hand-edit or stale config, not a code path; default is 5 (`settings.py`). Don't remove the clamp.
 - **Test discovery**: test files follow `*_test.py` naming under `tests/` mirroring `polyhost/` structure. pytest is disabled in VS Code config; use `unittest`. New test packages require an `__init__.py`.
 - **No *test* CI**: no workflow runs the unit tests. (The repo *does* have two

--- a/polyhost/cli/polyctl.py
+++ b/polyhost/cli/polyctl.py
@@ -131,7 +131,18 @@ def _print_result(result):
 
 def _cmd_status(client, args):
     result = client.call(protocol.M_STATUS_GET)
+    caps = result.pop("capabilities", None) if isinstance(result, dict) else None
     _print_result(result)
+    # Render per-feature support on its own lines rather than as a raw dict. The
+    # host connects across a range of firmware protocols and gates each feature by
+    # its minimum protocol, so this shows exactly which features this keyboard's
+    # firmware is too old (or too new) for.
+    if isinstance(caps, dict) and caps:
+        supported = sorted(f for f, ok in caps.items() if ok)
+        unsupported = sorted(f for f, ok in caps.items() if not ok)
+        print(f"capabilities: {', '.join(supported) or '(none)'}")
+        if unsupported:
+            print(f"unsupported (update firmware): {', '.join(unsupported)}")
     return 0
 
 

--- a/polyhost/cli/polyctl.py
+++ b/polyhost/cli/polyctl.py
@@ -186,6 +186,12 @@ def _cmd_idle_style(client, args):
     return 0
 
 
+def _cmd_newer_policy(client, args):
+    client.call(protocol.M_SET_NEWER_FW_POLICY, {"choice": args.choice})
+    print(f"newer-firmware policy set to {args.choice}")
+    return 0
+
+
 # Derived from the shared GlyphScript enum so new scripts appear automatically.
 _GLYPH_SCRIPT_VALUES = {s.name.lower(): s.value for s in GlyphScript}
 _GLYPH_SCRIPT_NAMES = {v: k for k, v in _GLYPH_SCRIPT_VALUES.items()}
@@ -532,6 +538,13 @@ def build_parser():
         help="omit to print the current script; 'standard' = normal legends, "
              "any other = fantasy/retro override (needs the fantasy font-pack bundle)")
     p_glyph_script.set_defaults(func=_cmd_glyph_script)
+
+    p_newer = sub.add_parser(
+        "newer-policy",
+        help="how to handle a keyboard whose firmware is newer than this host "
+             "(ignore = connect fully, safe = restricted to update+debug)")
+    p_newer.add_argument("choice", choices=["ignore", "safe"])
+    p_newer.set_defaults(func=_cmd_newer_policy)
 
     p_ov = sub.add_parser("overlay", help="overlay control")
     ov_sub = p_ov.add_subparsers(dest="overlay_action", required=True)

--- a/polyhost/client/remote_core.py
+++ b/polyhost/client/remote_core.py
@@ -232,6 +232,11 @@ class RemoteCore:
         return bool(self._get("paused", False))
 
     @property
+    def safe_mode(self):
+        """Newer-firmware restricted mode, cached from the daemon's status."""
+        return bool(self._get("safe_mode", False))
+
+    @property
     def last_applied_connected(self):
         return bool(self._get("connected", False))
 
@@ -326,6 +331,9 @@ class RemoteCore:
 
     def set_idle(self, idle):
         return self._device(p.M_IDLE_SET, {"idle": idle})
+
+    def set_newer_firmware_policy(self, choice):
+        return self._device(p.M_SET_NEWER_FW_POLICY, {"choice": choice})
 
     def set_idle_style(self, value):
         return self._device(p.M_IDLE_STYLE_SET, {"value": value})

--- a/polyhost/core/decisions.py
+++ b/polyhost/core/decisions.py
@@ -30,7 +30,7 @@ def decide_probe_publish(connected_now, last_applied_connected, fail_streak,
 
 
 def decide_reconnect_apply(snapshot, host_protocol, host_version, ignore_version,
-                           min_supported=2):
+                           min_supported=2, newer_fw_policy=None):
     """Pure decision tree for the reconnect compatibility check.
 
     The host connects across a **range** of firmware protocols and gates
@@ -40,12 +40,16 @@ def decide_reconnect_apply(snapshot, host_protocol, host_version, ignore_version
     protocol is at least ``min_supported`` (the floor below which the host can't
     even enumerate languages); an exact match is the fully-supported case, a
     lower protocol connects with a "some features need a firmware update" hint,
-    and a higher protocol connects with an "update the host app" hint (the host
-    then only uses the commands/formats it knows — see the overlay encode-branch).
+    and a higher protocol (newer firmware than the host) is governed by
+    ``newer_fw_policy`` — a session choice the user makes in a dialog:
+    ``"ignore"`` connects fully (host uses the commands/formats it knows — see the
+    overlay encode-branch), ``"safe"`` connects in a restricted **safe mode** (only
+    firmware-update + debugging), and ``None`` (undecided) defaults to safe mode and
+    flags ``newer_fw_pending`` so the UI prompts.
 
     Takes a worker-produced ``snapshot`` dict (no device/UI access) plus the
-    host's expected protocol/version, the ``--ignore-version`` flag, and the
-    ``min_supported`` protocol floor.
+    host's expected protocol/version, the ``--ignore-version`` flag, the
+    ``min_supported`` protocol floor, and the ``newer_fw_policy`` session choice.
 
     Returns a dict describing the UI decision:
         connected (bool)        — final connected state
@@ -53,6 +57,8 @@ def decide_reconnect_apply(snapshot, host_protocol, host_version, ignore_version
         icon (str|None)         — status icon filename, or None to leave as-is
         text (str|None)         — status action text, or None to leave as-is
         do_post_connect (bool)  — run add_supported_lang / resend / etc.
+        safe_mode (bool)        — connected but operationally restricted (newer fw)
+        newer_fw_pending (bool) — newer fw and no policy chosen yet -> prompt
 
     ``snapshot`` keys consumed here:
         version_ok (bool)       — query_version_info result
@@ -75,6 +81,8 @@ def decide_reconnect_apply(snapshot, host_protocol, host_version, ignore_version
         "icon": None,
         "text": None,
         "do_post_connect": False,
+        "safe_mode": False,
+        "newer_fw_pending": False,
     }
     if not connected:
         out["icon"] = "sync_disabled.svg"
@@ -105,9 +113,20 @@ def decide_reconnect_apply(snapshot, host_protocol, host_version, ignore_version
             elif kb_proto < host_protocol:
                 out["icon"] = "sync_problem.svg"
                 out["text"] = base + " — some features need a firmware update"
-            else:  # kb_proto > host_protocol
+            else:  # kb_proto > host_protocol — newer firmware than the host.
                 out["icon"] = "sync_problem.svg"
-                out["text"] = base + " — update the host app for full support"
+                if newer_fw_policy == "ignore":
+                    # User chose to connect fully; the host sends its newest-known
+                    # command formats (see the overlay encode-branch).
+                    out["text"] = base + " — update the host app for full support"
+                else:
+                    # "safe" or undecided (None) -> restricted safe mode. Stays
+                    # connected (so the probe doesn't churn) but compatible=False,
+                    # so no operational post-connect work runs.
+                    compatible = False
+                    out["safe_mode"] = True
+                    out["newer_fw_pending"] = newer_fw_policy is None
+                    out["text"] = base + " — safe mode (update the host app)"
     else:
         expected = host_version
         if kb_version and kb_version.startswith(expected[:3]):
@@ -128,6 +147,10 @@ def decide_reconnect_apply(snapshot, host_protocol, host_version, ignore_version
     if not compatible and ignore_version:
         compatible = True
         connected = True
+        # --ignore-version is an explicit "connect fully" override; it wins over the
+        # newer-firmware safe default too.
+        out["safe_mode"] = False
+        out["newer_fw_pending"] = False
         out["icon"] = "sync_problem.svg"
         ver = kb_version or "?"
         nm = name or "PolyKybd"

--- a/polyhost/core/decisions.py
+++ b/polyhost/core/decisions.py
@@ -29,12 +29,23 @@ def decide_probe_publish(connected_now, last_applied_connected, fail_streak,
     return True, streak
 
 
-def decide_reconnect_apply(snapshot, host_protocol, host_version, ignore_version):
+def decide_reconnect_apply(snapshot, host_protocol, host_version, ignore_version,
+                           min_supported=2):
     """Pure decision tree for the reconnect compatibility check.
 
-    Mirrors the original ``PolyHost.reconnect`` logic byte-for-byte in
-    behaviour. Takes a worker-produced ``snapshot`` dict (no device/UI access)
-    plus the host's expected protocol/version and the ``--ignore-version`` flag.
+    The host connects across a **range** of firmware protocols and gates
+    individual features by their minimum protocol (see
+    ``polyhost.device.poly_kybd.FEATURE_MIN_PROTOCOL``), instead of refusing the
+    whole connection on any protocol mismatch. A device is connected when its
+    protocol is at least ``min_supported`` (the floor below which the host can't
+    even enumerate languages); an exact match is the fully-supported case, a
+    lower protocol connects with a "some features need a firmware update" hint,
+    and a higher protocol connects with an "update the host app" hint (the host
+    then only uses the commands/formats it knows — see the overlay encode-branch).
+
+    Takes a worker-produced ``snapshot`` dict (no device/UI access) plus the
+    host's expected protocol/version, the ``--ignore-version`` flag, and the
+    ``min_supported`` protocol floor.
 
     Returns a dict describing the UI decision:
         connected (bool)        — final connected state
@@ -77,16 +88,26 @@ def decide_reconnect_apply(snapshot, host_protocol, host_version, ignore_version
     compatible = False
 
     if kb_proto is not None:
-        if kb_proto == host_protocol:
-            compatible = True
-            out["icon"] = "sync.svg"
-            out["text"] = f"PolyKybd {name} {hw_version} (FW {kb_version}, P{kb_proto})"
-        else:
+        if kb_proto < min_supported:
+            # Too old for the host to speak to at all (can't enumerate languages).
             out["icon"] = "sync_disabled.svg"
             out["text"] = (
-                f"Protocol mismatch: host P{host_protocol}, firmware P{kb_proto}. "
-                f"Please update.")
+                f"Firmware too old (P{kb_proto}); host needs P{min_supported}+. "
+                f"Please update the keyboard firmware.")
             connected = False
+        else:
+            # Within the supported range -> connect and feature-gate individually.
+            compatible = True
+            base = f"PolyKybd {name} {hw_version} (FW {kb_version}, P{kb_proto})"
+            if kb_proto == host_protocol:
+                out["icon"] = "sync.svg"
+                out["text"] = base
+            elif kb_proto < host_protocol:
+                out["icon"] = "sync_problem.svg"
+                out["text"] = base + " — some features need a firmware update"
+            else:  # kb_proto > host_protocol
+                out["icon"] = "sync_problem.svg"
+                out["text"] = base + " — update the host app for full support"
     else:
         expected = host_version
         if kb_version and kb_version.startswith(expected[:3]):

--- a/polyhost/core/poly_core.py
+++ b/polyhost/core/poly_core.py
@@ -100,6 +100,14 @@ class PolyCore:
         self.connected = False
         self.device_present = False
         self.paused = False
+        # Newer-firmware policy (session-only, like ignore_version): when the
+        # keyboard's protocol is NEWER than this host, the user chooses in a dialog
+        # whether to connect fully ("ignore") or run restricted ("safe"). None =
+        # undecided (defaults to safe + prompts). Remembered for the session, keyed
+        # to the protocol it was chosen for so a re-flash re-asks.
+        self.safe_mode = False
+        self._newer_fw_policy = None
+        self._newer_fw_policy_proto = None
         # Worker-side reconnect bookkeeping. `last_applied_connected` is the
         # host's last APPLIED state: the worker reads it, the applying client
         # writes it (a bool read/write is atomic under the GIL).
@@ -226,6 +234,23 @@ class PolyCore:
             self.worker.suspend()
         else:
             self.worker.resume()
+
+    def set_newer_firmware_policy(self, choice):
+        """Record the session choice for a keyboard whose firmware protocol is
+        NEWER than this host: "ignore" (connect fully) or "safe" (restricted).
+
+        Thread-agnostic (no Qt / no device I/O) — called in-process on the Qt main
+        thread or, in daemon mode, on a control-server thread over RPC. Forces a
+        prompt re-apply by dropping ``last_applied_connected`` so the next ~1 s
+        reconnect probe re-runs the decision tree with the new policy (a bool write,
+        atomic under the GIL; mirrors set_paused)."""
+        if choice not in ("ignore", "safe"):
+            return False, f"Unknown newer-firmware policy: {choice!r}"
+        self._newer_fw_policy = choice
+        self._newer_fw_policy_proto = self.keeb.get_protocol_version()
+        self.last_applied_connected = False
+        self.log.info("Newer-firmware policy set to '%s'.", choice)
+        return True, {"choice": choice}
 
     def start_window_tracking(self, interval_s=UPDATE_CYCLE_MSEC / 1000.0):
         """Run the active-window tick on a core-owned daemon thread.
@@ -385,7 +410,9 @@ class PolyCore:
         handler = self.overlay_handler
         if handler is None:
             return
-        if self.connected:
+        # safe_mode (newer firmware, user chose restricted): connected but no
+        # operational overlay/OS traffic — only firmware-update + debugging.
+        if self.connected and not self.safe_mode:
             data, cmd = handler.handle_active_window(update_cycle_msec, new_window_accept_msec)
             if cmd in (OverlayCommand.DISABLE, OverlayCommand.ENABLE):
                 self.submit_overlay_cmd(cmd)
@@ -641,10 +668,19 @@ class PolyCore:
         }
 
         if snapshot["state_changed"]:
+            # Forget a remembered newer-firmware choice if the device's protocol
+            # changed (e.g. after a firmware flash) so the user is asked again for
+            # the new firmware rather than silently reusing the old decision.
+            if (self._newer_fw_policy_proto is not None
+                    and snapshot.get("kb_proto") != self._newer_fw_policy_proto):
+                self._newer_fw_policy = None
+                self._newer_fw_policy_proto = None
             decision = decide_reconnect_apply(
                 snapshot, __protocol__, __version__, self.ignore_version,
-                min_supported=MIN_SUPPORTED_PROTOCOL)
+                min_supported=MIN_SUPPORTED_PROTOCOL,
+                newer_fw_policy=self._newer_fw_policy)
             applied["decision"] = decision
+            self.safe_mode = decision.get("safe_mode", False)
 
             # Mirror the original warning logs.
             if not snapshot["version_ok"] and self.ignore_version:
@@ -749,9 +785,24 @@ class PolyCore:
             # client can gate feature menus the same way the in-process app does
             # (the steady-state event, unlike status.get, otherwise omits them).
             "protocol": self.keeb.get_protocol_version(),
-            "capabilities": self.keeb.capabilities(),
+            "capabilities": self._reported_capabilities(),
+            # Newer-firmware safe mode + whether the user still needs to be
+            # prompted (drives the client's newer-firmware dialog off the status
+            # seam — no separate event needed, and a late-attaching client sees it).
+            "safe_mode": self.safe_mode,
+            "newer_fw_pending": bool(
+                (applied["decision"] or {}).get("newer_fw_pending")),
         })
         return applied
+
+    def _reported_capabilities(self):
+        """Per-feature capabilities as reported to clients. In safe mode every
+        gated feature reads False so the UI (feature submenus, glyph-reset button,
+        `polyctl status`) disables them with no extra mode-specific code."""
+        caps = self.keeb.capabilities()
+        if self.safe_mode:
+            return {k: False for k in caps}
+        return caps
 
     def _console_periodic(self, cancel):
         """Worker periodic (250 ms): read serial + console; publish."""
@@ -886,7 +937,11 @@ class PolyCore:
             "name": self.keeb.get_name(),
             "fw_version": self.keeb.get_sw_version(),
             "protocol": self.keeb.get_protocol_version(),
-            "capabilities": self.keeb.capabilities(),
+            "capabilities": self._reported_capabilities(),
+            "safe_mode": self.safe_mode,
+            # Undecided newer-firmware state: safe mode with no policy chosen yet.
+            # Lets a late-attaching client (status.get) still raise the dialog.
+            "newer_fw_pending": self.safe_mode and self._newer_fw_policy is None,
             "hw_version": self.keeb.get_hw_version(),
             "current_lang": self.keeb.get_current_lang(),
             "host_version": __version__,

--- a/polyhost/core/poly_core.py
+++ b/polyhost/core/poly_core.py
@@ -30,6 +30,7 @@ from polyhost._version import __version__, __protocol__
 # 'Logger' object has no attribute 'debug_detailed'. log_util is Qt-free.
 import polyhost.util.log_util  # noqa: F401
 from polyhost.core.decisions import decide_probe_publish, decide_reconnect_apply
+from polyhost.device.poly_kybd import MIN_SUPPORTED_PROTOCOL
 from polyhost.device.device_manager import DeviceManager
 from polyhost.device.device_settings import DeviceSettings
 from polyhost.device import hid_fw_up
@@ -641,7 +642,8 @@ class PolyCore:
 
         if snapshot["state_changed"]:
             decision = decide_reconnect_apply(
-                snapshot, __protocol__, __version__, self.ignore_version)
+                snapshot, __protocol__, __version__, self.ignore_version,
+                min_supported=MIN_SUPPORTED_PROTOCOL)
             applied["decision"] = decision
 
             # Mirror the original warning logs.
@@ -690,7 +692,11 @@ class PolyCore:
                 self.refresh_daylight_brightness()
                 # Auto-flash the bundled font pack if the keyboard's is missing
                 # or older (queued on the worker; self-terminating — see below).
-                self._maybe_auto_flash_fontpack()
+                # Gated on the font-pack capability (v6+ reports bundle versions in
+                # GET_ID): older firmware can't tell us what it has, so we must not
+                # blindly mass-flash it now that we connect across protocols.
+                if self.keeb.supports("fontpack"):
+                    self._maybe_auto_flash_fontpack()
 
         # The applying client owns the applied-connection state the worker reads.
         self.last_applied_connected = self.connected
@@ -739,6 +745,11 @@ class PolyCore:
             "text": (applied["decision"] or {}).get("text"),
             "icon": (applied["decision"] or {}).get("icon"),
             "lang": snapshot["lang"],
+            # Carry the device protocol + per-feature capabilities so a --connect
+            # client can gate feature menus the same way the in-process app does
+            # (the steady-state event, unlike status.get, otherwise omits them).
+            "protocol": self.keeb.get_protocol_version(),
+            "capabilities": self.keeb.capabilities(),
         })
         return applied
 
@@ -875,6 +886,7 @@ class PolyCore:
             "name": self.keeb.get_name(),
             "fw_version": self.keeb.get_sw_version(),
             "protocol": self.keeb.get_protocol_version(),
+            "capabilities": self.keeb.capabilities(),
             "hw_version": self.keeb.get_hw_version(),
             "current_lang": self.keeb.get_current_lang(),
             "host_version": __version__,

--- a/polyhost/device/poly_kybd.py
+++ b/polyhost/device/poly_kybd.py
@@ -29,11 +29,55 @@ PACKED_LANG_LIST_MIN_PROTOCOL = 2
 # Minimum firmware PROTOCOL_VERSION for the idle-style get/set command (cmd 28).
 IDLE_STYLE_MIN_PROTOCOL = 4
 
+# Minimum firmware PROTOCOL_VERSION for the SET_BRIGHTNESS flags byte (cmd 13:
+# volatile / host-auto). Older firmware ignores the flags byte. Mirrors
+# poly_core._BRIGHTNESS_FLAGS_PROTOCOL.
+BRIGHTNESS_FLAGS_MIN_PROTOCOL = 5
+
+# Minimum firmware PROTOCOL_VERSION for the per-bundle font-pack version block in
+# the GET_ID reply (cmd 6) — the host reads it to auto-flash stale bundles.
+FONTPACK_MIN_PROTOCOL = 6
+
 # Minimum firmware PROTOCOL_VERSION for the active host-OS get/set command (cmd 29).
 OS_MIN_PROTOCOL = 7
 
 # Minimum firmware PROTOCOL_VERSION for the glyph-script get/set command (cmd 30).
 GLYPH_SCRIPT_MIN_PROTOCOL = 9
+
+# Minimum firmware PROTOCOL_VERSION for the packed plain-overlay header (cmd 0x0A:
+# modifier and segment share one byte, (segment << 4) | modifier). Pre-v11 firmware
+# expects them as two separate header bytes — see send_overlay_for_keycode.
+OVERLAY_PACKED_HEADER_MIN_PROTOCOL = 11
+
+# Feature name -> minimum firmware PROTOCOL_VERSION that supports it. This is the
+# single source of truth for per-feature gating: the host connects across a range
+# of protocols (see polyhost/core/decisions.decide_reconnect_apply) and disables
+# only the individual features the firmware is too old for, instead of blocking the
+# whole connection on a protocol mismatch.
+FEATURE_MIN_PROTOCOL = {
+    "packed_lang_list": PACKED_LANG_LIST_MIN_PROTOCOL,
+    "idle_style": IDLE_STYLE_MIN_PROTOCOL,
+    "brightness_flags": BRIGHTNESS_FLAGS_MIN_PROTOCOL,
+    "fontpack": FONTPACK_MIN_PROTOCOL,
+    "os": OS_MIN_PROTOCOL,
+    "glyph_script": GLYPH_SCRIPT_MIN_PROTOCOL,
+    "overlay_packed_header": OVERLAY_PACKED_HEADER_MIN_PROTOCOL,
+}
+
+# The lowest firmware protocol the host can talk to at all: below this it cannot
+# even enumerate the language list (no ASCII fallback), so connecting is pointless.
+# The connect gate refuses anything lower and tells the user to update the firmware.
+MIN_SUPPORTED_PROTOCOL = PACKED_LANG_LIST_MIN_PROTOCOL
+
+
+def protocol_supports(protocol: int | None, feature: str) -> bool:
+    """Pure feature gate: does a device advertising ``protocol`` support ``feature``?
+
+    ``protocol`` may be ``None`` (very old firmware without a P token) — treated as
+    0, i.e. supports nothing gated here. Shared by :class:`PolyKybd` and the GUI
+    client so the feature/min-protocol table lives in exactly one place.
+    """
+    return (protocol or 0) >= FEATURE_MIN_PROTOCOL[feature]
 
 # Console self-heal (see get_console_output): reopen the console interface after
 # this many consecutive failed reads (~5 s at the 250 ms poll), throttled to at
@@ -237,6 +281,28 @@ class PolyKybd:
         """Return the protocol version reported by the firmware, or None for old firmware."""
         return self.protocol_version
 
+    def supports(self, feature: str) -> bool:
+        """Does the connected firmware's protocol support ``feature``?
+
+        Names come from FEATURE_MIN_PROTOCOL. Lazily populates protocol_version
+        (via query_version_info) when it hasn't been read yet, mirroring the
+        per-feature _X_supported helpers below.
+        """
+        if self.protocol_version is None:
+            self.query_version_info()
+        return protocol_supports(self.protocol_version, feature)
+
+    def capabilities(self) -> dict:
+        """Map every known feature -> whether the connected firmware supports it.
+
+        Used to gate the GUI/CLI surfaces (and carried in the status payload so a
+        --connect client renders the same gating as the in-process app). Reads the
+        CACHED protocol only — no device I/O — so it is safe to call from the
+        no-I/O status snapshot (get_status); the probe populates protocol_version
+        before this is read on a fresh connect."""
+        return {f: protocol_supports(self.protocol_version, f)
+                for f in FEATURE_MIN_PROTOCOL}
+
     def reset_overlay_mapping(self) -> tuple[bool, Any]:
         self.log.info("Reset Overlay Mapping...")
         return self.hid.send_and_read_validate(compose_cmd(Cmd.OVERLAY_FLAGS_ON, 0x80))
@@ -353,10 +419,7 @@ class PolyKybd:
         return self.hid.send_and_read_validate(compose_cmd(Cmd.IDLE_STATE, 1 if idle else 0))
 
     def _idle_style_supported(self) -> bool:
-        if self.protocol_version is None:
-            self.query_version_info()
-        return (self.protocol_version is not None
-                and self.protocol_version >= IDLE_STYLE_MIN_PROTOCOL)
+        return self.supports("idle_style")
 
     def set_idle_style(self, style: IdleStyle | int) -> tuple[bool, Any]:
         """Select the idle (anti-burn-in) display style (cmd 28, protocol v4+).
@@ -386,10 +449,7 @@ class PolyKybd:
         return False, 0
 
     def _glyph_script_supported(self) -> bool:
-        if self.protocol_version is None:
-            self.query_version_info()
-        return (self.protocol_version is not None
-                and self.protocol_version >= GLYPH_SCRIPT_MIN_PROTOCOL)
+        return self.supports("glyph_script")
 
     def set_glyph_script(self, script: GlyphScript | int) -> tuple[bool, Any]:
         """Select the glyph-script override (cmd 30, protocol v9+).
@@ -421,10 +481,7 @@ class PolyKybd:
         return False, 0
 
     def _os_supported(self) -> bool:
-        if self.protocol_version is None:
-            self.query_version_info()
-        return (self.protocol_version is not None
-                and self.protocol_version >= OS_MIN_PROTOCOL)
+        return self.supports("os")
 
     def set_os(self, os: OsType | int, pin: bool = False) -> tuple[bool, Any]:
         """Set the active host-OS identity (cmd 29, protocol v7+).
@@ -775,13 +832,24 @@ class PolyKybd:
         msg_cnt = 0
         max_msgs = self.device_settings.OVERLAY_PLAIN_DATA_REPORT_COUNT
         for msg_num in range(0, max_msgs):
-            # Protocol 11: modifier (low nibble, 0..8) and segment index (high
-            # nibble, 0..5) share one header byte, so the 4-byte header leaves a
-            # full 60-byte segment fitting the 64-byte report. Pre-v11 sent them
-            # as two separate bytes, which pushed the last data byte past the
-            # report (see the firmware v11 note).
-            cmd = compose_cmd(Cmd.SEND_OVERLAY, keycode,
-                              (msg_num << 4) | modifier.value)
+            # The plain-overlay header is version-dependent (the one core command
+            # whose wire format changed), so we encode it for the DEVICE's protocol
+            # rather than always sending the newest form — this is what lets the
+            # host connect to a keyboard on an older protocol without corrupting
+            # overlays. Protocol 11+: modifier (low nibble, 0..8) and segment index
+            # (high nibble, 0..5) share one header byte, so the 4-byte header leaves
+            # a full 60-byte segment fitting the 64-byte report. Pre-v11: modifier
+            # and segment are two separate header bytes (the last data byte then
+            # overran the report — see the firmware v11 note; reproduced faithfully
+            # here for genuinely old firmware). For a protocol NEWER than we know we
+            # send our newest (packed) form, accepting that a future breaking change
+            # to this command is unknown to us (the newer-firmware trade-off).
+            if (self.protocol_version or 0) >= OVERLAY_PACKED_HEADER_MIN_PROTOCOL:
+                cmd = compose_cmd(Cmd.SEND_OVERLAY, keycode,
+                                  (msg_num << 4) | modifier.value)
+            else:
+                cmd = compose_cmd(Cmd.SEND_OVERLAY, keycode,
+                                  modifier.value, msg_num)
             from_idx = msg_num * self.device_settings.OVERLAY_PLAIN_DATA_BYTES_PER_REPORT
             to_idx = from_idx + self.device_settings.OVERLAY_PLAIN_DATA_BYTES_PER_REPORT
             data = overlay.all_bytes[from_idx:to_idx]

--- a/polyhost/gui/newer_firmware_dialog.py
+++ b/polyhost/gui/newer_firmware_dialog.py
@@ -1,0 +1,94 @@
+"""Dialog shown when the keyboard's firmware protocol is NEWER than this host.
+
+A newer firmware may use command wire-formats this host app doesn't fully
+understand (see the overlay encode-branch), so instead of silently connecting we
+ask the user how to proceed. Three choices, returned as a short string:
+
+  "safe"   — connect but restrict to the stable set (firmware update + debugging);
+             the safe default (also used when the dialog is dismissed).
+  "update" — check for a host-app update that matches the firmware; the caller
+             installs it if found, else falls back to safe mode.
+  "ignore" — connect fully and use the host's newest-known formats anyway.
+
+Qt-only, no device or network access. Must run on the Qt main thread.
+"""
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QHBoxLayout,
+    QLabel,
+    QSizePolicy,
+    QStyle,
+    QVBoxLayout,
+)
+
+# (button label, returned choice). Order = left-to-right; the first entry is the
+# default/focus button. Kept module-level so it can be asserted in tests without a
+# QApplication.
+NEWER_FW_CHOICES = (
+    ("Safe mode", "safe"),
+    ("Check for updates", "update"),
+    ("Connect anyway", "ignore"),
+)
+NEWER_FW_DEFAULT = "safe"
+
+
+def confirm_newer_firmware(host_protocol, device_protocol, name="", fw_version=""):
+    """Ask how to handle a keyboard whose firmware protocol is newer than the host.
+
+    Returns one of ``"safe"`` / ``"update"`` / ``"ignore"`` (``"safe"`` if the
+    dialog is closed without a choice)."""
+    kb = f"PolyKybd {name}".strip()
+    lead = (
+        f"{kb}'s firmware (protocol P{device_protocol}) is newer than this host "
+        f"app (protocol P{host_protocol}).\n\n"
+        "A newer firmware may use commands this version of the app doesn't fully "
+        "understand, so some features could misbehave. How would you like to "
+        "proceed?\n\n"
+        "• Safe mode — connect, but enable only the stable set (firmware "
+        "update and debugging).\n"
+        "• Check for updates — look for a newer host app that matches; if none "
+        "is found, stay in safe mode.\n"
+        "• Connect anyway — use everything and accept the risk."
+    )
+
+    dlg = QDialog(None)
+    dlg.setWindowTitle("Newer keyboard firmware detected")
+    dlg.setWindowFlag(Qt.WindowStaysOnTopHint, True)
+
+    outer = QVBoxLayout(dlg)
+    outer.setContentsMargins(16, 16, 16, 12)
+    outer.setSpacing(10)
+
+    row = QHBoxLayout()
+    row.setSpacing(12)
+    icon_lbl = QLabel()
+    px = dlg.style().standardPixmap(QStyle.SP_MessageBoxWarning)
+    if not px.isNull():
+        icon_lbl.setPixmap(px)
+    icon_lbl.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+    row.addWidget(icon_lbl, 0, Qt.AlignTop)
+    msg = QLabel(lead)
+    msg.setWordWrap(True)
+    msg.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+    row.addWidget(msg, 1)
+    outer.addLayout(row)
+
+    # Three distinct choices via addButton + clickedButton (QDialogButtonBox's
+    # standard Ok/Yes/No set only gives two). ActionRole keeps them left-aligned
+    # and stops Qt from auto-mapping them to accept/reject.
+    btn_box = QDialogButtonBox()
+    buttons = {}
+    for label, choice in NEWER_FW_CHOICES:
+        b = btn_box.addButton(label, QDialogButtonBox.ActionRole)
+        b.clicked.connect(dlg.accept)   # any click closes the modal
+        buttons[b] = choice
+        if choice == NEWER_FW_DEFAULT:
+            b.setDefault(True)
+            b.setFocus()
+    outer.addWidget(btn_box, 0, Qt.AlignRight)
+
+    dlg.exec_()
+    clicked = btn_box.clickedButton()
+    return buttons.get(clicked, NEWER_FW_DEFAULT)

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -220,6 +220,10 @@ class PolyHost(QApplication):
         super().__init__(sys.argv)
         # Wall-clock start, for the About dialog's uptime line.
         self._start_time = time.monotonic()
+        # Per-feature support of the connected firmware (feature -> bool), cached
+        # from the reconnect/status payload so feature submenus can be gated by the
+        # device's protocol, not just by connectivity. See self.supports().
+        self._capabilities = {}
         # Tray-only app: keep it out of the macOS Dock (no-op elsewhere).
         from polyhost.util.macos_ui import hide_dock_icon
         hide_dock_icon()
@@ -708,6 +712,16 @@ class PolyHost(QApplication):
         only needs a present device, not a compatible one."""
         return (self.connected or self.device_present) and not self.paused
 
+    def supports(self, feature):
+        """Whether the connected firmware's protocol supports ``feature``.
+
+        Reads the capabilities cached from the reconnect/status payload
+        (``poly_kybd.FEATURE_MIN_PROTOCOL`` names). Used to gate feature submenus
+        by the device's protocol now that a protocol-mismatched keyboard still
+        connects — a feature its firmware is too old for is hidden/disabled rather
+        than only erroring on click. Works identically in-process and client mode."""
+        return bool(self._capabilities.get(feature))
+
     def managed_connection_status(self):
         enabled = self.connected and not self.paused
         fw_enabled = self._fw_actions_allowed()
@@ -717,6 +731,12 @@ class PolyHost(QApplication):
         # above just disabled its parent action on a mismatch). Both modes.
         self.cmdMenu.update_enabled(enabled, fw_enabled)
         self.firmware_update_action.setEnabled(fw_enabled)
+        # Feature submenus gate on the DEVICE's protocol, not just connectivity:
+        # a protocol-mismatched keyboard now connects, so disable the submenus
+        # whose firmware support is missing instead of letting them error on click
+        # (the blanket loop above already set them to `enabled`).
+        self.idle_style_menu.menuAction().setEnabled(enabled and self.supports("idle_style"))
+        self.glyph_script_menu.menuAction().setEnabled(enabled and self.supports("glyph_script"))
         # Available in both modes (driven via core methods).
         self.layout_editor.setEnabled(True)
         self.settings_dialog.setEnabled(True)
@@ -765,6 +785,9 @@ class PolyHost(QApplication):
         applied = self.core.apply_reconnect(snapshot)
         if applied is None:
             return
+        # Refresh the cached per-feature capabilities from the (now-populated)
+        # device protocol so the feature-submenu gating below reflects this probe.
+        self._capabilities = self.core.keeb.capabilities()
         connected_now = applied["connected_now"]
         response = applied["lang"]
         decision = applied["decision"]
@@ -847,6 +870,14 @@ class PolyHost(QApplication):
         first connected render rather than only on state_changed."""
         if self.paused or not isinstance(payload, dict):
             return
+        # Cache the daemon-reported per-feature capabilities for menu gating; the
+        # daemon carries them on every status_changed (a state-change event may be
+        # missed by a late-attaching client, so fall back to the status snapshot).
+        caps = payload.get("capabilities")
+        if caps is None:
+            caps = self.core.status_snapshot().get("capabilities")
+        if caps is not None:
+            self._capabilities = caps
         connected = bool(payload.get("connected"))
         self.status.setIcon(get_icon(payload.get("icon") or
                                      ("sync.svg" if connected else "sync_disabled.svg")))
@@ -1059,9 +1090,11 @@ class PolyHost(QApplication):
         # Client mode edits the DAEMON's settings over RPC (the local file may
         # be shared when co-located, but the daemon holds the live copy).
         current = self.core.settings_list() if self.client_mode else self.poly_settings.get_all()
-        # Offer the glyph-script reset button when a device is present (works over
-        # RPC in client mode too); it force-restores the normal language legends.
-        reset_cb = self.reset_glyph_script_to_standard if self.device_present else None
+        # Offer the glyph-script reset button when the connected firmware supports
+        # glyph scripts (v9+; works over RPC in client mode too); it force-restores
+        # the normal language legends. Gated on the capability, not mere presence,
+        # so a keyboard too old for cmd 30 doesn't show a button that only errors.
+        reset_cb = self.reset_glyph_script_to_standard if self.supports("glyph_script") else None
         dlg.setup(current, self.debug_mode, reset_glyph_script=reset_cb)
         if dlg.exec_() == QDialog.Accepted:
             updated = dlg.get_updated_settings()

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -224,6 +224,14 @@ class PolyHost(QApplication):
         # from the reconnect/status payload so feature submenus can be gated by the
         # device's protocol, not just by connectivity. See self.supports().
         self._capabilities = {}
+        # Newer-firmware dialog bookkeeping (see _maybe_prompt_newer_firmware):
+        # remember which protocol we've already prompted for so the ~1 s reconnect
+        # probe can't re-raise the modal, and guard against stacking it.
+        self._newer_fw_prompt_open = False
+        self._newer_fw_prompted_proto = None
+        # The Debugging submenu (created only with --debug), kept reachable so it
+        # stays enabled in newer-firmware safe mode. None when debug is off.
+        self._debug_menu = None
         # Tray-only app: keep it out of the macOS Dock (no-op elsewhere).
         from polyhost.util.macos_ui import hide_dock_icon
         hide_dock_icon()
@@ -511,6 +519,7 @@ class PolyHost(QApplication):
 
         if debug_mode > 0:
             debug_menu = self.menu.addMenu(get_icon("info.svg"), "Debugging")
+            self._debug_menu = debug_menu
             self.debug_lang_menu = debug_menu.addMenu(get_icon("language.svg"), "Change System Input Language")
             # Font-pack inspector: offline tool (no device needed), so it's
             # available in both modes — kept behind the debug flag.
@@ -662,6 +671,12 @@ class PolyHost(QApplication):
         self.core.device_present = value
 
     @property
+    def safe_mode(self):
+        """Newer-firmware restricted mode (core is the source of truth; RemoteCore
+        mirrors it from the daemon's status)."""
+        return getattr(self.core, "safe_mode", False)
+
+    @property
     def paused(self):
         return self.core.paused
 
@@ -722,8 +737,41 @@ class PolyHost(QApplication):
         than only erroring on click. Works identically in-process and client mode."""
         return bool(self._capabilities.get(feature))
 
+    def _maybe_prompt_newer_firmware(self, pending, proto, name, fw):
+        """Raise the newer-firmware dialog when the core reports an undecided
+        newer-firmware state (``newer_fw_pending``). Shown once per protocol per
+        session — the guard stops the ~1 s reconnect probe re-raising it, and a
+        different (newly flashed) protocol re-prompts. Driven off the status payload
+        so it works in-process and in --connect client mode alike."""
+        if (not pending or proto is None
+                or self._newer_fw_prompt_open
+                or self._newer_fw_prompted_proto == proto):
+            return
+        self._newer_fw_prompted_proto = proto
+        self._newer_fw_prompt_open = True
+        try:
+            from polyhost.gui.newer_firmware_dialog import confirm_newer_firmware
+            choice = confirm_newer_firmware(__protocol__, proto, name, fw)
+        finally:
+            self._newer_fw_prompt_open = False
+        if choice == "update":
+            # Look for a host-app update that matches the firmware; if none is
+            # found (or the check errors), fall back to safe mode. force=True so a
+            # throttled auto-check doesn't swallow our callbacks.
+            started = self._start_update_check(
+                on_no_update=lambda: self.core.set_newer_firmware_policy("safe"),
+                on_check_error=lambda _msg=None: self.core.set_newer_firmware_policy("safe"),
+                force=True)
+            if not started:
+                self.core.set_newer_firmware_policy("safe")
+        else:
+            # "ignore" -> connect fully; "safe" (or dismissed) -> stay restricted.
+            self.core.set_newer_firmware_policy(choice if choice == "ignore" else "safe")
+
     def managed_connection_status(self):
-        enabled = self.connected and not self.paused
+        # Newer-firmware safe mode: connected but operationally restricted — only
+        # the firmware-update mechanism + debugging stay live, like a mismatch.
+        enabled = self.connected and not self.paused and not self.safe_mode
         fw_enabled = self._fw_actions_allowed()
         for action in self.menu.actions():
             action.setEnabled(enabled)
@@ -737,6 +785,11 @@ class PolyHost(QApplication):
         # (the blanket loop above already set them to `enabled`).
         self.idle_style_menu.menuAction().setEnabled(enabled and self.supports("idle_style"))
         self.glyph_script_menu.menuAction().setEnabled(enabled and self.supports("glyph_script"))
+        # In safe mode the operational menu above is greyed, but debugging stays
+        # available (its offline entries — e.g. the font-pack inspector — work with
+        # no device); firmware update is already re-enabled via fw_enabled below.
+        if self._debug_menu is not None:
+            self._debug_menu.menuAction().setEnabled(self.safe_mode or enabled)
         # Available in both modes (driven via core methods).
         self.layout_editor.setEnabled(True)
         self.settings_dialog.setEnabled(True)
@@ -787,10 +840,18 @@ class PolyHost(QApplication):
             return
         # Refresh the cached per-feature capabilities from the (now-populated)
         # device protocol so the feature-submenu gating below reflects this probe.
-        self._capabilities = self.core.keeb.capabilities()
+        # Use the core's reported view so safe mode masks them to all-False, same
+        # as a --connect client sees.
+        self._capabilities = self.core._reported_capabilities()
         connected_now = applied["connected_now"]
         response = applied["lang"]
         decision = applied["decision"]
+        # Prompt for a newer-firmware choice off the same decision the core made
+        # (mirrors the client path, which reads it from the status payload).
+        if decision is not None:
+            self._maybe_prompt_newer_firmware(
+                decision.get("newer_fw_pending"), snapshot.get("kb_proto"),
+                snapshot.get("name") or "", snapshot.get("kb_version") or "")
 
         if decision is not None:
             if decision["icon"] is not None:
@@ -894,6 +955,15 @@ class PolyHost(QApplication):
 
         self.managed_connection_status()
         self.icon_manager.update()
+
+        # Newer-firmware prompt: the daemon flags an undecided newer-firmware
+        # state in the status; the snapshot backfills fields a steady-state event
+        # omits (and covers a late-attaching client).
+        snap = self.core.status_snapshot()
+        self._maybe_prompt_newer_firmware(
+            payload.get("newer_fw_pending", snap.get("newer_fw_pending")),
+            payload.get("protocol", snap.get("protocol")),
+            snap.get("name") or "", snap.get("fw_version") or "")
 
         if connected and lang and self.current_lang != lang:
             self.icon_manager.set_thinking()

--- a/polyhost/server/control_server.py
+++ b/polyhost/server/control_server.py
@@ -329,6 +329,8 @@ class ControlServer:
             p.M_DOOM_INSTALL: lambda conn, params: _unwrap(c.install_doomwad(params["path"])),
             p.M_DOOM_INSTALL_PACK: lambda conn, params: _unwrap(c.install_doompack(params["path"])),
             p.M_PAUSE_SET: self._cmd_pause_set,
+            p.M_SET_NEWER_FW_POLICY: lambda conn, params: _unwrap(
+                c.set_newer_firmware_policy(params["choice"])),
             p.M_MRU_SAVE: self._cmd_mru_save,
             p.M_SETTINGS_GET: lambda conn, params: c.settings_get(params["key"]),
             p.M_SETTINGS_LIST: lambda conn, params: c.settings_list(),

--- a/polyhost/server/protocol.py
+++ b/polyhost/server/protocol.py
@@ -73,6 +73,7 @@ M_FW_FLASH = "fw.flash"                # {"path": str, "apply": bool} -> {"queue
 M_UPDATE_CHECK = "update.check"        # {} -> {"available": bool, "version": str, "url": str}
 M_UPDATE_INSTALL = "update.install"    # {} -> {"queued": bool, "version": str} (streams update_* events)
 M_PAUSE_SET = "pause.set"              # {"paused": bool} -> {"paused": bool}
+M_SET_NEWER_FW_POLICY = "fw.newer_policy.set"  # {"choice": "ignore"|"safe"} -> {"choice": str}
 M_MRU_SAVE = "mru.save"                # {} -> {"queued": True}
 M_SETTINGS_GET = "settings.get"        # {"key": str} -> value
 M_SETTINGS_LIST = "settings.list"      # {} -> {key: value, ...} (all settings)

--- a/tests/cli/polyctl_test.py
+++ b/tests/cli/polyctl_test.py
@@ -98,6 +98,23 @@ class PolyctlTest(unittest.TestCase):
         self.assertEqual(params, {"lang": "deDE"})
         self.assertIn("language set to deDE", out)
 
+    def test_newer_policy_sends_choice(self):
+        rc, out, err, server = run_main(
+            ["newer-policy", "ignore"],
+            {protocol.M_SET_NEWER_FW_POLICY: {"choice": "ignore"}})
+        self.assertEqual(rc, 0)
+        self.assertEqual(dict(server.received)[protocol.M_SET_NEWER_FW_POLICY],
+                         {"choice": "ignore"})
+        self.assertIn("newer-firmware policy set to ignore", out)
+
+    def test_status_shows_safe_mode_and_capabilities(self):
+        status = {"connected": True, "safe_mode": True, "newer_fw_pending": True,
+                  "capabilities": {"idle_style": False, "glyph_script": False}}
+        rc, out, err, _ = run_main(["status"], {protocol.M_STATUS_GET: status})
+        self.assertEqual(rc, 0)
+        self.assertIn("safe_mode: True", out)
+        self.assertIn("unsupported (update firmware): glyph_script, idle_style", out)
+
     def test_error_response_returns_nonzero_and_prints_message(self):
         rc, out, err, _ = run_main(
             ["lang", "set", "xxYY"],

--- a/tests/core/poly_core_apply_test.py
+++ b/tests/core/poly_core_apply_test.py
@@ -133,14 +133,29 @@ class TestApplyReconnect(unittest.TestCase):
         self.assertTrue(applied["do_overlay_reset"])
         core.keeb.reset_overlays_and_usage.assert_called_once()
 
-    def test_protocol_mismatch_keeps_presence_for_flashing(self):
+    def test_below_floor_protocol_keeps_presence_for_flashing(self):
+        # Firmware BELOW the supported floor is still refused (host can't even
+        # enumerate languages), but presence is kept so it can be flashed.
         core = make_core()
-        applied = core.apply_reconnect(connect_snapshot(kb_proto=__protocol__ + 1))
+        applied = core.apply_reconnect(connect_snapshot(kb_proto=1))
         self.assertFalse(core.connected)
         self.assertTrue(core.device_present)      # GET_ID answered → flashable
         self.assertFalse(applied["decision"]["do_post_connect"])
         self.assertFalse(applied["do_overlay_reset"])
         core.overlay_handler.force_resend.assert_not_called()
+
+    def test_within_range_mismatch_connects_and_runs_post_connect(self):
+        # A protocol mismatch that is at/above the floor (older OR newer than the
+        # host) now CONNECTS and runs the post-connect work; individual features
+        # self-gate by protocol from there.
+        for kb_proto in (__protocol__ - 1, __protocol__ + 1):
+            with self.subTest(kb_proto=kb_proto):
+                core = make_core()
+                applied = core.apply_reconnect(connect_snapshot(kb_proto=kb_proto))
+                self.assertTrue(core.connected)
+                self.assertTrue(core.device_present)
+                self.assertTrue(applied["decision"]["do_post_connect"])
+                core.overlay_handler.force_resend.assert_called_once()
 
     def test_disconnect_clears_state_without_version_queries(self):
         core = make_core(connected=True)

--- a/tests/core/poly_core_apply_test.py
+++ b/tests/core/poly_core_apply_test.py
@@ -25,6 +25,9 @@ def make_core(*, paused=False, connected=False, unicode_mode=False):
     core.connected = connected
     core.device_present = connected
     core.last_applied_connected = connected
+    core.safe_mode = False
+    core._newer_fw_policy = None
+    core._newer_fw_policy_proto = None
     core.kb_sw_version = None
     core.needs_overlay_reset = False
     core._probe_fail_streak = 0
@@ -39,6 +42,9 @@ def make_core(*, paused=False, connected=False, unicode_mode=False):
     core.device_mgr = MagicMock()
     core.overlay_handler = MagicMock()
     core.keeb = MagicMock()
+    # Real dict so _reported_capabilities can mask it to all-False in safe mode.
+    core.keeb.capabilities.return_value = {
+        "idle_style": True, "glyph_script": True, "os": True}
     # apply_reconnect re-asserts the host brightness mode on connect via
     # refresh_daylight_brightness(), which reads core.sunlight (set in the real
     # __init__ this bare core skips).
@@ -144,18 +150,56 @@ class TestApplyReconnect(unittest.TestCase):
         self.assertFalse(applied["do_overlay_reset"])
         core.overlay_handler.force_resend.assert_not_called()
 
-    def test_within_range_mismatch_connects_and_runs_post_connect(self):
-        # A protocol mismatch that is at/above the floor (older OR newer than the
-        # host) now CONNECTS and runs the post-connect work; individual features
-        # self-gate by protocol from there.
-        for kb_proto in (__protocol__ - 1, __protocol__ + 1):
-            with self.subTest(kb_proto=kb_proto):
-                core = make_core()
-                applied = core.apply_reconnect(connect_snapshot(kb_proto=kb_proto))
-                self.assertTrue(core.connected)
-                self.assertTrue(core.device_present)
-                self.assertTrue(applied["decision"]["do_post_connect"])
-                core.overlay_handler.force_resend.assert_called_once()
+    def test_older_within_range_connects_and_runs_post_connect(self):
+        # An OLDER (but at/above the floor) protocol connects and runs the
+        # post-connect work; individual features self-gate by protocol.
+        core = make_core()
+        applied = core.apply_reconnect(connect_snapshot(kb_proto=__protocol__ - 1))
+        self.assertTrue(core.connected)
+        self.assertTrue(applied["decision"]["do_post_connect"])
+        self.assertFalse(core.safe_mode)
+        core.overlay_handler.force_resend.assert_called_once()
+
+    def test_newer_undecided_enters_safe_mode_and_flags_pending(self):
+        # NEWER firmware, no policy chosen: connected but restricted safe mode,
+        # no post-connect, and the status flags newer_fw_pending for the dialog.
+        core = make_core()
+        events = []
+        core.subscribe(lambda n, p: events.append((n, p)))
+        applied = core.apply_reconnect(connect_snapshot(kb_proto=__protocol__ + 1))
+        self.assertTrue(core.connected)
+        self.assertTrue(core.safe_mode)
+        self.assertFalse(applied["decision"]["do_post_connect"])
+        core.overlay_handler.force_resend.assert_not_called()
+        st = events[-1][1]
+        self.assertTrue(st["safe_mode"])
+        self.assertTrue(st["newer_fw_pending"])
+        # Capabilities are reported all-False in safe mode.
+        self.assertTrue(all(v is False for v in st["capabilities"].values()))
+
+    def test_newer_ignore_policy_connects_fully(self):
+        core = make_core()
+        core.keeb.get_protocol_version.return_value = __protocol__ + 1
+        ok, _ = core.set_newer_firmware_policy("ignore")
+        self.assertTrue(ok)
+        self.assertFalse(core.last_applied_connected)  # forced re-apply
+        applied = core.apply_reconnect(connect_snapshot(kb_proto=__protocol__ + 1))
+        self.assertTrue(core.connected)
+        self.assertFalse(core.safe_mode)
+        self.assertTrue(applied["decision"]["do_post_connect"])
+        core.overlay_handler.force_resend.assert_called_once()
+
+    def test_policy_reset_when_protocol_changes(self):
+        # A remembered choice for one protocol is forgotten if the device reports a
+        # different protocol (e.g. after a firmware flash) -> prompt again.
+        core = make_core()
+        core.keeb.get_protocol_version.return_value = __protocol__ + 1
+        core.set_newer_firmware_policy("ignore")
+        # Device now reports a different (still newer) protocol.
+        applied = core.apply_reconnect(connect_snapshot(kb_proto=__protocol__ + 2))
+        self.assertIsNone(core._newer_fw_policy)
+        self.assertTrue(core.safe_mode)
+        self.assertTrue(applied["decision"]["newer_fw_pending"])
 
     def test_disconnect_clears_state_without_version_queries(self):
         core = make_core(connected=True)

--- a/tests/core/poly_core_overlay_test.py
+++ b/tests/core/poly_core_overlay_test.py
@@ -18,6 +18,7 @@ def make_core(*, connected=True, handler=True, run_when_disconnected=False):
     core = PolyCore.__new__(PolyCore)
     core.log = logging.getLogger("test.polycore.overlay")
     core.connected = connected
+    core.safe_mode = False
     core._observers = []
     core._observers_lock = threading.Lock()
     core.worker = MagicMock()
@@ -83,6 +84,13 @@ class TestTickWindowTracking(unittest.TestCase):
 
     def test_disconnected_skips_query_unless_dev_flag(self):
         core = make_core(connected=False, run_when_disconnected=False)
+        core.tick_window_tracking()
+        core.overlay_handler.handle_active_window.assert_not_called()
+
+    def test_safe_mode_skips_overlay_tracking(self):
+        # Newer-firmware safe mode: connected but no operational overlay/OS traffic.
+        core = make_core(connected=True)
+        core.safe_mode = True
         core.tick_window_tracking()
         core.overlay_handler.handle_active_window.assert_not_called()
 

--- a/tests/device/poly_kybd_capabilities_test.py
+++ b/tests/device/poly_kybd_capabilities_test.py
@@ -1,0 +1,128 @@
+"""Unit tests for the per-feature protocol capability model and the
+version-dependent plain-overlay header encoding.
+
+The host connects across a RANGE of firmware protocols (see
+polyhost.core.decisions.decide_reconnect_apply) and gates each feature by its
+minimum protocol via FEATURE_MIN_PROTOCOL. Additive features simply enable when
+supported; the plain-overlay upload (the one core command whose wire format
+changed at protocol 11) must instead be *encoded for the device's protocol* so
+an older keyboard still receives the header it understands.
+"""
+import unittest
+from unittest.mock import MagicMock
+
+from polyhost.device.poly_kybd import (
+    PolyKybd, protocol_supports, FEATURE_MIN_PROTOCOL, MIN_SUPPORTED_PROTOCOL,
+    OVERLAY_PACKED_HEADER_MIN_PROTOCOL,
+)
+from polyhost.device.device_settings import DeviceSettings
+from polyhost.device.command_ids import HidId, Cmd
+from polyhost.device.keys import Modifier
+from polyhost.settings import PolySettings
+
+
+class _Overlay:
+    """Minimal stand-in for the object send_overlay_for_keycode consumes."""
+    def __init__(self, all_bytes):
+        self.all_bytes = all_bytes
+
+
+class TestProtocolSupports(unittest.TestCase):
+    def test_min_supported_is_the_packed_lang_list_floor(self):
+        self.assertEqual(MIN_SUPPORTED_PROTOCOL, FEATURE_MIN_PROTOCOL["packed_lang_list"])
+
+    def test_none_protocol_supports_nothing_gated(self):
+        for feature in FEATURE_MIN_PROTOCOL:
+            self.assertFalse(protocol_supports(None, feature))
+
+    def test_threshold_is_inclusive(self):
+        for feature, minp in FEATURE_MIN_PROTOCOL.items():
+            self.assertTrue(protocol_supports(minp, feature), feature)
+            self.assertFalse(protocol_supports(minp - 1, feature), feature)
+
+    def test_high_protocol_supports_everything(self):
+        highest = max(FEATURE_MIN_PROTOCOL.values())
+        for feature in FEATURE_MIN_PROTOCOL:
+            self.assertTrue(protocol_supports(highest, feature))
+
+
+class TestCapabilities(unittest.TestCase):
+    def _keeb(self, protocol):
+        keeb = PolyKybd(DeviceSettings(), PolySettings())
+        keeb.protocol_version = protocol
+        keeb.hid = MagicMock()
+        return keeb
+
+    def test_supports_matches_table(self):
+        keeb = self._keeb(9)  # glyph_script threshold
+        self.assertTrue(keeb.supports("glyph_script"))
+        self.assertTrue(keeb.supports("os"))          # 7 <= 9
+        self.assertFalse(keeb.supports("overlay_packed_header"))  # 11 > 9
+
+    def test_capabilities_is_cached_only_no_io(self):
+        keeb = self._keeb(4)
+        caps = keeb.capabilities()
+        # No device query was triggered (protocol was already known).
+        keeb.hid.send_and_read_validate.assert_not_called()
+        self.assertEqual(set(caps), set(FEATURE_MIN_PROTOCOL))
+        self.assertTrue(caps["idle_style"])      # 4 <= 4
+        self.assertFalse(caps["os"])             # 7 > 4
+
+    def test_supports_lazily_queries_when_protocol_unknown(self):
+        keeb = self._keeb(None)
+        # query_version_info populates protocol_version from a GET_ID reply.
+        keeb.query_version_info = MagicMock(
+            side_effect=lambda: setattr(keeb, "protocol_version", 11) or (True, "x"))
+        self.assertTrue(keeb.supports("overlay_packed_header"))
+        keeb.query_version_info.assert_called_once()
+
+
+class TestOverlayHeaderEncoding(unittest.TestCase):
+    """The plain-overlay header must match the DEVICE's protocol.
+
+    Protocol 11+: [id, cmd, keycode, (segment<<4)|modifier] + 60 data = 64 bytes.
+    Pre-v11:      [id, cmd, keycode, modifier, segment]      + 60 data = 65 bytes.
+    """
+    KEYCODE = 0x04
+    MOD = Modifier.SHIFT
+
+    def _capture(self, protocol):
+        keeb = PolyKybd(DeviceSettings(), PolySettings())
+        keeb.protocol_version = protocol
+        keeb.hid = MagicMock()
+        keeb.hid.send_multiple.return_value = (True, b"")
+        # 360 non-zero bytes so no segment is skipped as empty -> all 6 sent.
+        data = bytes(((i % 250) + 1) for i in range(360))
+        mapping = {self.KEYCODE: _Overlay(data)}
+        sent = keeb.send_overlay_for_keycode(self.KEYCODE, self.MOD, mapping)
+        self.assertEqual(sent, keeb.device_settings.OVERLAY_PLAIN_DATA_REPORT_COUNT)
+        return [c.args[0] for c in keeb.hid.send_multiple.call_args_list]
+
+    def test_packed_header_at_protocol_11(self):
+        reports = self._capture(OVERLAY_PACKED_HEADER_MIN_PROTOCOL)
+        for msg_num, rep in enumerate(reports):
+            self.assertEqual(rep[0], HidId.ID_POLYKYBD.value)
+            self.assertEqual(rep[1], Cmd.SEND_OVERLAY.value)
+            self.assertEqual(rep[2], self.KEYCODE)
+            # One packed header byte: (segment << 4) | modifier.
+            self.assertEqual(rep[3], (msg_num << 4) | self.MOD.value)
+            self.assertEqual(len(rep), 64)  # 4-byte header + 60 data
+
+    def test_separate_header_pre_protocol_11(self):
+        reports = self._capture(OVERLAY_PACKED_HEADER_MIN_PROTOCOL - 1)
+        for msg_num, rep in enumerate(reports):
+            self.assertEqual(rep[2], self.KEYCODE)
+            # Two separate header bytes: modifier, then segment index.
+            self.assertEqual(rep[3], self.MOD.value)
+            self.assertEqual(rep[4], msg_num)
+            self.assertEqual(len(rep), 65)  # 5-byte header + 60 data (pre-v11 form)
+
+    def test_unknown_protocol_uses_pre_v11_form(self):
+        # protocol_version None (pre-protocol firmware) -> the pre-v11 header.
+        reports = self._capture(None)
+        self.assertEqual(reports[0][3], self.MOD.value)
+        self.assertEqual(reports[0][4], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/device/poly_kybd_cmd_test.py
+++ b/tests/device/poly_kybd_cmd_test.py
@@ -20,6 +20,7 @@ from polyhost.device.keys import KeyCode, Modifier
 from polyhost.device.overlay_cache import OverlayMRUCache
 from polyhost.device.overlay_data import OverlayData
 from polyhost.device.poly_kybd import PolyKybd
+from polyhost._version import __protocol__
 from polyhost.input.unicode_input import InputMethod
 
 from tests.device.fake_hid import FakeHidDevice, make_hid_helper, pad, ack, nack
@@ -46,6 +47,10 @@ def make_keeb(replies=None, auto_ack=False, settings=None):
     keeb = PolyKybd(DeviceSettings(), settings or StubPolySettings())
     device = FakeHidDevice(replies=replies, auto_ack=auto_ack)
     keeb.hid = make_hid_helper(device)
+    # Represent a current-firmware device so protocol-gated paths (e.g. the v11
+    # packed plain-overlay header) take their modern branch. Version-parse tests
+    # call query_version_info(), which overwrites this from the GET_ID reply.
+    keeb.protocol_version = __protocol__
     return keeb, device
 
 

--- a/tests/gui/newer_firmware_dialog_test.py
+++ b/tests/gui/newer_firmware_dialog_test.py
@@ -1,0 +1,31 @@
+"""Tests for the newer-firmware dialog's choice contract.
+
+The dialog itself needs a QApplication/display (covered by the host smoke tests
+under xvfb); here we pin the pure choice metadata that both the dialog and the
+tests rely on — the three offered choices and the safe default — so a rename can't
+silently break the host wiring that matches on these strings.
+"""
+import unittest
+
+from polyhost.gui.newer_firmware_dialog import NEWER_FW_CHOICES, NEWER_FW_DEFAULT
+
+
+class NewerFirmwareChoicesTest(unittest.TestCase):
+    def test_offers_exactly_the_three_expected_choices(self):
+        choices = [c for _label, c in NEWER_FW_CHOICES]
+        self.assertEqual(set(choices), {"safe", "update", "ignore"})
+        # No duplicates, and every entry has a non-empty label.
+        self.assertEqual(len(choices), len(set(choices)))
+        self.assertTrue(all(label.strip() for label, _c in NEWER_FW_CHOICES))
+
+    def test_default_is_safe_and_is_an_offered_choice(self):
+        self.assertEqual(NEWER_FW_DEFAULT, "safe")
+        self.assertIn(NEWER_FW_DEFAULT, [c for _l, c in NEWER_FW_CHOICES])
+
+    def test_safe_is_the_first_button(self):
+        # host.py relies on safe being the default/focus button; keep it first.
+        self.assertEqual(NEWER_FW_CHOICES[0][1], "safe")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/gui/worker_bridge_test.py
+++ b/tests/gui/worker_bridge_test.py
@@ -5,7 +5,9 @@ it can be exercised without a QApplication.
 """
 import unittest
 
-from polyhost.gui.worker_bridge import decide_reconnect_apply, decide_probe_publish
+# Import the Qt-free decision logic from its canonical home so these pure-logic
+# tests run without PyQt5 (worker_bridge re-exports them for compatibility).
+from polyhost.core.decisions import decide_reconnect_apply, decide_probe_publish
 
 HOST_PROTO = 7
 HOST_VERSION = "1.2.3"
@@ -34,17 +36,43 @@ class DecideReconnectApplyTest(unittest.TestCase):
         self.assertIn("FW 1.2.3", d["text"])
         self.assertIn("P7", d["text"])
 
-    def test_protocol_mismatch_disconnects(self):
+    def test_older_protocol_connects_with_update_hint(self):
+        # A firmware older than the host (but at/above the floor) now CONNECTS and
+        # feature-gates individually, instead of being rejected outright.
         d = decide_reconnect_apply(_snap(kb_proto=6), HOST_PROTO, HOST_VERSION, False)
+        self.assertTrue(d["connected"])
+        self.assertTrue(d["compatible"])
+        self.assertTrue(d["do_post_connect"])
+        self.assertEqual(d["icon"], "sync_problem.svg")
+        self.assertIn("P6", d["text"])
+        self.assertIn("some features need a firmware update", d["text"])
+
+    def test_newer_protocol_connects_with_host_update_hint(self):
+        # A firmware NEWER than the host also connects (the host uses the
+        # commands/formats it knows); we just hint the user to update the app.
+        d = decide_reconnect_apply(_snap(kb_proto=9), HOST_PROTO, HOST_VERSION, False)
+        self.assertTrue(d["connected"])
+        self.assertTrue(d["compatible"])
+        self.assertTrue(d["do_post_connect"])
+        self.assertEqual(d["icon"], "sync_problem.svg")
+        self.assertIn("P9", d["text"])
+        self.assertIn("update the host app", d["text"])
+
+    def test_below_floor_refuses(self):
+        # Below the minimum supported protocol the host cannot even enumerate
+        # languages, so it refuses and tells the user to update the firmware.
+        d = decide_reconnect_apply(_snap(kb_proto=1), HOST_PROTO, HOST_VERSION, False,
+                                   min_supported=2)
         self.assertFalse(d["connected"])
         self.assertFalse(d["compatible"])
         self.assertEqual(d["icon"], "sync_disabled.svg")
-        self.assertIn("Protocol mismatch", d["text"])
-        self.assertIn("host P7", d["text"])
-        self.assertIn("firmware P6", d["text"])
+        self.assertIn("too old", d["text"])
+        self.assertIn("P1", d["text"])
 
-    def test_protocol_mismatch_bypassed_by_ignore_version(self):
-        d = decide_reconnect_apply(_snap(kb_proto=6), HOST_PROTO, HOST_VERSION, True)
+    def test_below_floor_bypassed_by_ignore_version(self):
+        # --ignore-version still forces a connect even below the floor.
+        d = decide_reconnect_apply(_snap(kb_proto=1), HOST_PROTO, HOST_VERSION, True,
+                                   min_supported=2)
         self.assertTrue(d["connected"])
         self.assertTrue(d["compatible"])
         self.assertEqual(d["icon"], "sync_problem.svg")

--- a/tests/gui/worker_bridge_test.py
+++ b/tests/gui/worker_bridge_test.py
@@ -47,16 +47,43 @@ class DecideReconnectApplyTest(unittest.TestCase):
         self.assertIn("P6", d["text"])
         self.assertIn("some features need a firmware update", d["text"])
 
-    def test_newer_protocol_connects_with_host_update_hint(self):
-        # A firmware NEWER than the host also connects (the host uses the
-        # commands/formats it knows); we just hint the user to update the app.
+    def test_newer_protocol_undecided_defaults_to_safe_and_prompts(self):
+        # A firmware NEWER than the host, no policy chosen yet: connect but in
+        # restricted safe mode, and flag that the UI should prompt.
         d = decide_reconnect_apply(_snap(kb_proto=9), HOST_PROTO, HOST_VERSION, False)
+        self.assertTrue(d["connected"])          # stays connected (no churn)
+        self.assertFalse(d["compatible"])        # but no operational post-connect
+        self.assertFalse(d["do_post_connect"])
+        self.assertTrue(d["safe_mode"])
+        self.assertTrue(d["newer_fw_pending"])
+        self.assertEqual(d["icon"], "sync_problem.svg")
+        self.assertIn("safe mode", d["text"])
+
+    def test_newer_protocol_safe_policy_restricts_without_prompt(self):
+        d = decide_reconnect_apply(_snap(kb_proto=9), HOST_PROTO, HOST_VERSION, False,
+                                   newer_fw_policy="safe")
+        self.assertTrue(d["connected"])
+        self.assertFalse(d["compatible"])
+        self.assertTrue(d["safe_mode"])
+        self.assertFalse(d["newer_fw_pending"])  # decided -> no prompt
+
+    def test_newer_protocol_ignore_policy_connects_fully(self):
+        d = decide_reconnect_apply(_snap(kb_proto=9), HOST_PROTO, HOST_VERSION, False,
+                                   newer_fw_policy="ignore")
         self.assertTrue(d["connected"])
         self.assertTrue(d["compatible"])
         self.assertTrue(d["do_post_connect"])
-        self.assertEqual(d["icon"], "sync_problem.svg")
-        self.assertIn("P9", d["text"])
+        self.assertFalse(d["safe_mode"])
+        self.assertFalse(d["newer_fw_pending"])
         self.assertIn("update the host app", d["text"])
+
+    def test_newer_protocol_ignore_version_overrides_safe_default(self):
+        # --ignore-version means "connect fully" and wins over the safe default.
+        d = decide_reconnect_apply(_snap(kb_proto=9), HOST_PROTO, HOST_VERSION, True)
+        self.assertTrue(d["connected"])
+        self.assertTrue(d["compatible"])
+        self.assertFalse(d["safe_mode"])
+        self.assertFalse(d["newer_fw_pending"])
 
     def test_below_floor_refuses(self):
         # Below the minimum supported protocol the host cannot even enumerate


### PR DESCRIPTION
## Summary

Replaces the exact-match reconnect gate with a **range-connect + per-feature** model. Instead of refusing to connect (and greying out the whole menu) on *any* firmware protocol mismatch, the host now connects to any keyboard within a supported protocol window and disables only the individual features the firmware is too old — or too new — for.

The design hinges on distinguishing two kinds of version difference:

- **Additive features** (idle-style P4, brightness P5, font pack P6, OS P7, glyph-script P9) — new commands older firmware just NACKs. Gated individually via `FEATURE_MIN_PROTOCOL` + `PolyKybd.supports()/capabilities()`.
- **Wire-format-breaking change to an *existing* command** — the P11 plain-overlay header repack is the only one. `send_overlay_for_keycode` encodes the header for the device's protocol (packed 4-byte ≥ 11, pre-v11 5-byte below), so overlays work on an older keyboard instead of being corrupted.

The connect gate (`core/decisions.py`) refuses below `MIN_SUPPORTED_PROTOCOL` (the packed-lang-list floor, 2), else connects: `== host` fully supported (`sync.svg`), a lower protocol with *"— some features need a firmware update"*, and a higher (newer) protocol via the dialog below. Protocol + capabilities are carried on `status_changed` / `status.get` so both the in-process app and a `--connect` client gate the menus identically.

## Newer-firmware dialog (2nd commit)

A newer-than-host firmware may use command formats this app doesn't fully understand, so rather than silently trusting it the host now **prompts** (session policy, default safe; works in-process and in daemon/`--connect` mode):

- **Safe mode** (default / on dismiss) — connect but restrict to the stable set: firmware-update + Debugging. Overlays, language, glyph-script, idle-style, etc. are disabled. Represented as `connected=True` + a `safe_mode` flag (so the reconnect probe doesn't churn); `tick_window_tracking` skips operational traffic and capabilities are reported all-False.
- **Check for updates** — run the host-app update check (`force=True`); install if a matching release is found (restart resolves the mismatch), else fall back to safe mode.
- **Connect anyway** — full connect, host's newest-known formats.

The choice is a session-only core policy (`set_newer_firmware_policy` → `M_SET_NEWER_FW_POLICY`, RemoteCore mirror; re-asks when the protocol changes, e.g. after a flash), driven off the status seam (`newer_fw_pending`) in both render paths — once per protocol per session. `--ignore-version` still forces a full connect. Headless daemons default to safe; `polyctl newer-policy [ignore|safe]` overrides.

## Version bump label

`bump:minor` — new, backwards-compatible feature (no protocol change).

## Testing
- [ ] Tested locally against real hardware
- [x] Tested with mock device (if UI changes)

Full unit suite green under `xvfb` (`OK`, 0 failures) — including the `host_client_test` subprocess smoke tests that construct the real `PolyHost` in both default and `--connect` mode. Coverage added for: the capability model, the v11-vs-pre-v11 overlay header bytes, the decision policy matrix (older/newer/below-floor, ignore/safe/undecided), apply-level safe-mode + `newer_fw_pending` + policy reset + `set_newer_firmware_policy`, `tick_window_tracking` safe-mode skip, the dialog's choice contract, and `polyctl newer-policy`.

⚠️ No real hardware in this environment: the overlay encode-branch is verified by asserting emitted bytes against the recovered pre-v11 form, and the newer-firmware path via the decision/apply/status unit tests — worth a smoke-test on an older-firmware unit before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVXkv6Z6DTmKzGgBq6HM2K

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compatibility across supported firmware protocol versions with feature-level capability detection.
  * Added newer-firmware handling with Safe Mode, update-check, or connect-anyway choices.
  * Added CLI controls for selecting newer-firmware policy and viewing unsupported features.
  * Added protocol-aware overlay handling and capability-based feature availability.

* **Bug Fixes**
  * Prevented unsupported features from running on incompatible firmware.
  * Fixed overlay tracking and automatic font updates in restricted or unsupported scenarios.
  * Improved post-update behavior so newly available features activate correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->