### PR TITLE
Use native KDE file dialog on Plasma, Qt dialog elsewhere on Linux

### DIFF
--- a/polyhost/gui/cmd_menu.py
+++ b/polyhost/gui/cmd_menu.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 from contextlib import contextmanager
 
 from PyQt5.QtWidgets import (
@@ -8,6 +7,7 @@ from PyQt5.QtWidgets import (
 
 from polyhost.device.keys import KeyCode, keycode_to_mapping_idx
 from polyhost.device.hid_fw_up import get_fw_version, validate_rp2040_firmware, validate_polykybd_firmware, apply_staged_firmware
+from polyhost.gui import file_dialogs
 from polyhost.gui.get_icon import get_icon
 
 
@@ -31,12 +31,13 @@ def _get_open_file_explicit(caption: str, name_filter: str) -> str:
     Open (never accepts on a single click).  Returns the chosen path, or '' if
     cancelled.
 
-    On Windows and macOS the OS-native picker is used directly.  On Linux the
-    Qt dialog is used instead, with single-click activation disabled — needed
-    because KDE Plasma's default "activate on single click" setting would
-    otherwise accept the dialog the moment the user clicks a file.
+    The native-vs-Qt choice follows the shared per-desktop policy in
+    ``file_dialogs`` (native on Windows/macOS/KDE, Qt's own dialog on other
+    Linux desktops).  Only the non-native Qt widget dialog needs the
+    single-click-activation fix below — the native KDE/portal dialog handles
+    single-click on its own — so it is applied only in that branch.
     """
-    if sys.platform in ('win32', 'darwin'):
+    if file_dialogs.use_native():
         path, _ = QFileDialog.getOpenFileName(None, caption, "", name_filter)
         return path
 

--- a/polyhost/gui/file_dialogs.py
+++ b/polyhost/gui/file_dialogs.py
@@ -37,8 +37,12 @@ def _is_kde():
     return bool(os.environ.get("KDE_FULL_SESSION"))
 
 
-def _use_native():
-    """Whether to let Qt use the OS-native dialog (see module docstring)."""
+def use_native():
+    """Whether to let Qt use the OS-native dialog (see module docstring).
+
+    Public so other pickers (e.g. ``cmd_menu._get_open_file_explicit``) share
+    the exact same per-desktop policy.
+    """
     if sys.platform in ('win32', 'darwin'):
         return True
     return _is_kde()
@@ -46,7 +50,7 @@ def _use_native():
 
 def _dialog_options():
     """No native flag when native is wanted; DontUseNativeDialog otherwise."""
-    if _use_native():
+    if use_native():
         return QFileDialog.Options()
     return QFileDialog.DontUseNativeDialog
 

--- a/polyhost/gui/file_dialogs.py
+++ b/polyhost/gui/file_dialogs.py
@@ -1,40 +1,67 @@
-"""Shared file-dialog helpers that force the Qt (non-native) picker on Linux.
+"""Shared file-dialog helpers that pick the best picker per platform.
 
-Qt's ``QFileDialog`` static helpers use the OS-native picker by default. On
-Linux that means the GTK / KDE / xdg-desktop-portal dialog, whose look and
-behaviour drift from the rest of this PyQt5 app (and which can misbehave under
-some portals). We want the Qt dialog on Linux everywhere; Windows and macOS
-keep their native picker, which is the expected platform look there.
+Qt's ``QFileDialog`` static helpers use the OS-native picker by default, but
+on Linux "native" is not one dialog — it is whatever the Qt platform-theme
+plugin provides, and its quality varies by desktop:
+
+- **Windows / macOS** — native, the expected platform look.
+- **Linux KDE / Plasma** — native, which (with ``plasma-integration``) is the
+  modern KFileWidget / xdg-desktop-portal dialog: places panel, previews, and
+  it respects the user's KDE settings. Much nicer than Qt's built-in dialog.
+  If ``plasma-integration`` is absent Qt falls back to its own widget dialog
+  anyway, so requesting native here is safe.
+- **Other Linux (GNOME, …)** — NOT native: there "native" is the GTK dialog,
+  which looks foreign in this PyQt5 app. Use Qt's own widget dialog instead
+  for a consistent look.
 
 Route every open/save picker through these wrappers instead of calling
 ``QFileDialog.getOpenFileName`` / ``getSaveFileName`` directly. They call the
 same static methods (so unit tests that patch ``QFileDialog.getOpenFileName``
-still work), only adding the ``DontUseNativeDialog`` option on Linux.
+still work), only toggling the ``DontUseNativeDialog`` option per the policy
+above.
 
-``cmd_menu._get_open_file_explicit`` is a richer variant (it also defeats
-KDE's single-click-to-accept); it likewise forces the Qt dialog on Linux.
+``cmd_menu._get_open_file_explicit`` is a richer variant that always forces the
+Qt dialog (and defeats KDE's single-click-to-accept); it predates this module.
 """
+import os
 import sys
 
 from PyQt5.QtWidgets import QFileDialog
 
 
-def _linux_qt_options():
-    """DontUseNativeDialog on Linux (force the Qt picker); no-op elsewhere."""
+def _is_kde():
+    """True on a KDE/Plasma session (matches the window-reporter backend check)."""
+    for var in ("XDG_CURRENT_DESKTOP", "XDG_SESSION_DESKTOP"):
+        if "kde" in os.environ.get(var, "").lower():
+            return True
+    return bool(os.environ.get("KDE_FULL_SESSION"))
+
+
+def _use_native():
+    """Whether to let Qt use the OS-native dialog (see module docstring)."""
     if sys.platform in ('win32', 'darwin'):
+        return True
+    return _is_kde()
+
+
+def _dialog_options():
+    """No native flag when native is wanted; DontUseNativeDialog otherwise."""
+    if _use_native():
         return QFileDialog.Options()
     return QFileDialog.DontUseNativeDialog
 
 
 def get_open_file_name(parent, caption, directory="", name_filter=""):
-    """Drop-in for ``QFileDialog.getOpenFileName`` that uses the Qt dialog on
-    Linux. Returns the ``(path, selected_filter)`` tuple, same as Qt."""
+    """Drop-in for ``QFileDialog.getOpenFileName`` that uses the native dialog on
+    Windows/macOS/KDE and the Qt dialog elsewhere. Returns the
+    ``(path, selected_filter)`` tuple, same as Qt."""
     return QFileDialog.getOpenFileName(
-        parent, caption, directory, name_filter, options=_linux_qt_options())
+        parent, caption, directory, name_filter, options=_dialog_options())
 
 
 def get_save_file_name(parent, caption, directory="", name_filter=""):
-    """Drop-in for ``QFileDialog.getSaveFileName`` that uses the Qt dialog on
-    Linux. Returns the ``(path, selected_filter)`` tuple, same as Qt."""
+    """Drop-in for ``QFileDialog.getSaveFileName`` that uses the native dialog on
+    Windows/macOS/KDE and the Qt dialog elsewhere. Returns the
+    ``(path, selected_filter)`` tuple, same as Qt."""
     return QFileDialog.getSaveFileName(
-        parent, caption, directory, name_filter, options=_linux_qt_options())
+        parent, caption, directory, name_filter, options=_dialog_options())

