### PR TITLE
KDE file picker: modern Plasma dialog via portal, default to Downloads

### DIFF
--- a/polyhost/gui/file_dialogs.py
+++ b/polyhost/gui/file_dialogs.py
@@ -5,11 +5,14 @@ on Linux "native" is not one dialog — it is whatever the Qt platform-theme
 plugin provides, and its quality varies by desktop:
 
 - **Windows / macOS** — native, the expected platform look.
-- **Linux KDE / Plasma** — native, which (with ``plasma-integration``) is the
-  modern KFileWidget / xdg-desktop-portal dialog: places panel, previews, and
-  it respects the user's KDE settings. Much nicer than Qt's built-in dialog.
-  If ``plasma-integration`` is absent Qt falls back to its own widget dialog
-  anyway, so requesting native here is safe.
+- **Linux KDE / Plasma** — native, so the file picker is the modern Plasma
+  dialog (places panel, previews, respects KDE settings). ⚠️ We run a **pip /
+  venv PyQt5**, whose bundled Qt ships **no** KDE ``plasma-integration`` plugin,
+  so a plain "native" dialog would fall back to Qt's old widget dialog even on
+  KDE. The bundled Qt *does* ship the **xdg-desktop-portal** plugin, and KDE
+  runs ``xdg-desktop-portal-kde``, so ``maybe_set_portal_platformtheme()``
+  (called once at GUI startup) points Qt at that theme — which is what actually
+  produces the Plasma picker here.
 - **Other Linux (GNOME, …)** — NOT native: there "native" is the GTK dialog,
   which looks foreign in this PyQt5 app. Use Qt's own widget dialog instead
   for a consistent look.
@@ -55,17 +58,86 @@ def _dialog_options():
     return QFileDialog.DontUseNativeDialog
 
 
+def downloads_dir():
+    """The user's Downloads folder — the most likely place for a .bin / overlay
+    / .plyf — falling back to the home directory when it can't be resolved."""
+    try:
+        import platformdirs
+        d = platformdirs.user_downloads_dir()
+        if d and os.path.isdir(d):
+            return d
+    except Exception:
+        pass
+    home = os.path.expanduser("~")
+    cand = os.path.join(home, "Downloads")
+    return cand if os.path.isdir(cand) else home
+
+
+def _default_directory(directory):
+    """Start pickers in Downloads when the caller gave no location.
+
+    - ``""`` → the Downloads folder.
+    - a bare suggested filename (no directory part, e.g. ``"pack.plyf"``) →
+      that name inside Downloads (used by save dialogs).
+    - anything with a directory component / absolute path → left untouched.
+    """
+    if not directory:
+        return downloads_dir()
+    if not os.path.dirname(directory):
+        return os.path.join(downloads_dir(), directory)
+    return directory
+
+
 def get_open_file_name(parent, caption, directory="", name_filter=""):
     """Drop-in for ``QFileDialog.getOpenFileName`` that uses the native dialog on
-    Windows/macOS/KDE and the Qt dialog elsewhere. Returns the
-    ``(path, selected_filter)`` tuple, same as Qt."""
+    Windows/macOS/KDE and the Qt dialog elsewhere, defaulting to the Downloads
+    folder. Returns the ``(path, selected_filter)`` tuple, same as Qt."""
     return QFileDialog.getOpenFileName(
-        parent, caption, directory, name_filter, options=_dialog_options())
+        parent, caption, _default_directory(directory), name_filter,
+        options=_dialog_options())
 
 
 def get_save_file_name(parent, caption, directory="", name_filter=""):
     """Drop-in for ``QFileDialog.getSaveFileName`` that uses the native dialog on
