### PR TITLE
tools: centre glyph-script glyphs in the preview (fix Amiga/C64/APL clipping)

### DIFF
--- a/tools/glyph_script_demo.py
+++ b/tools/glyph_script_demo.py
@@ -67,7 +67,15 @@ def script_glyph_image(font, ch: str):
     cp = font.first + idx
     if not (font.first <= cp <= font.last):
         return None
-    return FR.keycap_image(font, cp, scale=1, fg=255, bg=0)
+    # The firmware draws a glyph-script override CENTERED in both axes from the
+    # glyph's pixel bbox (poly_keymap.c render_key), NOT at the fixed y=23 Latin
+    # baseline. The script fonts are ~30 px tall, so a baseline draw pushes a tall
+    # glyph's top above 0 and clips it (Amiga/C64/APL ran ~10 px off the top). Match
+    # the firmware: centre the raw glyph bitmap in the 72x40 window.
+    g = FR.glyph_to_image(font, cp, scale=1, fg=255, bg=0)
+    canvas = Image.new("L", (FR.OLED_W, FR.OLED_H), 0)
+    canvas.paste(g, ((FR.OLED_W - g.width) // 2, (FR.OLED_H - g.height) // 2))
+    return canvas
 
 
 def script_frame(base_frame, matrix_kc, font):


### PR DESCRIPTION
## Summary
Fixes tall glyph-script glyphs being cut off in the `glyph_script_demo.py` preview.

The demo rendered each script glyph via `keycap_image`, which places the glyph at the fixed **y=23 Latin baseline**. But the firmware draws a glyph-script override **centered in both axes from the glyph's pixel bbox** (`poly_keymap.c` `render_key`). The script fonts are ~30 px tall (Amiga/C64 ≈35 px, `yOffset` ≈ −33), so at the baseline the top of a tall glyph lands above 0 and clips off the top of the 40 px display — Amiga/C64/APL ran ~10 px off-screen in the preview even though the keyboard shows them fine.

Fix: center the raw glyph bitmap in the 72×40 window, matching the firmware's bbox-centered draw.

## Version bump label
*(none)* — dev-tooling only → patch bump.

## Testing
- [ ] Tested locally against real hardware
- [ ] Tested with mock device (if UI changes)

Not applicable — offline rendering tool. Verified by regenerating the GIF and confirming the Amiga Topaz and Commodore 64 frames now render every letter/digit fully within each keycap (previously clipped at the top); other scripts and the modifier icons are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FN8FvtwhZ6wSZ21ihrcA72

---
_Generated by [Claude Code](https://claude.ai/code/session_01FN8FvtwhZ6wSZ21ihrcA72)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering of individual letters and digits in the glyph display.
  * Glyphs are now centered consistently within the OLED canvas.
  * Other key and script overlay behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->