--- a/polyhost/gui/file_dialogs.py
+++ b/polyhost/gui/file_dialogs.py
@@ -1,0 +1,40 @@
+"""Shared file-dialog helpers that force the Qt (non-native) picker on Linux.
+
+Qt's ``QFileDialog`` static helpers use the OS-native picker by default. On
+Linux that means the GTK / KDE / xdg-desktop-portal dialog, whose look and
+behaviour drift from the rest of this PyQt5 app (and which can misbehave under
+some portals). We want the Qt dialog on Linux everywhere; Windows and macOS
+keep their native picker, which is the expected platform look there.
+
+Route every open/save picker through these wrappers instead of calling
+``QFileDialog.getOpenFileName`` / ``getSaveFileName`` directly. They call the
+same static methods (so unit tests that patch ``QFileDialog.getOpenFileName``
+still work), only adding the ``DontUseNativeDialog`` option on Linux.
+
+``cmd_menu._get_open_file_explicit`` is a richer variant (it also defeats
+KDE's single-click-to-accept); it likewise forces the Qt dialog on Linux.
+"""
+import sys
+
+from PyQt5.QtWidgets import QFileDialog
+
+
+def _linux_qt_options():
+    """DontUseNativeDialog on Linux (force the Qt picker); no-op elsewhere."""
+    if sys.platform in ('win32', 'darwin'):
+        return QFileDialog.Options()
+    return QFileDialog.DontUseNativeDialog
+
+
+def get_open_file_name(parent, caption, directory="", name_filter=""):
+    """Drop-in for ``QFileDialog.getOpenFileName`` that uses the Qt dialog on
+    Linux. Returns the ``(path, selected_filter)`` tuple, same as Qt."""
+    return QFileDialog.getOpenFileName(
+        parent, caption, directory, name_filter, options=_linux_qt_options())
+
+
+def get_save_file_name(parent, caption, directory="", name_filter=""):
+    """Drop-in for ``QFileDialog.getSaveFileName`` that uses the Qt dialog on
+    Linux. Returns the ``(path, selected_filter)`` tuple, same as Qt."""
+    return QFileDialog.getSaveFileName(
+        parent, caption, directory, name_filter, options=_linux_qt_options())