-    Windows/macOS/KDE and the Qt dialog elsewhere. Returns the
-    ``(path, selected_filter)`` tuple, same as Qt."""
+    Windows/macOS/KDE and the Qt dialog elsewhere, defaulting to the Downloads
+    folder. Returns the ``(path, selected_filter)`` tuple, same as Qt."""
     return QFileDialog.getSaveFileName(
-        parent, caption, directory, name_filter, options=_dialog_options())
+        parent, caption, _default_directory(directory), name_filter,
+        options=_dialog_options())
+
+
+def _portal_theme_available():
+    """True if this Qt build ships the xdg-desktop-portal platform-theme plugin."""
+    try:
+        import glob
+        from PyQt5.QtCore import QLibraryInfo
+        plugins = QLibraryInfo.location(QLibraryInfo.PluginsPath)
+    except Exception:
+        return False
+    return bool(glob.glob(os.path.join(plugins, "platformthemes", "*xdgdesktopportal*")))
+
+
+def maybe_set_portal_platformtheme():
+    """On KDE, route Qt's native dialogs through xdg-desktop-portal so the file
+    picker is the modern Plasma dialog. Returns True if it set the theme.
+
+    Our pip/venv PyQt5 ships no KDE ``plasma-integration`` plugin, so a plain
+    "native" dialog falls back to Qt's old widget dialog even on KDE. The
+    bundled Qt *does* ship the xdg-desktop-portal plugin, and KDE runs
+    ``xdg-desktop-portal-kde``, so pointing Qt at that theme yields the native
+    Plasma picker. **Must be called before the QApplication is constructed.**
+
+    No-op unless: on Linux KDE, ``QT_QPA_PLATFORMTHEME`` unset, and the portal
+    platform-theme plugin is present — so it never overrides a user/session
+    setting and never names a theme this Qt can't load.
+    """
+    if sys.platform in ('win32', 'darwin'):
+        return False
+    if os.environ.get('QT_QPA_PLATFORMTHEME'):
+        return False
+    if not _is_kde():
+        return False
+    if not _portal_theme_available():
+        return False
+    os.environ['QT_QPA_PLATFORMTHEME'] = 'xdgdesktopportal'
+    return True

--- a/polyhost/host.py
+++ b/polyhost/host.py
@@ -1500,9 +1500,8 @@ class PolyHost(QApplication):
         dlg.exec_()
 
     def send_shortcuts(self):
-        file_name = get_open_file_name(None, 'Open file', '', "Image files (*.jpg *.gif *.png *.bmp *.jpeg)")
-        if file_name[0]:
-            path = file_name[0]
+        path, _ = get_open_file_name(None, 'Open file', '', "Image files (*.jpg *.gif *.png *.bmp *.jpeg)")
+        if path:
 
             def _job(cancel):
                 for entry in self.device_mgr.all_entries:
@@ -1616,8 +1615,8 @@ class PolyHost(QApplication):
 
     def read_overlay_mapping_file(self, file):
         if not file:
-            file = get_open_file_name(None, 'Open file', '', "PolyKybd overlay mapping (*.poly.yaml)")
-        if len(file) > 0:
+            file, _ = get_open_file_name(None, 'Open file', '', "PolyKybd overlay mapping (*.poly.yaml)")
+        if file:
             self.core.load_overlay_mapping(file)
 
     def save_overlay_mapping_file(self, filename="overlay-mapping.poly.yaml"):

--- a/polyhost/main_app.py
+++ b/polyhost/main_app.py
@@ -271,6 +271,11 @@ def main(launch_monotonic=None, post_bootstrap_monotonic=None):
     # Important for XWayland icon matching
     if sys.platform.startswith('linux'):
         QApplication.setDesktopFileName('PolyHost')
+        # On KDE, route native file dialogs through xdg-desktop-portal so the
+        # picker is the modern Plasma dialog (our pip Qt has no KDE plugin).
+        # Must run before the QApplication instance below reads the env.
+        from polyhost.gui import file_dialogs
+        file_dialogs.maybe_set_portal_platformtheme()
 
     if args.host or args.host_file:
         from polyhost.forwarder import PolyForwarder

--- a/tests/gui/file_dialogs_test.py
+++ b/tests/gui/file_dialogs_test.py
@@ -51,5 +51,56 @@ class FileDialogPolicyTest(unittest.TestCase):
         self.assertEqual(opts, QFileDialog.DontUseNativeDialog)
 
 