--- a/polyhost/gui/fontpack_extend_dialog.py
+++ b/polyhost/gui/fontpack_extend_dialog.py
@@ -26,7 +26,7 @@ from PyQt5.QtCore import Qt, QEvent, QThread, QTimer, pyqtSignal
 from PyQt5.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QGridLayout, QFormLayout, QLabel, QLineEdit,
     QSpinBox, QDoubleSpinBox, QComboBox, QCheckBox, QPushButton, QScrollArea, QSlider,
-    QFileDialog, QMessageBox, QApplication, QWidget, QListWidget, QListWidgetItem,
+    QMessageBox, QApplication, QWidget, QListWidget, QListWidgetItem,
     QProgressDialog, QButtonGroup, QRadioButton,
 )
 
@@ -502,8 +502,9 @@ class FontPackExtendDialog(QDialog):
         self._ok_btn.setEnabled(False)
 
     def _browse(self):
-        path, _ = QFileDialog.getOpenFileName(self, "Select font", "",
-                                              "Fonts (*.ttf *.otf);;All files (*)")
+        from polyhost.gui.file_dialogs import get_open_file_name
+        path, _ = get_open_file_name(self, "Select font", "",
+                                     "Fonts (*.ttf *.otf);;All files (*)")
         if path:
             self._src.setText(path)
 

--- a/polyhost/gui/fontpack_inspector_dialog.py
+++ b/polyhost/gui/fontpack_inspector_dialog.py
@@ -742,9 +742,10 @@ class FontPackInspectorDialog(QDialog):
         self._empty_note.setVisible(not has)
 
     def _open_file(self):
-        from PyQt5.QtWidgets import QFileDialog, QMessageBox
-        path, _ = QFileDialog.getOpenFileName(self, "Open font pack", "",
-                                              "Font pack (*.plyf);;All files (*)")
+        from PyQt5.QtWidgets import QMessageBox
+        from polyhost.gui.file_dialogs import get_open_file_name
+        path, _ = get_open_file_name(self, "Open font pack", "",
+                                     "Font pack (*.plyf);;All files (*)")
         if not path:
             return
         label = fpr._stem(path)
@@ -992,9 +993,10 @@ class FontPackSaveDialog(QDialog):
             f"{nonempty} glyphs · {size:,} B → save as v{self._version.value()}")
 
     def _save(self):
-        from PyQt5.QtWidgets import QFileDialog, QMessageBox
-        path, _ = QFileDialog.getSaveFileName(self, "Save font pack", f"{self._label}.plyf",
-                                              "Font pack (*.plyf)")
+        from PyQt5.QtWidgets import QMessageBox
+        from polyhost.gui.file_dialogs import get_save_file_name
+        path, _ = get_save_file_name(self, "Save font pack", f"{self._label}.plyf",
+                                     "Font pack (*.plyf)")
         if not path:
             return
         try:

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -20,13 +20,13 @@ from PyQt5.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QMessageBox,
-    QFileDialog,
     QProgressDialog,
     QSizePolicy,
     QStyle,
     QVBoxLayout, )
 
 from polyhost.device.command_ids import IdleStyle, GlyphScript
+from polyhost.gui.file_dialogs import get_open_file_name
 from polyhost.gui.get_icon import get_icon
 from polyhost.gui.update_dialog import confirm_update
 
@@ -1006,7 +1006,7 @@ class PolyHost(QApplication):
         flash it over RPC. The path must be readable by the daemon — works when
         the GUI and daemon share a filesystem (co-located / same machine).
         Progress arrives as fw_flash_*/fw_apply_* events (see _on_flash_*)."""
-        path, _ = QFileDialog.getOpenFileName(
+        path, _ = get_open_file_name(
             None, "Select firmware .bin", "", "Firmware image (*.bin)")
         if not path:
             return
@@ -1500,7 +1500,7 @@ class PolyHost(QApplication):
         dlg.exec_()
 
     def send_shortcuts(self):
-        file_name = QFileDialog.getOpenFileName(None, 'Open file', '', "Image files (*.jpg *.gif *.png *.bmp *.jpeg)")
+        file_name = get_open_file_name(None, 'Open file', '', "Image files (*.jpg *.gif *.png *.bmp *.jpeg)")
         if file_name[0]:
             path = file_name[0]
 
@@ -1616,7 +1616,7 @@ class PolyHost(QApplication):
 
     def read_overlay_mapping_file(self, file):
         if not file:
-            file = QFileDialog.getOpenFileName(None, 'Open file', '', "PolyKybd overlay mapping (*.poly.yaml)")
+            file = get_open_file_name(None, 'Open file', '', "PolyKybd overlay mapping (*.poly.yaml)")
         if len(file) > 0:
             self.core.load_overlay_mapping(file)
 

--- a/tests/gui/file_dialogs_test.py
+++ b/tests/gui/file_dialogs_test.py
@@ -16,7 +16,7 @@ class FileDialogPolicyTest(unittest.TestCase):
         with patch.object(fd, "sys") as m_sys, \
              patch.dict(fd.os.environ, environ, clear=True):
             m_sys.platform = platform
-            return fd._use_native(), fd._dialog_options()
+            return fd.use_native(), fd._dialog_options()
 
     def test_windows_native(self):
         native, opts = self._opts({}, "win32")

--- a/tests/gui/file_dialogs_test.py
+++ b/tests/gui/file_dialogs_test.py
@@ -1,0 +1,55 @@
+"""Unit tests for the per-desktop file-dialog policy (pure logic, no display).
+
+Policy: native picker on Windows/macOS and on Linux KDE/Plasma (the modern
+KFileWidget/portal dialog); Qt's own widget dialog on other Linux desktops
+(GNOME, …) where "native" would be the foreign-looking GTK dialog.
+"""
+import unittest
+from unittest.mock import patch
+
+from polyhost.gui import file_dialogs as fd
+from PyQt5.QtWidgets import QFileDialog
+
+
+class FileDialogPolicyTest(unittest.TestCase):
+    def _opts(self, environ, platform):
+        with patch.object(fd, "sys") as m_sys, \
+             patch.dict(fd.os.environ, environ, clear=True):
+            m_sys.platform = platform
+            return fd._use_native(), fd._dialog_options()
+
+    def test_windows_native(self):
+        native, opts = self._opts({}, "win32")
+        self.assertTrue(native)
+        self.assertNotEqual(opts, QFileDialog.DontUseNativeDialog)
+
+    def test_macos_native(self):
+        native, _ = self._opts({}, "darwin")
+        self.assertTrue(native)
+
+    def test_linux_kde_native(self):
+        native, opts = self._opts({"XDG_CURRENT_DESKTOP": "KDE"}, "linux")
+        self.assertTrue(native)
+        self.assertNotEqual(opts, QFileDialog.DontUseNativeDialog)
+
+    def test_linux_kde_plasma_colon_native(self):
+        native, _ = self._opts({"XDG_CURRENT_DESKTOP": "KDE:plasma"}, "linux")
+        self.assertTrue(native)
+
+    def test_linux_kde_full_session_native(self):
+        native, _ = self._opts({"KDE_FULL_SESSION": "true"}, "linux")
+        self.assertTrue(native)
+
+    def test_linux_gnome_forces_qt(self):
+        native, opts = self._opts({"XDG_CURRENT_DESKTOP": "GNOME"}, "linux")
+        self.assertFalse(native)
+        self.assertEqual(opts, QFileDialog.DontUseNativeDialog)
+
+    def test_linux_unset_forces_qt(self):
+        native, opts = self._opts({}, "linux")
+        self.assertFalse(native)
+        self.assertEqual(opts, QFileDialog.DontUseNativeDialog)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Several file-picker dialogs on Linux were showing the OS-native dialog inconsistently, and where they were "fixed" they used Qt's plain widget dialog — the old-style one with the single-click-accept quirk — even on KDE, where the *native* dialog is the much nicer modern one.

This PR makes the picker choice a single, shared, per-desktop policy:

- **Windows / macOS** → native (expected platform look)
- **Linux KDE / Plasma** → native → the modern KFileWidget / xdg-desktop-portal dialog (places panel, previews, respects KDE settings). On KDE without `plasma-integration`, Qt falls back to its own dialog anyway, so this is safe.
- **Other Linux (GNOME, …)** → Qt's own widget dialog, since "native" there is the foreign-looking GTK dialog.

Changes:
- New `polyhost/gui/file_dialogs.py` with `get_open_file_name` / `get_save_file_name` wrappers and a public `use_native()` policy (detects KDE via `XDG_CURRENT_DESKTOP` / `XDG_SESSION_DESKTOP` / `KDE_FULL_SESSION`, matching the existing window-reporter backend check). The wrappers call the same `QFileDialog` static methods, so tests that patch `QFileDialog.getOpenFileName` keep working.
- Routed the six previously-native call sites through it: `host.py` (firmware `.bin` flash, send-shortcuts image, overlay-mapping file), `fontpack_extend_dialog.py` (source-font browse), `fontpack_inspector_dialog.py` (open/save `.plyf`). Dropped the now-unused `QFileDialog` imports.
- Unified `cmd_menu._get_open_file_explicit` onto the same `use_native()` policy (it previously did its own win32/darwin-vs-Linux split and always forced Qt on Linux). Its single-click-explicit fix (`_RequireExplicitOpen`) is kept but applied only in the non-native Qt branch, where it's needed.
- Added `tests/gui/file_dialogs_test.py` covering the policy per platform/desktop.

No protocol or wire-format change; GUI-only.

## Version bump label

Patch (no label) — GUI behavior tweak, no new feature or protocol change.

## Testing
- [ ] Tested locally against real hardware
- [x] Tested with mock device (if UI changes)

Automated: `file_dialogs`, `cmd_menu`, and both fontpack dialog suites pass under xvfb (78 tests, 8 env-skips). Policy verified across simulated desktops — KDE / `KDE:plasma` / `KDE_FULL_SESSION` → native; GNOME / unset → Qt. Not yet exercised on real KDE/GNOME hardware.

---
_Generated by [Claude Code](https://claude.ai/code/session_012j5i9owwNRDDvczFpfRkQm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * File-open and file-save dialogs now follow desktop-specific conventions for a more consistent experience.
  * Native dialogs are used on Windows, macOS, and KDE/Plasma desktops.
  * Qt-based dialogs are used on other Linux desktop environments.
  * Updated font, firmware, shortcut, overlay, and mapping file selection workflows to use the improved dialog behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->