+class PortalPlatformThemeTest(unittest.TestCase):
+    def _run(self, environ, platform, portal_available):
+        with patch.object(fd, "sys") as m_sys, \
+             patch.object(fd, "_portal_theme_available", return_value=portal_available), \
+             patch.dict(fd.os.environ, environ, clear=True):
+            m_sys.platform = platform
+            set_it = fd.maybe_set_portal_platformtheme()
+            return set_it, fd.os.environ.get("QT_QPA_PLATFORMTHEME")
+
+    def test_kde_unset_sets_portal(self):
+        set_it, theme = self._run({"XDG_CURRENT_DESKTOP": "KDE"}, "linux", True)
+        self.assertTrue(set_it)
+        self.assertEqual(theme, "xdgdesktopportal")
+
+    def test_kde_already_set_is_noop(self):
+        set_it, theme = self._run(
+            {"XDG_CURRENT_DESKTOP": "KDE", "QT_QPA_PLATFORMTHEME": "kde"}, "linux", True)
+        self.assertFalse(set_it)
+        self.assertEqual(theme, "kde")   # user/session setting preserved
+
+    def test_kde_without_portal_plugin_is_noop(self):
+        set_it, theme = self._run({"XDG_CURRENT_DESKTOP": "KDE"}, "linux", False)
+        self.assertFalse(set_it)
+        self.assertIsNone(theme)
+
+    def test_gnome_is_noop(self):
+        set_it, theme = self._run({"XDG_CURRENT_DESKTOP": "GNOME"}, "linux", True)
+        self.assertFalse(set_it)
+        self.assertIsNone(theme)
+
+    def test_windows_is_noop(self):
+        set_it, theme = self._run({}, "win32", True)
+        self.assertFalse(set_it)
+        self.assertIsNone(theme)
+
+
+class DefaultDirectoryTest(unittest.TestCase):
+    def test_empty_uses_downloads(self):
+        with patch.object(fd, "downloads_dir", return_value="/home/u/Downloads"):
+            self.assertEqual(fd._default_directory(""), "/home/u/Downloads")
+
+    def test_bare_filename_goes_into_downloads(self):
+        with patch.object(fd, "downloads_dir", return_value="/home/u/Downloads"):
+            self.assertEqual(fd._default_directory("pack.plyf"),
+                             "/home/u/Downloads/pack.plyf")
+
+    def test_path_with_dir_is_untouched(self):
+        with patch.object(fd, "downloads_dir", return_value="/home/u/Downloads"):
+            self.assertEqual(fd._default_directory("/tmp/x.bin"), "/tmp/x.bin")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Follow-up to #117. On KDE the file pickers were still showing Qt's **old-style widget dialog** instead of the modern Plasma one, even though our policy correctly requested "native".

**Root cause** (confirmed via on-device diagnostic): we run a **pip/venv PyQt5**, whose bundled Qt ships **no** KDE `plasma-integration` plugin, so a plain "native" dialog falls back to Qt's own widget dialog. The bundled Qt *does* ship the **xdg-desktop-portal** platform-theme plugin, and KDE runs `xdg-desktop-portal-kde`.

Changes:
- **Modern KDE dialog** — `file_dialogs.maybe_set_portal_platformtheme()`, called once from `main_app` **before** the `QApplication` is created, sets `QT_QPA_PLATFORMTHEME=xdgdesktopportal` on KDE. Guarded: Linux KDE only, only when `QT_QPA_PLATFORMTHEME` is unset (never overrides a user/session setting), and only when the portal plugin is actually present (never names a theme this Qt can't load). Confirmed on KDE Wayland that this yields the modern Plasma picker.
- **Default start folder → Downloads** — the wrappers default an empty directory to the user's Downloads folder (via `platformdirs.user_downloads_dir()`, home fallback), and a bare suggested filename (save dialogs) to that name inside Downloads. An explicit path is left untouched.
- **Tuple-unpack fixes in `host.py`** (both flagged by CodeRabbit on #117): `read_overlay_mapping_file` assigned the `(path, filter)` tuple straight to `file`, so `len(file)` was always 2 and a *tuple* was passed to `load_overlay_mapping` — a real pre-existing bug in the interactive branch. Now unpacks the path. Also tidied `send_shortcuts` to unpack directly instead of index access.
- Tests for the portal-theme decision (KDE/unset/plugin-present → set; already-set/GNOME/no-plugin/Windows → no-op) and the Downloads defaulting.

No protocol or wire-format change; GUI-only.

**Known limitation (not addressed):** the "detailed view" request can't be forced by the app for the portal/KDE dialog — its view mode is owned by KDE and remembered once the user selects it in the dialog. Whether the KDE portal honors the requested Downloads start folder is Qt/portal-version dependent (Qt passes it as `current_folder`).

## Version bump label

Patch (no label) — GUI behavior fix, no new feature or protocol change.

## Testing
- [ ] Tested locally against real hardware
- [x] Tested with mock device (if UI changes)

Automated: `file_dialogs`, `cmd_menu`, and both fontpack dialog suites pass under xvfb (86 tests, 8 env-skips). Portal theme + Downloads resolution verified at runtime under a simulated KDE env. The `QT_QPA_PLATFORMTHEME=xdgdesktopportal` fix was confirmed on real KDE Wayland to produce the modern picker; the wired-in startup call and the Downloads default still need a real-hardware pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_012j5i9owwNRDDvczFpfRkQm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File open and save dialogs now default to the user’s Downloads folder.
  * Bare filenames in save dialogs are automatically placed in Downloads.
  * KDE Plasma users receive the modern portal-based native file picker when available.

* **Bug Fixes**
  * Improved file-selection handling for canceled or empty dialog results.

* **Tests**
  * Added coverage for Downloads defaults and KDE portal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->